### PR TITLE
feat: auth locale + rôles front

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # MamaStock
 ⚠️ Ce logiciel est propriétaire. Toute utilisation, copie ou distribution sans licence commerciale valide est interdite.
 
-L’accès est contrôlé par Supabase Auth + RLS. Aucun mécanisme de licence front n’est nécessaire.
-Pour un contrôle commercial, utiliser les rôles/permissions ou un champ `licence_active` côté DB.
+L’accès est maintenant géré localement via une table `utilisateurs` stockée dans `src/db/users.json`.
+Un script `npm run seed:admin` permet de créer l’utilisateur initial `admin@mamastock.local`.
 
 
-React application using Supabase. The toolchain relies on modern ESM modules and
+React application using local authentication. The toolchain relies on modern ESM modules and
 requires **Node.js 18+** (see `package.json` engines field).
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-virtual": "^3.13.12",
         "@tauri-apps/plugin-sql": "^2.3.0",
+        "bcryptjs": "^2.4.3",
         "date-fns": "3.6.0",
         "express": "^5.1.0",
         "file-saver": "^2.0.5",
@@ -6424,6 +6425,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "audit": "node scripts/audit-project.mjs",
     "audit:fix": "node scripts/fix-project.mjs",
     "db:smoke": "node scripts/migration-smoke.js",
+    "seed:admin": "node scripts/seed-admin.js",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },
@@ -53,6 +54,7 @@
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-virtual": "^3.13.12",
     "@tauri-apps/plugin-sql": "^2.3.0",
+    "bcryptjs": "^2.4.3",
     "date-fns": "3.6.0",
     "express": "^5.1.0",
     "file-saver": "^2.0.5",
@@ -117,14 +119,14 @@
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
     "recast": "^0.23.11",
+    "sql.js": "^1.11.2",
     "supertest": "^7.1.1",
     "tailwindcss": "^3.4.17",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
     "vite": "7.1.3",
     "vite-plugin-pwa": "^1.0.0",
