### PR TITLE
feat: backup/restore DB + maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Pour partager les données, synchronisez le dossier choisi avec un outil comme *
 Assurez‑vous qu'un seul poste utilise la base à la fois.
 
 ## Backup et restauration
-- `npm run backup` crée une copie horodatée de `mamastock.db` dans le répertoire courant.
-- Pour restaurer, remplacez simplement le fichier `mamastock.db` par la sauvegarde souhaitée.
+- Depuis la page **Outils système**, cliquez sur **Sauvegarder** pour créer une copie horodatée de `mamastock.db` dans `Documents/MamaStock/Backups`.
+- Le bouton **Restaurer** permet de choisir un fichier `.db`, de remplacer la base courante puis de redémarrer automatiquement l'application.
+- **Maintenance** exécute `wal_checkpoint(TRUNCATE)` puis `VACUUM` pour compacter la base.
+- `npm run backup` reste disponible en ligne de commande.
 
 ## Maintenance
 - Vérifiez régulièrement que la synchronisation (Syncthing) est à jour.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,6 +12,7 @@ This document tracks the global progress of the project.
 - DAL SQLite pour Produits/Fournisseurs/Factures
 - Paramétrage du dossier de données avec verrou distribué et auto‑fermeture
 - Workflows CI: vérification des PR (build + db:smoke) et release Windows via tag `v*`
+- Sauvegarde/restauration/maintenance SQLite via interface
 
 ### En cours
 - TBD

--- a/docs/reports/PR-009_report.json
+++ b/docs/reports/PR-009_report.json
@@ -1,0 +1,44 @@
+{
+  "pr_number": "009",
+  "title": "feat: backup/restore DB + maintenance",
+  "summary": "ajoute des boutons d'outil système pour sauvegarde, restauration avec redémarrage et maintenance, plus documentation",
+  "files": {
+    "added": [
+      "docs/reports/PR-009_report.md",
+      "docs/reports/PR-009_report.json"
+    ],
+    "modified": [
+      "package.json",
+      "package-lock.json",
+      "src-tauri/Cargo.toml",
+      "src-tauri/Cargo.lock",
+      "src-tauri/src/main.rs",
+      "src/pages/parametrage/SystemTools.jsx",
+      "README.md",
+      "docs/STATUS.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "✓ built in 16.25s"
+    },
+    {
+      "name": "db:smoke",
+      "command": "npm run db:smoke",
+      "status": "pass",
+      "stdout": "migration smoke ok"
+    },
+    {
+      "name": "unit",
+      "command": "npm test",
+      "status": "pass",
+      "stdout": "Test Files 3 passed"
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-009_report.md
+++ b/docs/reports/PR-009_report.md
@@ -1,0 +1,32 @@
+# PR-009 Report
+
+## Résumé
+Ajout de boutons d'outils système pour sauvegarder, restaurer (avec redémarrage) et maintenir la base SQLite, avec notifications et documentation.
+
+## Fichiers ajoutés/modifiés/supprimés
+- package.json
+- package-lock.json
+- src-tauri/Cargo.toml
+- src-tauri/Cargo.lock
+- src-tauri/src/main.rs
+- src/pages/parametrage/SystemTools.jsx
+- README.md
+- docs/STATUS.md
+- docs/reports/PR-009_report.md
+- docs/reports/PR-009_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm run build
+npm run db:smoke
+npm test
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- TBD
+
+## Impact utilisateur
+- Sauvegarde, restauration (redémarrage auto) et maintenance de la base accessibles depuis l'interface avec toasts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-virtual": "^3.13.12",
+        "@tauri-apps/plugin-process": "^2.3.0",
         "@tauri-apps/plugin-sql": "^2",
         "bcryptjs": "^2.4.3",
         "date-fns": "3.6.0",
@@ -5500,6 +5501,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.0.tgz",
+      "integrity": "sha512-0DNj6u+9csODiV4seSxxRbnLpeGYdojlcctCuLOCgpH9X3+ckVZIEj6H7tRQ7zqWr7kSTEWnrxtAdBb0FbtrmQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.6.0"
       }
     },
     "node_modules/@tauri-apps/plugin-sql": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-virtual": "^3.13.12",
+    "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-sql": "^2",
     "bcryptjs": "^2.4.3",
     "date-fns": "3.6.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1896,6 +1896,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-process",
  "tauri-plugin-sql",
 ]
 
@@ -3896,6 +3897,16 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.5",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7461c622a5ea00eb9cd9f7a08dbd3bf79484499fd5c21aa2964677f64ca651ab"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 tauri = { version = "2", features = ["wry"] }
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,7 @@
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(tauri_plugin_process::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- add system tools buttons to backup, restore with auto-restart and run maintenance with toast feedback
- document backup/restore/maintenance workflow and update project status
- enable Tauri process plugin for relaunch

## Testing
- `npm run build`
- `npm run db:smoke`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc952da2dc832d9b3ccb8ac482f17b