### PR TITLE
feat: add Tauri offline support

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,29 @@
+name: Build Windows
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - name: Install dependencies
+        run: npm ci
+      - name: Build application
+        uses: tauri-apps/tauri-action@v0
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: MamaStock ${{ github.ref_name }}
+          releaseBody: Windows release
+          includeDebug: false
+          includeRelease: true
+          targets: "msi nsis"

--- a/README-offline.md
+++ b/README-offline.md
@@ -1,0 +1,18 @@
+# MamaStock Offline
+
+Cette variante embarque une base SQLite locale et Tauri pour fonctionner hors ligne.
+
+## Choisir le dossier des données
+- Lancez l'application puis ouvrez la page **Paramètres**.
+- Sélectionnez le dossier qui contiendra `mamastock.db` et les fichiers de verrou (`db.lock.json`, `shutdown.request.json`).
+- Le chemin est enregistré dans `%APPDATA%\MamaStock\config.json`.
+
+## Règle "un seul poste à la fois"
+Un fichier `db.lock.json` protège l'accès à la base. Un poste doit être fermé (menu quitter) avant d'ouvrir l'application sur un autre poste. Un `shutdown.request.json` peut être créé pour demander la libération du verrou.
+
+## Synchronisation
+Pour partager les données entre postes, utilisez un outil de synchronisation comme **Syncthing** sur le dossier de données.
+
+## Build
+- `npx tauri dev` pour le mode développement.
+- `npx tauri build` pour produire l'exécutable et l'installateur MSI.

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,9 @@
+# One-click build script for Windows
+winget install -e --id Node.js.LTS -h
+winget install -e --id Rustlang.Rustup -h
+winget install -e --id Microsoft.VisualStudio.2022.BuildTools -h
+winget install -e --id WiXToolset.WiXToolset -h
+
+npm ci
+npm run build
+npx tauri build

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "schema:analyze": "node scripts/analyzeFrontBackend.js",
     "sanitize:src": "node scripts/sanitize-source.js",
     "audit": "node scripts/audit-project.mjs",
-    "audit:fix": "node scripts/fix-project.mjs"
+    "audit:fix": "node scripts/fix-project.mjs",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -76,7 +78,8 @@
     "tesseract.js": "^6.0.1",
     "uuid": "^11.1.0",
     "xlsx": "^0.18.5",
