### PR TITLE
feat: exports CSV/XLSX/PDF locaux

### DIFF
--- a/README-offline.md
+++ b/README-offline.md
@@ -7,6 +7,12 @@ Cette variante embarque une base SQLite locale et Tauri pour fonctionner hors li
 - Sélectionnez le dossier qui contiendra `mamastock.db` et les fichiers de verrou (`db.lock.json`, `shutdown.request.json`).
 - Le chemin est enregistré dans `%APPDATA%\MamaStock\config.json`.
 
+## Exports locaux
+- Des boutons **Export CSV/XLSX/PDF** sont disponibles dans les listes Produits, Fournisseurs et Factures.
+- Les fichiers sont enregistrés par défaut dans `Documents/MamaStock/Exports`.
+- Le dossier peut être modifié dans la page **Paramètres** via le champ *Dossier d'export*.
+- Aucun accès Internet n'est requis pour générer les fichiers.
+
 ## Règle "un seul poste à la fois"
 Un fichier `db.lock.json` protège l'accès à la base. Un poste doit être fermé (menu quitter) avant d'ouvrir l'application sur un autre poste. Un `shutdown.request.json` peut être créé pour demander la libération du verrou.
 

--- a/src/lib/export/dir.ts
+++ b/src/lib/export/dir.ts
@@ -1,0 +1,31 @@
+import { documentDir, join } from "@tauri-apps/api/path";
+import { createDir, exists, readTextFile, writeTextFile } from "@tauri-apps/api/fs";
+
+const CONFIG_FILE = "export.config.json";
+
+async function configPath(): Promise<string> {
+  const base = await documentDir();
+  const dir = await join(base, "MamaStock");
+  await createDir(dir, { recursive: true });
+  return await join(dir, CONFIG_FILE);
+}
+
+export async function getExportDir(): Promise<string> {
+  const cfg = await configPath();
+  if (await exists(cfg)) {
+    try {
+      const data = JSON.parse(await readTextFile(cfg));
+      if (data.exportDir) return data.exportDir as string;
+    } catch {
+      /* ignore */
+    }
+  }
+  const base = await documentDir();
+  return await join(base, "MamaStock", "Exports");
+}
+
+export async function setExportDir(dir: string) {
+  const cfg = await configPath();
+  await createDir(dir, { recursive: true });
+  await writeTextFile(cfg, JSON.stringify({ exportDir: dir }));
+}

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -15,8 +15,6 @@ import PaginationFooter from '@/components/ui/PaginationFooter';
 import TableHeader from '@/components/ui/TableHeader';
 import FournisseurRow from '@/components/fournisseurs/FournisseurRow';
 import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
-import JSPDF from 'jspdf';
-import 'jspdf-autotable';
 import { toast } from 'sonner';
 import {
   ResponsiveContainer,
@@ -40,7 +38,7 @@ export default function Fournisseurs() {
     createFournisseur,
     updateFournisseur,
     toggleFournisseurActive,
-    exportFournisseursToExcel,
+    exportFournisseurs,
   } = useFournisseursActions();
   const { fetchStatsAll } = useFournisseurStats();
   const { getProduitsDuFournisseur, countProduitsDuFournisseur } =
@@ -115,22 +113,6 @@ export default function Fournisseurs() {
     if (fournisseurs.length) fetchCounts();
   }, [fournisseurs]);
 
-  const exportPDF = () => {
-    const doc = new JSPDF();
-    doc.text('Liste Fournisseurs', 10, 12);
-    doc.autoTable({
-      startY: 20,
-      head: [['Nom', 'Téléphone', 'Contact', 'Email']],
-      body: listWithContact.map((f) => [
-        f.nom,
-        f.contact?.tel || '',
-        f.contact?.nom || '',
-        f.contact?.email || '',
-      ]),
-      styles: { fontSize: 9 },
-    });
-    doc.save('fournisseurs.pdf');
-  };
 
   async function handleDiag() {
     const { data, error: diagError } = await supabase
@@ -250,10 +232,13 @@ export default function Fournisseurs() {
                 <PlusCircle className="mr-2" size={18} /> Ajouter fournisseur
               </Button>
             )}
-            <Button className="w-auto" onClick={() => exportFournisseursToExcel(fournisseurs)}>
+            <Button className="w-auto" onClick={() => exportFournisseurs(fournisseurs, 'excel')}>
               Export Excel
             </Button>
-            <Button className="w-auto" onClick={exportPDF}>
+            <Button className="w-auto" onClick={() => exportFournisseurs(fournisseurs, 'csv')}>
+              Export CSV
+            </Button>
+            <Button className="w-auto" onClick={() => exportFournisseurs(fournisseurs, 'pdf')}>
               Export PDF
             </Button>
             <Button className="w-auto" onClick={handleDiag}>

--- a/src/pages/parametrage/MamaSettingsForm.jsx
+++ b/src/pages/parametrage/MamaSettingsForm.jsx
@@ -7,6 +7,9 @@ import GlassCard from "@/components/ui/GlassCard";
 import useMamaSettings from "@/hooks/useMamaSettings";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 import { useAuth } from '@/hooks/useAuth';
+import { Button } from '@/components/ui/button';
+import { open } from '@tauri-apps/api/dialog';
+import { getExportDir, setExportDir } from '@/lib/export/dir';
 
 export default function MamaSettingsForm() {
   const { mama_id } = useAuth();
@@ -14,6 +17,7 @@ export default function MamaSettingsForm() {
   const [form, setForm] = useState(settings);
   const [logoFile, setLogoFile] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [exportDir, setExportDirState] = useState('');
 
   useEffect(() => {
     fetchMamaSettings();
@@ -22,6 +26,10 @@ export default function MamaSettingsForm() {
   useEffect(() => {
     setForm(settings);
   }, [settings]);
+
+  useEffect(() => {
+    getExportDir().then(setExportDirState);
+  }, []);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -48,6 +56,7 @@ export default function MamaSettingsForm() {
         fields.logo_url = url;
       }
       await updateMamaSettings(fields);
+      await setExportDir(exportDir);
       toast.success("Paramètres enregistrés");
     } catch (err) {
       console.error(err);
@@ -96,6 +105,21 @@ export default function MamaSettingsForm() {
           value={form.email_alertes || ""}
           onChange={handleChange}
         />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Dossier d'export</label>
+        <div className="flex gap-2">
+          <Input className="flex-1" value={exportDir} readOnly />
+          <Button
+            type="button"
+            onClick={async () => {
+              const dir = await open({ directory: true });
+              if (dir) setExportDirState(dir);
+            }}
+          >
+            Choisir
+          </Button>
+        </div>
       </div>
       <div>
         <label className="block text-sm mb-1">Mode sombre</label>


### PR DESCRIPTION
## Summary
- add configurable local export directory
- enable CSV/XLSX/PDF exports for produits, fournisseurs et factures
- document offline export usage

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts)*
- `npm run lint` *(fails: ESLint looked for configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_68bb47fcfcb4832dbecc233c8e08e5cc