### PR TITLE
feat: verrou distribué + auto-fermeture

### DIFF
--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,48 +1,75 @@
 import { join } from "@tauri-apps/api/path";
 import { exists, readTextFile, writeTextFile, removeFile } from "@tauri-apps/api/fs";
-import { getDataDir } from "./db";
+import { appWindow } from "@tauri-apps/api/window";
+import { v4 as uuidv4 } from "uuid";
+import { shutdownDbSafely } from "./shutdown";
 
 const TTL = 20_000; // 20s
 const HEARTBEAT = 5_000; // 5s
 
+const instanceId = uuidv4();
 let heartbeat: ReturnType<typeof setInterval> | null = null;
 
-export async function ensureSingleOwner() {
-  const dir = await getDataDir();
-  const lockPath = await join(dir, "db.lock.json");
-  const now = Date.now();
-  if (await exists(lockPath)) {
+async function path(dir: string, file: string) {
+  return await join(dir, file);
+}
+
+export async function ensureSingleOwner(syncDir: string, waitMs = 30_000) {
+  const lockPath = await path(syncDir, "db.lock.json");
+  const start = Date.now();
+  let requested = false;
+  while (await exists(lockPath)) {
     try {
       const { ts } = JSON.parse(await readTextFile(lockPath));
-      if (now - ts < TTL) {
-        throw new Error("Database already locked");
+      if (Date.now() - ts > TTL) {
+        break; // stale lock
       }
-    } catch (_) {
-      /* ignore */
+    } catch {
+      // ignore parse errors
     }
+    if (!requested) {
+      await requestRemoteShutdown(syncDir);
+      requested = true;
+    }
+    if (Date.now() - start > waitMs) {
+      throw new Error("Database already locked");
+    }
+    await new Promise((r) => setTimeout(r, HEARTBEAT));
   }
-  await writeTextFile(lockPath, JSON.stringify({ ts: now }));
+  await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }));
   heartbeat = setInterval(async () => {
-    await writeTextFile(lockPath, JSON.stringify({ ts: Date.now() }));
+    await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }));
   }, HEARTBEAT);
 }
 
-export async function monitorShutdownRequests(handler: () => void) {
-  const dir = await getDataDir();
-  const shutdownPath = await join(dir, "shutdown.request.json");
+export async function monitorShutdownRequests(syncDir: string) {
+  const shutdownPath = await path(syncDir, "shutdown.request.json");
   const check = async () => {
     if (await exists(shutdownPath)) {
-      await removeFile(shutdownPath);
-      await handler();
+      try {
+        const { requester } = JSON.parse(await readTextFile(shutdownPath));
+        if (requester !== instanceId) {
+          await shutdownDbSafely();
+          await releaseLock(syncDir);
+          await removeFile(shutdownPath);
+          await appWindow.close();
+        }
+      } catch {
+        await removeFile(shutdownPath);
+      }
     }
   };
   await check();
   setInterval(check, HEARTBEAT);
 }
 
-export async function releaseLock() {
-  const dir = await getDataDir();
-  const lockPath = await join(dir, "db.lock.json");
+export async function requestRemoteShutdown(syncDir: string) {
+  const shutdownPath = await path(syncDir, "shutdown.request.json");
+  await writeTextFile(shutdownPath, JSON.stringify({ ts: Date.now(), requester: instanceId }));
+}
+
+export async function releaseLock(syncDir: string) {
+  const lockPath = await path(syncDir, "db.lock.json");
   if (heartbeat) {
     clearInterval(heartbeat);
     heartbeat = null;

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -1,6 +1,7 @@
 import { getDb } from "./db";
 
-export async function shutdown() {
+export async function shutdownDbSafely() {
   const db = await getDb();
   await db.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+  await db.close();
 }


### PR DESCRIPTION
## Summary
- prevent concurrent database access via distributed file lock with remote shutdown support
- ensure clean SQLite shutdown and lock release on exit
- add "Quitter & synchroniser" button and integrate lock lifecycle on app startup

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47e9ac20832d881008053c731b30