### PR TITLE
ci: verify & windows release

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,28 +1,12 @@
 name: Build Windows
 
 on:
-  pull_request:
   push:
     tags:
       - 'v*'
 
 jobs:
-  verify:
-    if: github.event_name == 'pull_request'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
-      - run: npm ci
-      - run: npm run build
-
   build:
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,4 +25,4 @@ jobs:
           releaseBody: Windows release
           includeDebug: false
           includeRelease: true
-          targets: "msi"
+          targets: "msi nsis"

--- a/.github/workflows/verify-local.yml
+++ b/.github/workflows/verify-local.yml
@@ -1,0 +1,16 @@
+name: Verify local
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run db:smoke

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ If linting or tests fail because required packages are missing, simply run
 `npm install` again. This ensures `tesseract.js`, `vitest`, `@eslint/js` and
 `playwright` are available before running the commands above.
 
+## Release
+
+To create a Windows installer:
+
+1. Commit your changes and bump the version if needed.
+2. Tag the commit with a `v*` version:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+3. GitHub Actions builds MSI and EXE installers with Tauri and attaches them to a release.
+
 During production builds, `console.debug` output is automatically disabled so
 the browser console stays clean. Use the `DEV` mode if you need verbose debug information.
 


### PR DESCRIPTION
## Summary
- add verify-local workflow to build the web app and run a DB smoke test for pull requests
- build Windows MSI and EXE installers on `v*` tags using tauri-action and publish release
- document tagging and release steps in README

## Testing
- `npm test` *(fails: Failed to load url /workspace/MAMASTOCK-LOCAL/test/setup.ts; Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf830f0bc832d8141568f06aff509