### PR TITLE
feat: backup/restore DB + maintenance

### DIFF
--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { open } from "@tauri-apps/api/dialog";
+import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
+
+export default function SystemTools() {
+  const [message, setMessage] = useState("");
+
+  const backup = async () => {
+    await backupDb();
+    setMessage("Sauvegarde effectuée.");
+  };
+
+  const restore = async () => {
+    const file = await open({ filters: [{ name: "Base", extensions: ["db"] }] });
+    if (file) {
+      await restoreDb(file as string);
+      setMessage("Base restaurée. Veuillez redémarrer l'application.");
+    }
+  };
+
+  const maintain = async () => {
+    await maintenanceDb();
+    setMessage("Maintenance effectuée.");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl">Outils système</h1>
+      <div className="flex gap-2">
+        <button onClick={backup} className="border px-2 py-1">Sauvegarder</button>
+        <button onClick={restore} className="border px-2 py-1">Restaurer</button>
+        <button onClick={maintain} className="border px-2 py-1">Maintenance</button>
+      </div>
+      {message && <p className="text-sm text-gray-500">{message}</p>}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -73,6 +73,7 @@ const SousFamilles = lazyWithPreload(() => import("@/pages/parametrage/SousFamil
 const Unites = lazyWithPreload(() => import("@/pages/parametrage/Unites.jsx"));
 const Periodes = lazyWithPreload(() => import("@/pages/parametrage/Periodes.jsx"));
 const DataFolder = lazyWithPreload(() => import("@/pages/parametrage/DataFolder.jsx"));
+const SystemTools = lazyWithPreload(() => import("@/pages/parametrage/SystemTools.jsx"));
 const Onboarding = lazyWithPreload(() => import("@/pages/public/Onboarding.jsx"));
 const Accueil = lazyWithPreload(() => import("@/pages/Accueil.jsx"));
 const Signup = lazyWithPreload(() => import("@/pages/public/Signup.jsx"));
@@ -188,6 +189,7 @@ export const routePreloadMap = {
   '/parametrage/unites': Unites.preload,
   '/parametrage/periodes': Periodes.preload,
   '/parametrage/data': DataFolder.preload,
+  '/parametrage/system': SystemTools.preload,
   '/consentements': Consentements.preload,
   '/supervision': SupervisionGroupe.preload,
   '/supervision/comparateur': ComparateurFiches.preload,
@@ -569,6 +571,10 @@ export default function Router() {
           <Route
             path="/parametrage/periodes"
             element={<Periodes />}
+          />
+          <Route
+            path="/parametrage/system"
+            element={<SystemTools />}
           />
           <Route
             path="/parametrage/data"


### PR DESCRIPTION
## Summary
- add database backup, restore and maintenance helpers
- expose new "Outils système" page to trigger operations
- register page route

## Testing
- `npm test` (fails: Failed to load url test/setup.ts)
- `npm run lint` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_e_68bbf46145a8832d9651bf394558902c