### PR TITLE
feat: Settings dossier de données + persistence

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -31,6 +31,7 @@ export default function Sidebar() {
   const canFamilles = canParam("familles");
   const canSousFamilles = canParam("sous_familles");
   const canUnites = canParam("unites");
+  const canData = canParam("settings");
   const hasParamModule =
     enabledModules?.includes?.("parametrage") ||
     rights?.enabledModules?.includes?.("parametrage");
@@ -169,6 +170,16 @@ export default function Sidebar() {
                   }
                 >
                   Unités
+                </NavLink>
+              )}
+              {canData && (
+                <NavLink
+                  to="/parametrage/data"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Dossier données
                 </NavLink>
               )}
             </div>

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -28,6 +28,7 @@ import {
   Mail,
   MessageCircle,
   Plug,
+  Folder,
 } from "lucide-react";
 
 export default function Sidebar() {
@@ -159,6 +160,7 @@ export default function Sidebar() {
         { module: "access", to: "/parametrage/access", label: "Accès", icon: <Shield size={16} /> },
         { module: "apikeys", to: "/parametrage/api-keys", label: "API Keys", icon: <Key size={16} /> },
         { module: "parametrage", to: "/parametrage/api-fournisseurs", label: "API Fournisseurs", icon: <Plug size={16} /> },
+        { module: "settings", to: "/parametrage/data", label: "Dossier données", icon: <Folder size={16} /> },
         { module: "settings", to: "/parametrage/settings", label: "Autres", icon: <Settings size={16} /> },
         { module: "zones_stock", to: "/parametrage/zones", label: "Zones de stock", icon: <Boxes size={16} /> },
         { module: "parametrage", to: "/parametrage/familles", label: "Familles", icon: <Boxes size={16} /> },

--- a/src/pages/parametrage/DataFolder.jsx
+++ b/src/pages/parametrage/DataFolder.jsx
@@ -4,6 +4,7 @@ import { setDataDir, getDataDir } from "@/lib/db";
 
 export default function DataFolder() {
   const [dir, setDir] = useState("");
+  const [saved, setSaved] = useState(false);
 
   useEffect(() => {
     getDataDir().then(setDir);
@@ -15,7 +16,10 @@ export default function DataFolder() {
   };
 
   const save = async () => {
-    if (dir) await setDataDir(dir);
+    if (dir) {
+      await setDataDir(dir);
+      setSaved(true);
+    }
   };
 
   return (
@@ -36,6 +40,11 @@ export default function DataFolder() {
             Enregistrer
           </button>
         </div>
+        {saved && (
+          <p className="text-sm text-gray-500">
+            Redémarrez l'application pour appliquer les modifications.
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add data directory selector to settings page with restart hint
- expose data directory settings in navigation

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bbef715c0c832d807449088ca8ca15