### PR TITLE
chore: branding (SVG) + génération d’icônes à la build (no binaries)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
       - run: npm ci
-      - name: Generate icons (if script exists)
-        run: npm run icon:gen --if-present
+      - name: Generate icons
+        run: npm run icon:gen
       - run: npm run build
       - uses: tauri-apps/tauri-action@v0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ weekly_cost_centers.xlsx
 backup_*.json
 invoices_*.xlsx
 
-# Tauri generated icons
-src-tauri/icons
+# Tauri generated icons (not tracked)
+src-tauri/icons/

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <title>MamaStock Local logo</title>
   <rect x="96" y="64" width="320" height="384" rx="40" ry="40" fill="none" stroke="#0d9488" stroke-width="24"/>
   <rect x="96" y="256" width="320" height="192" rx="40" ry="40" fill="#0d9488"/>

--- a/build.ps1
+++ b/build.ps1
@@ -26,8 +26,8 @@ try {
     }
 
     npm ci
-    npm run icon:gen
     npm run build
+    npm run icon:gen
     npx tauri build
 
     $bundlePath = Join-Path $PSScriptRoot 'src-tauri\\target\\release\\bundle'

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -14,6 +14,7 @@ This document tracks the global progress of the project.
 - Workflows CI: vérification des PR (build + db:smoke) et release Windows via tag `v*`
 - Sauvegarde/restauration/maintenance SQLite via interface
 - Exports locaux (CSV/XLSX/PDF) pour produits, fournisseurs et factures
+- Logo vectoriel et génération d'icônes Tauri automatisée à la build
 
 ### En cours
 - TBD

--- a/docs/reports/PR-008_report.json
+++ b/docs/reports/PR-008_report.json
@@ -1,0 +1,38 @@
+{
+  "pr_number": "008",
+  "title": "chore: branding (SVG) + génération d’icônes à la build (no binaries)",
+  "summary": "add SVG logo, generate Tauri icons during build without committing binaries",
+  "files": {
+    "added": [
+      "docs/reports/PR-008_report.md",
+      "docs/reports/PR-008_report.json"
+    ],
+    "modified": [
+      "assets/logo.svg",
+      "package.json",
+      "build.ps1",
+      ".github/workflows/build-windows.yml",
+      "src-tauri/tauri.conf.json",
+      ".gitignore",
+      "docs/STATUS.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "icon:gen",
+      "command": "npm run icon:gen",
+      "status": "pass",
+      "stdout": "ICO Creating icon.ico"
+    },
+    {
+      "name": "tauri build",
+      "command": "npx tauri build",
+      "status": "fail",
+      "stdout": "Rollup failed to resolve import \"@tauri-apps/plugin-process\""
+    }
+  ],
+  "todos": [],
+  "risks": []
+}
+

--- a/docs/reports/PR-008_report.md
+++ b/docs/reports/PR-008_report.md
@@ -1,0 +1,31 @@
+# PR-008 Report
+
+## Résumé
+Ajout du logo SVG et génération automatique des icônes Tauri à la build, sans versionner les PNG/ICO.
+
+## Fichiers ajoutés/modifiés/supprimés
+- assets/logo.svg
+- package.json
+- build.ps1
+- .github/workflows/build-windows.yml
+- src-tauri/tauri.conf.json
+- .gitignore
+- docs/STATUS.md
+- docs/reports/PR-008_report.md
+- docs/reports/PR-008_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm run icon:gen
+npx tauri build
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- TBD
+
+## Impact utilisateur
+- Logo vectoriel et icônes générées automatiquement lors des builds Tauri.
+

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "db:apply": "node --enable-source-maps scripts/sqlite-apply.js",
     "db:smoke": "node --enable-source-maps scripts/migration-smoke.js",
     "seed:admin": "node scripts/seed-admin.js",
-    "icon:gen": "tauri icon assets/logo.svg -o src-tauri/icons || node scripts/icon-fallback.js",
+    "icon:gen": "tauri icon assets/logo.svg -o src-tauri/icons",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "doctor": "pwsh scripts/doctor.ps1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run icon:gen && npm run build",
+    "beforeBuildCommand": "npm run build",
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist"
   },
@@ -24,14 +24,6 @@
   "bundle": {
     "active": true,
     "targets": ["msi"],
-    "windows": { "webviewInstallMode": { "type": "embedBootstrapper" } },
-    "icon": [
-      "icons/icon.ico",
-      "icons/icon.icns",
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/256x256.png",
-      "icons/512x512.png"
-    ]
+    "windows": { "webviewInstallMode": { "type": "embedBootstrapper" } }
   }
 }


### PR DESCRIPTION
## Summary
- add vector logo and ignore generated icons
- generate Tauri icons from SVG via npm script
- run icon generation in Windows build and build script
- simplify Tauri config to auto-detect icons
- document PR in STATUS and reports

## Testing
- `npm run icon:gen`
- `npx tauri build` *(fails: Rollup failed to resolve import `@tauri-apps/plugin-process`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98d49ac8832d9be6e348a2cf33bf