-    "zod": "3.23.8"
+    "zod": "3.23.8",
+    "@tauri-apps/plugin-sql": "^2.0.0"
   },
   "devDependencies": {
     "@babel/parser": "^7.28.0",
@@ -118,7 +121,8 @@
     "typescript": "5.4.5",
     "vite": "7.1.3",
     "vite-plugin-pwa": "^1.0.0",
-    "vitest": "1.6.1"
+    "vitest": "1.6.1",
+    "@tauri-apps/cli": "^2.0.0"
   },
   "overrides": {
     "react": "18.3.1",

--- a/public/migrations/001_init.sql
+++ b/public/migrations/001_init.sql
@@ -1,0 +1,58 @@
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS utilisateurs (
+  id TEXT PRIMARY KEY,
+  email TEXT UNIQUE,
+  nom TEXT,
+  prenom TEXT
+);
+
+CREATE TABLE IF NOT EXISTS fournisseurs (
+  id TEXT PRIMARY KEY,
+  nom TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS produits (
+  id TEXT PRIMARY KEY,
+  fournisseur_id TEXT REFERENCES fournisseurs(id),
+  nom TEXT NOT NULL,
+  stock REAL DEFAULT 0,
+  pmp REAL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS factures (
+  id TEXT PRIMARY KEY,
+  fournisseur_id TEXT REFERENCES fournisseurs(id),
+  total REAL,
+  date TEXT
+);
+
+CREATE TABLE IF NOT EXISTS facture_lignes (
+  id TEXT PRIMARY KEY,
+  facture_id TEXT REFERENCES factures(id),
+  produit_id TEXT REFERENCES produits(id),
+  quantite REAL,
+  prix REAL
+);
+
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+CREATE TRIGGER IF NOT EXISTS trig_facture_insert
+AFTER INSERT ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    pmp = ((pmp * stock) + (NEW.prix * NEW.quantite)) / (stock + NEW.quantite),
+    stock = stock + NEW.quantite
+  WHERE id = NEW.produit_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trig_facture_delete
+AFTER DELETE ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock = stock - OLD.quantite
+  WHERE id = OLD.produit_id;
+END;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mamastock"
+version = "0.1.0"
+edition = "2021"
+description = "MamaStock"
+authors = ["MamaStock"]
+license = "MIT"
+
+[dependencies]
+tauri = { version = "2", features = ["windows"] }
+tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
+
+[[bin]]
+name = "mamastock"
+path = "src/main.rs"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_sql::Builder::default().build())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "MamaStock",
+  "version": "0.1.0",
+  "identifier": "com.mamastock.app",
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "tauri": {
+    "bundle": {
+      "targets": ["msi", "nsis"],
+      "windows": {
+        "certificateThumbprint": null,
+        "timestampUrl": null
+      }
+    },
+    "windows": [
+      {
+        "title": "MamaStock",
+        "width": 1024,
+        "height": 768
+      }
+    ],
+    "plugins": {
+      "sql": {
+        "default": {
+          "path": "mamastock.db"
+        }
+      }
+    }
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,108 @@
+import Database from "@tauri-apps/plugin-sql";
+import { appDataDir, join } from "@tauri-apps/api/path";
+import { createDir, readTextFile, writeTextFile, exists } from "@tauri-apps/api/fs";
+
+let dbPromise: Promise<Database> | null = null;
+
+async function configPath(): Promise<string> {
+  const base = await appDataDir();
+  const dir = await join(base, "MamaStock");
+  await createDir(dir, { recursive: true });
+  return await join(dir, "config.json");
+}
+
+export async function getDataDir(): Promise<string> {
+  const cfg = await configPath();
+  if (await exists(cfg)) {
+    try {
+      const data = JSON.parse(await readTextFile(cfg));
+      if (data.dataDir) return data.dataDir as string;
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  const base = await appDataDir();
+  return await join(base, "MamaStock", "data");
+}
+
+export async function setDataDir(dir: string) {
+  const cfg = await configPath();
+  await writeTextFile(cfg, JSON.stringify({ dataDir: dir }));
+  dbPromise = null; // force reload
+}
+
+export async function getDb(): Promise<Database> {
+  if (!dbPromise) {
+    const dir = await getDataDir();
+    await createDir(dir, { recursive: true });
+    const dbPath = await join(dir, "mamastock.db");
+    dbPromise = Database.load(`sqlite:${dbPath}`);
+  }
+  return dbPromise;
+}
+
+export async function produits_list() {
+  const db = await getDb();
+  return db.select("SELECT * FROM produits");
+}
+
+export async function produits_create(p: { id: string; fournisseur_id?: string; nom: string }) {
+  const db = await getDb();
+  await db.execute(
+    "INSERT INTO produits (id, fournisseur_id, nom) VALUES (?, ?, ?)",
+    [p.id, p.fournisseur_id, p.nom]
+  );
+}
+
+export async function produits_update(
+  id: string,
+  fields: { fournisseur_id?: string; nom?: string }
+) {
+  const db = await getDb();
+  const sets: string[] = [];
+  const values: any[] = [];
+  if (fields.fournisseur_id !== undefined) {
+    sets.push("fournisseur_id = ?");
+    values.push(fields.fournisseur_id);
+  }
+  if (fields.nom !== undefined) {
+    sets.push("nom = ?");
+    values.push(fields.nom);
+  }
+  values.push(id);
+  await db.execute(`UPDATE produits SET ${sets.join(",")} WHERE id = ?`, values);
+}
+
+export async function fournisseurs_list() {
+  const db = await getDb();
+  return db.select("SELECT * FROM fournisseurs");
+}
+
+export async function fournisseurs_create(f: { id: string; nom: string }) {
+  const db = await getDb();
+  await db.execute("INSERT INTO fournisseurs (id, nom) VALUES (?, ?)", [f.id, f.nom]);
+}
+
+export async function facture_create_with_lignes(
+  facture: { id: string; fournisseur_id: string; total: number; date: string },
+  lignes: Array<{ id: string; produit_id: string; quantite: number; prix: number }>
+) {
+  const db = await getDb();
+  await db.execute("BEGIN");
+  try {
+    await db.execute(
+      "INSERT INTO factures (id, fournisseur_id, total, date) VALUES (?,?,?,?)",
+      [facture.id, facture.fournisseur_id, facture.total, facture.date]
+    );
+    for (const l of lignes) {
+      await db.execute(
+        "INSERT INTO facture_lignes (id, facture_id, produit_id, quantite, prix) VALUES (?,?,?,?,?)",
+        [l.id, facture.id, l.produit_id, l.quantite, l.prix]
+      );
+    }
+    await db.execute("COMMIT");
+  } catch (e) {
+    await db.execute("ROLLBACK");
+    throw e;
+  }
+}

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,0 +1,53 @@
+import { join } from "@tauri-apps/api/path";
+import { exists, readTextFile, writeTextFile, removeFile } from "@tauri-apps/api/fs";
+import { getDataDir } from "./db";
+
+const TTL = 20_000; // 20s
+const HEARTBEAT = 5_000; // 5s
+
+let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+export async function ensureSingleOwner() {
+  const dir = await getDataDir();
+  const lockPath = await join(dir, "db.lock.json");
+  const now = Date.now();
+  if (await exists(lockPath)) {
+    try {
+      const { ts } = JSON.parse(await readTextFile(lockPath));
+      if (now - ts < TTL) {
+        throw new Error("Database already locked");
+      }
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  await writeTextFile(lockPath, JSON.stringify({ ts: now }));
+  heartbeat = setInterval(async () => {
+    await writeTextFile(lockPath, JSON.stringify({ ts: Date.now() }));
+  }, HEARTBEAT);
+}
+
+export async function monitorShutdownRequests(handler: () => void) {
+  const dir = await getDataDir();
+  const shutdownPath = await join(dir, "shutdown.request.json");
+  const check = async () => {
+    if (await exists(shutdownPath)) {
+      await removeFile(shutdownPath);
+      await handler();
+    }
+  };
+  await check();
+  setInterval(check, HEARTBEAT);
+}
+
+export async function releaseLock() {
+  const dir = await getDataDir();
+  const lockPath = await join(dir, "db.lock.json");
+  if (heartbeat) {
+    clearInterval(heartbeat);
+    heartbeat = null;
+  }
+  if (await exists(lockPath)) {
+    await removeFile(lockPath);
+  }
+}

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -1,0 +1,6 @@
+import { getDb } from "./db";
+
+export async function shutdown() {
+  const db = await getDb();
+  await db.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+}

--- a/src/pages/parametrage/DataFolder.jsx
+++ b/src/pages/parametrage/DataFolder.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { open } from "@tauri-apps/api/dialog";
+import { setDataDir, getDataDir } from "@/lib/db";
+
+export default function DataFolder() {
+  const [dir, setDir] = useState("");
+
+  useEffect(() => {
+    getDataDir().then(setDir);
+  }, []);
+
+  const choose = async () => {
+    const selected = await open({ directory: true });
+    if (selected) setDir(selected as string);
+  };
+
+  const save = async () => {
+    if (dir) await setDataDir(dir);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl">Paramètres</h1>
+      <div className="space-y-2">
+        <label>Dossier des données</label>
+        <input
+          value={dir}
+          onChange={(e) => setDir(e.target.value)}
+          className="border p-1 w-full"
+        />
+        <div className="flex gap-2">
+          <button onClick={choose} className="border px-2 py-1">
+            Choisir...
+          </button>
+          <button onClick={save} className="border px-2 py-1">
+            Enregistrer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -72,6 +72,7 @@ const Familles = lazyWithPreload(() => import("@/pages/parametrage/Familles.jsx"
 const SousFamilles = lazyWithPreload(() => import("@/pages/parametrage/SousFamilles.jsx"));
 const Unites = lazyWithPreload(() => import("@/pages/parametrage/Unites.jsx"));
 const Periodes = lazyWithPreload(() => import("@/pages/parametrage/Periodes.jsx"));
+const DataFolder = lazyWithPreload(() => import("@/pages/parametrage/DataFolder.jsx"));
 const Onboarding = lazyWithPreload(() => import("@/pages/public/Onboarding.jsx"));
 const Accueil = lazyWithPreload(() => import("@/pages/Accueil.jsx"));
 const Signup = lazyWithPreload(() => import("@/pages/public/Signup.jsx"));
@@ -186,6 +187,7 @@ export const routePreloadMap = {
   '/parametrage/sous-familles': SousFamilles.preload,
   '/parametrage/unites': Unites.preload,
   '/parametrage/periodes': Periodes.preload,
+  '/parametrage/data': DataFolder.preload,
   '/consentements': Consentements.preload,
   '/supervision': SupervisionGroupe.preload,
   '/supervision/comparateur': ComparateurFiches.preload,
@@ -579,6 +581,10 @@ export default function Router() {
           <Route
             path="/parametrage/periodes"
             element={<Periodes />}
+          />
+          <Route
+            path="/parametrage/data"
+            element={<DataFolder />}
           />
           <Route
             path="/parametrage/access"


### PR DESCRIPTION
## Summary
- integrate Tauri scaffolding and SQL plugin for Windows builds
- add SQLite migrations, DAL, shutdown and locking helpers
- add data directory settings page, build script, offline docs and CI workflow

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1ecc57c8832d9f1d6d8f6e9a7d4d