### PR TITLE
feat: backup/restore DB + maintenance

### DIFF
--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { open } from "@tauri-apps/api/dialog";
+import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
+
+export default function SystemTools() {
+  const [message, setMessage] = useState("");
+
+  const doBackup = async () => {
+    try {
+      await backupDb();
+      setMessage("Sauvegarde effectuée.");
+    } catch (e) {
+      setMessage(`Erreur sauvegarde: ${e}`);
+    }
+  };
+
+  const doRestore = async () => {
+    try {
+      const file = await open({ filters: [{ name: "Database", extensions: ["db"] }] });
+      if (file) {
+        await restoreDb(file as string);
+        setMessage("Base restaurée. Veuillez redémarrer l'application.");
+      }
+    } catch (e) {
+      setMessage(`Erreur restauration: ${e}`);
+    }
+  };
+
+  const doMaintenance = async () => {
+    try {
+      await maintenanceDb();
+      setMessage("Maintenance terminée.");
+    } catch (e) {
+      setMessage(`Erreur maintenance: ${e}`);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl">Outils système</h1>
+      <div className="flex flex-col gap-2">
+        <button onClick={doBackup} className="border px-2 py-1">
+          Sauvegarder
+        </button>
+        <button onClick={doRestore} className="border px-2 py-1">
+          Restaurer
+        </button>
+        <button onClick={doMaintenance} className="border px-2 py-1">
+          Maintenance
+        </button>
+      </div>
+      {message && <div>{message}</div>}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -73,6 +73,7 @@ const SousFamilles = lazyWithPreload(() => import("@/pages/parametrage/SousFamil
 const Unites = lazyWithPreload(() => import("@/pages/parametrage/Unites.jsx"));
 const Periodes = lazyWithPreload(() => import("@/pages/parametrage/Periodes.jsx"));
 const DataFolder = lazyWithPreload(() => import("@/pages/parametrage/DataFolder.jsx"));
+const SystemTools = lazyWithPreload(() => import("@/pages/parametrage/SystemTools.jsx"));
 const Onboarding = lazyWithPreload(() => import("@/pages/public/Onboarding.jsx"));
 const Accueil = lazyWithPreload(() => import("@/pages/Accueil.jsx"));
 const Signup = lazyWithPreload(() => import("@/pages/public/Signup.jsx"));
@@ -582,10 +583,14 @@ export default function Router() {
             path="/parametrage/periodes"
             element={<Periodes />}
           />
-          <Route
-            path="/parametrage/data"
-            element={<DataFolder />}
-          />
+            <Route
+              path="/parametrage/data"
+              element={<DataFolder />}
+            />
+            <Route
+              path="/parametrage/systeme"
+              element={<SystemTools />}
+            />
           <Route
             path="/parametrage/access"
             element={<AccessRights />}


### PR DESCRIPTION
## Summary
- add database backup, restore and maintenance utilities
- expose new system tools page for these operations
- wire route for system tools

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4804f170832d8ffa20804003fa1f