### PR TITLE
chore: Release Windows 1.0.0 (CHANGELOG + QA + tag guide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 1.0.0 - 2025-09-07
+
+### Added
+- Migration vers Tauri v2 et purge Supabase/Postgres.
+- Base SQLite locale avec `valeur_stock` et triggers pour stock/PMP.
+- Authentification locale (bcrypt) avec script `seed-admin`.
+- DAL SQLite pour produits, fournisseurs et factures.
+- Paramétrage du dossier de données avec verrou distribué et auto-fermeture des instances concurrentes.
+- Exports locaux (CSV, XLSX, PDF).
+- Sauvegarde, restauration et maintenance de la base via l'interface.
+- Workflows CI Windows générant un installateur MSI.
+- Branding : logo vectoriel et génération d'icônes automatisée.
+
+### Breaking changes
+- Aucun.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 Cette variante, basée sur **Tauri v2**, embarque une base SQLite locale pour fonctionner hors ligne.
 
 ## Installation
+- Prérequis : Windows 11 x64. Si WebView2 est absent, le bootstrapper l'installera.
 - Télécharger l'installateur **MSI** produit par la CI.
-- L'exécuter : le bootstrapper WebView2 gère automatiquement l'installation du moteur.
+- L'exécuter.
 
 ## Choisir le dossier des données
 - Lancez l'application puis ouvrez la page **Paramètres**.
@@ -51,7 +52,8 @@ Exécuter dans **PowerShell** :
 
 Ce script installe Node.js LTS, Rustup, les Build Tools C++ de Visual Studio et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run icon:gen`, `npm run build` et `npx tauri build`.
 
-## Release
-- Créez et poussez un tag `v1.0.0` (exemple).
-- Récupérez l’installateur MSI généré par la CI dans l’onglet **Actions** ou la page **Releases** de GitHub.
+## Publier une release Windows
+- `git tag v1.0.0`
+- `git push origin v1.0.0`
+- Récupérer l’installateur MSI généré par la CI sur la page **Releases** de GitHub.
 

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,15 +1,14 @@
 # QA
 
-Parcours manuel pour valider une release candidate.
+Parcours manuel pour valider une release candidate Windows.
 
-1. Se connecter avec un compte valide.
+1. Lancer l'application puis se connecter avec l'administrateur créé via `npm run seed:admin`.
 2. Créer un fournisseur.
 3. Créer un produit.
 4. Émettre une facture pour ce fournisseur avec une ligne :
    - quantité : 10
    - prix unitaire : 2.5
 5. Vérifier que le PMP du produit est de 2.5 et que le stock est de 10.
-6. Exporter les produits en CSV.
-7. Sauvegarder la base de données.
-8. Restaurer cette sauvegarde.
-
+6. Exporter les produits en CSV **et** en XLSX puis vérifier que les fichiers sont présents.
+7. Sauvegarder la base de données, restaurer cette sauvegarde et vérifier le redémarrage de l'application.
+8. Tester le verrou distribué : une instance A est ouverte, démarrer une instance B → A se ferme et B prend la main.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,6 +21,7 @@ This document tracks the global progress of the project.
 - Alias '@' unifié pour Vite/Vitest/TS avec fallback Node et tests d'export stabilisés
 - Passage à `@tauri-apps/api/path` avec suppression du faux plugin path et mise à jour du script d'interdiction d'import
 - Durcissement Windows uniquement : workflows CI Windows, bundle MSI, build.ps1 et documentation dédiés
+- Préparation de la première release Windows 1.0.0 : changelog initial, guide QA et instructions de publication
 
 ### En cours
 - TBD

--- a/docs/reports/PR-019-WIN_report.json
+++ b/docs/reports/PR-019-WIN_report.json
@@ -1,0 +1,40 @@
+{
+  "pr_number": "019-WIN",
+  "title": "chore: Release Windows 1.0.0 (CHANGELOG + QA + tag guide)",
+  "summary": "Préparation de la première release Windows 1.0.0 : changelog initial, guide QA minimal et guide de publication (tags).",
+  "files": {
+    "added": [
+      "CHANGELOG.md",
+      "docs/reports/PR-019-WIN_report.md",
+      "docs/reports/PR-019-WIN_report.json"
+    ],
+    "modified": [
+      "README.md",
+      "docs/QA.md",
+      "docs/STATUS.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "npm run build",
+      "command": "npm run build",
+      "status": "fail",
+      "stdout": "Rollup failed to resolve import '@tauri-apps/plugin-dialog'"
+    },
+    {
+      "name": "npm run db:smoke",
+      "command": "npm run db:smoke",
+      "status": "pass",
+      "stdout": "migration smoke ok"
+    },
+    {
+      "name": "npm run check:tauri",
+      "command": "npm run check:tauri",
+      "status": "pass",
+      "stdout": ""
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-019-WIN_report.md
+++ b/docs/reports/PR-019-WIN_report.md
@@ -1,0 +1,28 @@
+# PR-019-WIN Report
+
+## Résumé
+Préparation de la première release Windows 1.0.0 : changelog initial, guide QA minimal et guide de publication (tags).
+
+## Fichiers ajoutés/modifiés/supprimés
+- CHANGELOG.md
+- README.md
+- docs/QA.md
+- docs/STATUS.md
+- docs/reports/PR-019-WIN_report.md
+- docs/reports/PR-019-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm run build
+npm run db:smoke
+npm run check:tauri
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- Aucun.
+
+## Impact utilisateur
+- Guide clair pour publier et valider la première release Windows.


### PR DESCRIPTION
## Summary
- add CHANGELOG for Windows 1.0.0
- document QA scenario and release tagging
- note release steps and prerequisites in README

## Testing
- `npm run build` *(fails: Rollup failed to resolve import '@tauri-apps/plugin-dialog')*
- `npm run db:smoke`
- `npm run check:tauri`


------
https://chatgpt.com/codex/tasks/task_e_68bd34b9d87c832d81e9fff7f2abcf4d