### PR TITLE
fix: Windows toolchain MSVC only (no MSYS) + hardening build.ps1 & CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,6 +16,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
+      - name: Force MSVC
+        run: |
+          rustup set default-host x86_64-pc-windows-msvc
+          rustup toolchain install stable-x86_64-pc-windows-msvc
+          rustup default stable-x86_64-pc-windows-msvc
+          rustc -Vv
+          cargo -Vv
       - run: npm ci
       - name: Generate icons
         run: npm run icon:gen

--- a/.github/workflows/verify-local.yml
+++ b/.github/workflows/verify-local.yml
@@ -11,6 +11,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+      - name: Force MSVC
+        run: |
+          rustup set default-host x86_64-pc-windows-msvc
+          rustup toolchain install stable-x86_64-pc-windows-msvc
+          rustup default stable-x86_64-pc-windows-msvc
+          rustc -Vv
+          cargo -Vv
       - run: npm ci
       - run: npm run build
       - run: npm run db:smoke

--- a/build.ps1
+++ b/build.ps1
@@ -15,6 +15,16 @@ Start-Transcript -Path $logPath -Append | Out-Null
 try {
     Set-Location -Path $PSScriptRoot
 
+    rustup set default-host x86_64-pc-windows-msvc
+    rustup toolchain install stable-x86_64-pc-windows-msvc
+    rustup default stable-x86_64-pc-windows-msvc
+    rustc -Vv
+    cargo -Vv
+
+    if ($env:PATH -match 'msys|mingw|git\\usr\\bin') {
+        Write-Warning 'MSYS/MinGW detected in PATH. Build may fail.'
+    }
+
     $packages = @(
         'OpenJS.NodeJS.LTS',
         'Rustlang.Rustup',

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -12,3 +12,15 @@ Parcours manuel pour valider une release candidate Windows.
 6. Exporter les produits en CSV **et** en XLSX puis vérifier que les fichiers sont présents.
 7. Sauvegarder la base de données, restaurer cette sauvegarde et vérifier le redémarrage de l'application.
 8. Tester le verrou distribué : une instance A est ouverte, démarrer une instance B → A se ferme et B prend la main.
+
+## Astuce build Windows
+
+Pour compiler sous Windows, forcer l'usage exclusif du toolchain Rust MSVC (`x86_64-pc-windows-msvc`) :
+
+```powershell
+rustup set default-host x86_64-pc-windows-msvc
+rustup toolchain install stable-x86_64-pc-windows-msvc
+rustup default stable-x86_64-pc-windows-msvc
+```
+
+Assurez-vous qu'aucun élément MSYS/MinGW (comme `git\usr\bin`) ne figure dans `PATH`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,6 +22,7 @@ This document tracks the global progress of the project.
 - Passage à `@tauri-apps/api/path` avec suppression du faux plugin path et mise à jour du script d'interdiction d'import
 - Durcissement Windows uniquement : workflows CI Windows, bundle MSI, build.ps1 et documentation dédiés
 - Préparation de la première release Windows 1.0.0 : changelog initial, guide QA et instructions de publication
+- Forçage du toolchain Rust MSVC et avertissement en cas de présence de MSYS/MinGW
 
 ### En cours
 - TBD

--- a/docs/reports/PR-020-WIN_report.json
+++ b/docs/reports/PR-020-WIN_report.json
@@ -1,0 +1,42 @@
+{
+  "pr_number": "020-WIN",
+  "title": "fix: Windows toolchain MSVC only (no MSYS) + hardening build.ps1 & CI",
+  "summary": "Force MSVC Rust toolchain, warn on MSYS/MinGW, and document Windows-only build requirements.",
+  "files": {
+    "added": [
+      "docs/reports/PR-020-WIN_report.md",
+      "docs/reports/PR-020-WIN_report.json"
+    ],
+    "modified": [
+      "build.ps1",
+      ".github/workflows/build-windows.yml",
+      ".github/workflows/verify-local.yml",
+      "docs/QA.md",
+      "docs/STATUS.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "npm ci",
+      "command": "npm ci",
+      "status": "pass",
+      "stdout": "added 1133 packages, and audited 1140 packages in 18s"
+    },
+    {
+      "name": "npm run build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "✓ built in 21.64s"
+    },
+    {
+      "name": "npx tauri build",
+      "command": "npx tauri build",
+      "status": "fail",
+      "stdout": "cannot find function `init` in crate `tauri_plugin_sql`"
+    }
+  ],
+  "todos": [],
+  "risks": []
+}
+

--- a/docs/reports/PR-020-WIN_report.md
+++ b/docs/reports/PR-020-WIN_report.md
@@ -1,0 +1,30 @@
+# PR-020-WIN Report
+
+## Résumé
+Forçage du toolchain Rust MSVC et durcissement des builds Windows.
+
+## Fichiers ajoutés/modifiés/supprimés
+- build.ps1
+- .github/workflows/build-windows.yml
+- .github/workflows/verify-local.yml
+- docs/QA.md
+- docs/STATUS.md
+- docs/reports/PR-020-WIN_report.md
+- docs/reports/PR-020-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm ci
+npm run build
+npx tauri build
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- Aucun.
+
+## Impact utilisateur
+- Build Windows plus fiable grâce à l'utilisation exclusive de la toolchain MSVC.
+


### PR DESCRIPTION
## Summary
- force Rust MSVC toolchain in build script and warn when MSYS/MinGW appears in PATH
- enforce MSVC toolchain setup in Windows CI workflows
- document Windows build tips and update project status

## Testing
- `npm ci`
- `npm run build`
- `npx tauri build` *(fails: cannot find function `init` in crate `tauri_plugin_sql`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3794a2c8832dbf4af3b1ea325ba6