-    "vitest": "1.6.1",
-    "sql.js": "^1.11.2"
+    "vitest": "1.6.1"
   },
   "overrides": {
     "react": "18.3.1",

--- a/public/migrations/002_local_auth.sql
+++ b/public/migrations/002_local_auth.sql
@@ -1,0 +1,4 @@
+ALTER TABLE utilisateurs ADD COLUMN mot_de_passe_hash TEXT;
+ALTER TABLE utilisateurs ADD COLUMN role TEXT DEFAULT 'user';
+ALTER TABLE utilisateurs ADD COLUMN actif INTEGER DEFAULT 1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_utilisateurs_email ON utilisateurs(email);

--- a/scripts/migration-smoke.js
+++ b/scripts/migration-smoke.js
@@ -5,8 +5,10 @@ import initSqlJs from 'sql.js';
 async function main() {
   const SQL = await initSqlJs({ locateFile: file => `node_modules/sql.js/dist/${file}` });
   const db = new SQL.Database();
-  const migration = readFileSync('public/migrations/001_init.sql', 'utf8');
-  db.exec(migration);
+  const m1 = readFileSync('public/migrations/001_init.sql', 'utf8');
+  db.exec(m1);
+  const m2 = readFileSync('public/migrations/002_local_auth.sql', 'utf8');
+  db.exec(m2);
 
   db.run("INSERT INTO fournisseurs (id, nom) VALUES ('f1','Four');");
   db.run("INSERT INTO produits (id, fournisseur_id, nom) VALUES ('p1','f1','Prod');");

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import bcrypt from 'bcryptjs';
+
+const FILE = 'src/db/users.json';
+const EMAIL = 'admin@mamastock.local';
+const PASSWORD = 'admin';
+const ROLE = 'admin';
+
+async function main() {
+  let users = [];
+  if (existsSync(FILE)) {
+    users = JSON.parse(readFileSync(FILE, 'utf8'));
+  }
+  if (users.find(u => u.email === EMAIL)) {
+    console.log('Admin user already exists');
+    return;
+  }
+  const mot_de_passe_hash = await bcrypt.hash(PASSWORD, 10);
+  users.push({ email: EMAIL, mot_de_passe_hash, role: ROLE, actif: true });
+  writeFileSync(FILE, JSON.stringify(users, null, 2));
+  console.log('Admin user created:', EMAIL);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,2 +1,11 @@
-import PrivateOutlet from '@/router/PrivateOutlet'
-export default function ProtectedRoute() { return <PrivateOutlet /> }
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function ProtectedRoute({ roles }) {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/login" replace />;
+  if (roles && roles.length && !roles.includes(user.role)) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+  return <Outlet />;
+}

--- a/src/contexts/AuthContext.d.ts
+++ b/src/contexts/AuthContext.d.ts
@@ -1,12 +1,11 @@
 declare module '@/contexts/AuthContext' {
   interface AuthContextValue {
-    session?: any
-    userData?: { access_rights?: Record<string, unknown> } | null
-    loading?: boolean
-    hasAccess?: (key?: string | null) => boolean
-    [key: string]: any
+    user: { email: string; role: string } | null
+    login: (email: string, password: string) => Promise<void>
+    logout: () => Promise<void>
+    hasAccess: (module?: string | null, perm?: string | null) => boolean
   }
-  export function useAuth(): AuthContextValue | null
+  export function useAuth(): AuthContextValue
   export const AuthProvider: React.ComponentType<React.PropsWithChildren<unknown>>
   export default AuthProvider
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,99 +1,54 @@
-import supabase from '@/lib/supabase';import { useEffect, useState, useRef, createContext, useContext, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
-
-import { normalizeAccessKey } from '@/lib/access';
+import { createContext, useContext, useEffect, useState, useMemo } from 'react';
+import bcrypt from 'bcryptjs';
+import users from '@/db/users.json';
 
 const AuthCtx = createContext(null);
 export const useAuth = () => useContext(AuthCtx);
 
-function AuthProvider({ children }) {
-  const [session, setSession] = useState(null);
+export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
-  const [userData, setUserData] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const rights = useMemo(() => userData?.access_rights ?? {}, [userData?.access_rights]);
-  const initRef = useRef(false);
-  const lastLoadedUserRef = useRef(null);
-  const pollTimerRef = useRef(null);
-  const navigate = useNavigate();
-
-  async function loadProfile(sess) {
-    if (!sess) {setUserData(null);return;}
-    const displayName = sess.user?.user_metadata?.full_name || sess.user?.email || null;
-    await supabase.rpc('bootstrap_my_profile', { p_nom: displayName });
-    const { data, error } = await supabase.rpc('get_my_profile');
-    if (error) {console.error(error);setUserData(null);} else
-    {setUserData(data);}
-  }
 
   useEffect(() => {
-    if (initRef.current) return;
-    initRef.current = true;
-    if (import.meta.env.DEV) console.debug('[auth] init');
-    const init = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setSession(session ?? null);
-      setUser(session?.user ?? null);
-      if (session) {
-        setLoading(true);
-        if (import.meta.env.DEV) console.time('[auth] loadProfile');
-        await loadProfile(session);
-        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile');
-        setLoading(false);
-        navigate('/dashboard');
-      }
-    };
-    init();
-    const { data: sub } = supabase.auth.onAuthStateChange(async (_evt, sess) => {
-      setSession(sess ?? null);
-      setUser(sess?.user ?? null);
-      if (sess) {
-        setLoading(true);
-        if (import.meta.env.DEV) console.time('[auth] loadProfile');
-        await loadProfile(sess);
-        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile');
-        setLoading(false);
-        navigate('/dashboard');
-      } else {
-        setUserData(null);
-      }
-    });
-    let tries = 0;
-    const tick = async () => {
-      tries++;
-      const { data: { session } } = await supabase.auth.getSession();
-      if (session && !userData) {
-        setSession(session);
-        setUser(session.user);
-        setLoading(true);
-        if (import.meta.env.DEV) console.time('[auth] loadProfile');
-        await loadProfile(session);
-        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile');
-        setLoading(false);
-        window.clearInterval(pollTimerRef.current);
-        pollTimerRef.current = null;
-      } else if (tries >= 10) {
-        window.clearInterval(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-    };
-    pollTimerRef.current = window.setInterval(tick, 500);
-    return () => {sub?.subscription?.unsubscribe?.();if (pollTimerRef.current) window.clearInterval(pollTimerRef.current);};
-  }, [navigate, userData]);
+    const saved = localStorage.getItem('session');
+    if (saved) setUser(JSON.parse(saved));
+  }, []);
+
+  const login = async (email, password) => {
+    const found = users.find(u => u.email === email && u.actif);
+    if (!found) throw new Error('Utilisateur introuvable');
+    const ok = await bcrypt.compare(password, found.mot_de_passe_hash);
+    if (!ok) throw new Error('Mot de passe incorrect');
+    const sess = { email: found.email, role: found.role };
+    setUser(sess);
+    localStorage.setItem('session', JSON.stringify(sess));
+  };
+
+  const logout = async () => {
+    setUser(null);
+    localStorage.removeItem('session');
+  };
+
+  const roleRights = {
+    admin: { factures: { peut_modifier: true } },
+    manager: { factures: { peut_modifier: true } },
+    user: { factures: { peut_modifier: false } },
+  };
+
   const hasAccess = useMemo(() => {
-    return (key) => {
-      const k = normalizeAccessKey(key);
-      if (!k) return true;
-      return !!rights[k];
+    return (module, perm) => {
+      if (!user) return false;
+      const rights = roleRights[user.role] || {};
+      if (!module || !perm) return true;
+      return !!rights[module]?.[perm];
     };
-  }, [rights]);
+  }, [user]);
 
   const value = useMemo(
-    () => ({ session, user, userData, loading, hasAccess, ...(userData || {}) }),
-    [session, user, userData, loading, hasAccess]
+    () => ({ user, login, logout, hasAccess }),
+    [user, hasAccess]
   );
+
   return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
 }
 
 export default AuthProvider;
-export { AuthProvider };

--- a/src/db/users.json
+++ b/src/db/users.json
@@ -1,0 +1,8 @@
+[
+  {
+    "email": "admin@mamastock.local",
+    "mot_de_passe_hash": "$2a$10$WtjCbNLb6Ni.ikq8BiLGrO7e9Gm.85WfWs7KAvMrsQ7YDsD/2a0q2",
+    "role": "admin",
+    "actif": true
+  }
+]

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,19 +1,7 @@
 import { useAuth as useAuthContext } from '@/contexts/AuthContext'
-import { normalizeAccessKey } from '@/lib/access'
 
 export function useAuth() {
   return useAuthContext()
 }
 
 export default useAuth
-
-/** Hook pratique: renvoie une fonction hasAccess(key) */
-export function useHasAccess() {
-  const auth = useAuthContext()
-  const rights = auth?.userData?.access_rights ?? {}
-  return (key?: string | null) => {
-    const k = normalizeAccessKey(key)
-    if (!k) return true
-    return !!rights[k]
-  }
-}

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import supabase from '@/lib/supabase';
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 import PageWrapper from '@/components/ui/PageWrapper';
 import GlassCard from '@/components/ui/GlassCard';
@@ -10,6 +10,7 @@ import PreviewBanner from '@/components/ui/PreviewBanner';
 
 export default function Login() {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const [pending, setPending] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
@@ -27,27 +28,15 @@ export default function Login() {
       setPending(false);
       return;
     }
-    if (import.meta.env.DEV) console.time('[login] signIn');
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (import.meta.env.DEV) console.timeEnd('[login] signIn');
-    if (error) {
-      console.error('[login] error', error);
-      setErrorMsg(error.message || 'Connexion impossible');
+    try {
+      await login(email, password);
       setPending(false);
-      return;
-    }
-    let tries = 0;
-    let sess = null;
-    while (!sess && tries < 10) {
-      const { data: { session } } = await supabase.auth.getSession();
-      sess = session;
-      if (!sess) await new Promise((r) => setTimeout(r, 200));
-      tries++;
-    }
-    setPending(false);
-    if (sess) {
       if (import.meta.env.DEV) console.debug('[login] navigate to /dashboard');
       navigate('/dashboard', { replace: true });
+    } catch (err) {
+      console.error('[login] error', err);
+      setErrorMsg(err.message || 'Connexion impossible');
+      setPending(false);
     }
   }
 

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -5,7 +5,6 @@ import lazyWithPreload from "@/lib/lazyWithPreload";
 import nprogress from 'nprogress';
 import { useLocation } from 'react-router-dom';
 import ErrorBoundary from "@/components/ErrorBoundary";
-import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import PageSkeleton from "@/components/ui/PageSkeleton";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { useAuth } from '@/contexts/AuthContext';
@@ -21,6 +20,7 @@ import DebugAuth from "@/pages/debug/DebugAuth";
 import AccessExample from "@/pages/debug/AccessExample";
 import DebugRights from "@/pages/debug/DebugRights";
 import PrivateOutlet from "@/router/PrivateOutlet";
+import ProtectedRoute from "@/components/ProtectedRoute";
 
 const Dashboard = lazyWithPreload(() => import("@/pages/Dashboard.jsx"));
 const Fournisseurs = lazyWithPreload(() => import("@/pages/fournisseurs/Fournisseurs.jsx"));
@@ -203,13 +203,8 @@ export const routePreloadMap = {
 
 function RootRoute() {
   const location = useLocation();
-  const { session, userData, loading } = useAuth();
-
-  if (loading || (session && !userData)) {
-    return <LoadingSpinner message="Chargement..." />;
-  }
-
-  if (!session) {
+  const { user } = useAuth();
+  if (!user) {
     return (
       <Navigate
         to="/login"
@@ -218,9 +213,6 @@ function RootRoute() {
       />
     );
   }
-
-  if (userData?.actif === false) return <Navigate to="/blocked" replace />;
-
   return <Navigate to="/dashboard" replace />;
 }
 
@@ -289,14 +281,10 @@ export default function Router() {
             path="/factures"
             element={<Factures />}
           />
-          <Route
-            path="/factures/new"
-            element={<FactureForm />}
-          />
-          <Route
-            path="/factures/:id"
-            element={<FactureForm />}
-          />
+          <Route element={<ProtectedRoute roles={['admin','manager']} />}>
+            <Route path="/factures/new" element={<FactureForm />} />
+            <Route path="/factures/:id" element={<FactureForm />} />
+          </Route>
           <Route
             path="/factures/import"
             element={<ImportFactures />}


### PR DESCRIPTION
## Summary
- replace cloud auth with bcrypt-powered local session
- gate invoice creation by role via ProtectedRoute
- seed admin user and add SQL migration for users

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Failed to load url test/setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf178dc88832d829792136c26805f