### PR TITLE
chore: build.ps1 one-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ To create a Windows installer:
    ```
 3. GitHub Actions builds MSI and EXE installers with Tauri and attaches them to a release.
 
+### One-click build
+
+On Windows 11 you can double-click `build.ps1` to install Node.js LTS, Rustup,
+Visual Studio Build Tools and the WiX Toolset via `winget`, then run `npm ci`,
+`npm run build` and `npx tauri build`. The script logs output to `build.log`
+and prints the path to the generated installer bundle.
+
 During production builds, `console.debug` output is automatically disabled so
 the browser console stays clean. Use the `DEV` mode if you need verbose debug information.
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,9 +1,38 @@
 # One-click build script for Windows
-winget install -e --id Node.js.LTS -h
-winget install -e --id Rustlang.Rustup -h
-winget install -e --id Microsoft.VisualStudio.2022.BuildTools -h
-winget install -e --id WiXToolset.WiXToolset -h
 
-npm ci
-npm run build
-npx tauri build
+# Ensure script runs as administrator
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "Please run this script as Administrator."
+    exit 1
+}
+
+# Log everything to build.log
+$logPath = Join-Path $PSScriptRoot 'build.log'
+Start-Transcript -Path $logPath -Append | Out-Null
+
+try {
+    Set-Location -Path $PSScriptRoot
+
+    $packages = @(
+        'Node.js.LTS',
+        'Rustlang.Rustup',
+        'Microsoft.VisualStudio.2022.BuildTools',
+        'WiXToolset.WiXToolset'
+    )
+
+    foreach ($pkg in $packages) {
+        winget install -e --id $pkg --accept-package-agreements --accept-source-agreements -h
+    }
+
+    npm ci
+    npm run build
+    npx tauri build
+
+    $bundlePath = Join-Path $PSScriptRoot 'src-tauri\\target\\release\\bundle'
+    Write-Host "Bundle generated in: $bundlePath"
+}
+finally {
+    Stop-Transcript | Out-Null
+}
+


### PR DESCRIPTION
## Summary
- add Windows one-click build script to install prerequisites, build, and log output
- document automated build workflow in README

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint looked for configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfd3047f4832d9195d9e40dd7f850