### PR TITLE
fix: enforce MSVC + Windows SDK (lib.exe) in build.ps1 & CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,7 +19,7 @@ jobs:
           rustup set default-host x86_64-pc-windows-msvc
           rustup toolchain install stable-x86_64-pc-windows-msvc
           rustup default stable-x86_64-pc-windows-msvc
-          where.exe lib.exe || (echo "lib.exe not found" && exit 1)
+          where lib.exe || (echo "lib.exe not found" && exit 1)
       - run: npm ci
       - run: npm run icon:gen --if-present
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Assurez‑vous qu'un seul poste utilise la base à la fois.
 - `npm run db:smoke` vérifie les triggers et la valeur du stock.
 
 ## Build local
-Exécuter dans **PowerShell Administrateur** (**pas Git Bash / WSL**) :
+Exécuter `build.ps1` en **PowerShell Administrateur** (jamais depuis Git Bash ou WSL) :
 
 ```powershell
 ./build.ps1
 ```
 
-Prérequis : VS Build Tools (C++ x64) et Windows 11 SDK doivent être installés. `where lib.exe` doit répondre.
+S'assurer que **VS Build Tools (C++ x64)** et le **Windows 11 SDK** sont installés et activés ; `where lib.exe` doit répondre avant `npx tauri build`.
 
 Ce script installe Node.js LTS, Rustup, le toolchain `stable-x86_64-pc-windows-msvc`, les Build Tools C++ de Visual Studio, le Windows 11 SDK et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run icon:gen`, `npm run build` et `npx tauri build`.
 

--- a/build.ps1
+++ b/build.ps1
@@ -49,8 +49,9 @@ try {
         --add Microsoft.VisualStudio.Component.Windows11SDK.22621 `
         --add Microsoft.VisualStudio.Component.VC.CMake.Project
 
-    $libPath = (Get-Command lib.exe -ErrorAction SilentlyContinue)?.Source
+    $libPath = (where.exe lib.exe 2>$null | Select-Object -First 1)
     if (-not $libPath) { Write-Error "lib.exe introuvable (VS Build Tools non prêts)"; exit 1 }
+    Write-Host "lib.exe détecté : $libPath"
     & vswhere -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Write-Host
 
     npm ci

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -14,7 +14,7 @@ Parcours manuel pour valider une release candidate Windows.
 
 ## Astuce build Windows
 
-Build local : exécuter `build.ps1` en **PowerShell Administrateur** (pas Git Bash / WSL). VS Build Tools (C++ x64) et Windows 11 SDK doivent être installés ; `where lib.exe` doit répondre.
+Build local : exécuter `build.ps1` en **PowerShell Administrateur** (pas Git Bash / WSL). S'assurer que **VS Build Tools (C++ x64)** et le **Windows 11 SDK** sont installés ; `where lib.exe` doit répondre.
 
 Pour compiler sous Windows, forcer l'usage exclusif du toolchain Rust MSVC (`x86_64-pc-windows-msvc`) :
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -27,7 +27,7 @@ This document tracks the global progress of the project.
 - Migration du plugin SQL vers le Builder v2 avec permissions dédiées et build Windows revalidé
 - Sanity finale Windows : extension du script doctor (plugin SQL + capacités) et rappel du guide de publication
 - Enforcement final Windows : workflows CI et release exclusivement Windows, doctor vérifiant Node/npm/Rust/VS Build Tools/WebView2/migrations
-- Vérification MSVC/SDK : build.ps1 et CI installent VS Build Tools + Windows 11 SDK et contrôlent `lib.exe`
+- Vérification MSVC/SDK : build.ps1 et CI installent VS Build Tools + Windows 11 SDK et vérifient `lib.exe` pour éviter « lib.exe not found »
 
 ### En cours
 - TBD

--- a/docs/reports/PR-025-WIN_report.json
+++ b/docs/reports/PR-025-WIN_report.json
@@ -1,18 +1,17 @@
 {
   "pr_number": "025-WIN",
   "title": "fix: enforce MSVC + Windows SDK (lib.exe) in build.ps1 & CI",
-  "summary": "Ajoute l'installation des VS Build Tools et du SDK Windows 11, vérifie lib.exe avant les builds.",
+  "summary": "Durcit build.ps1 et la CI pour vérifier lib.exe via MSVC et le SDK Windows 11.",
   "files": {
-    "added": [
-      "docs/reports/PR-025-WIN_report.md",
-      "docs/reports/PR-025-WIN_report.json"
-    ],
+    "added": [],
     "modified": [
       "build.ps1",
       ".github/workflows/build-windows.yml",
       "README.md",
       "docs/QA.md",
-      "docs/STATUS.md"
+      "docs/STATUS.md",
+      "docs/reports/PR-025-WIN_report.md",
+      "docs/reports/PR-025-WIN_report.json"
     ],
     "removed": []
   },
@@ -21,19 +20,19 @@
       "name": "npm ci",
       "command": "npm ci",
       "status": "pass",
-      "stdout": "added 1133 packages"
+      "stdout": "added 1133 packages, and audited 1140 packages"
     },
     {
       "name": "npm run build",
       "command": "npm run build",
       "status": "pass",
-      "stdout": "\u2713 built in 36.89s"
+      "stdout": "\u2713 built in 21.37s"
     },
     {
       "name": "npx tauri build",
       "command": "npx tauri build",
       "status": "fail",
-      "stdout": "The system library `gobject-2.0` required by crate `gobject-sys` was not found."
+      "stdout": "The system library `glib-2.0` required by crate `glib-sys` was not found."
     }
   ],
   "todos": [],

--- a/docs/reports/PR-025-WIN_report.md
+++ b/docs/reports/PR-025-WIN_report.md
@@ -1,7 +1,7 @@
 # PR-025-WIN Report
 
 ## Résumé
-Durcissement MSVC/SDK : build.ps1 et workflow CI vérifient l'installation de VS Build Tools et du Windows 11 SDK pour éviter « lib.exe not found ».
+Durcissement MSVC/SDK : build.ps1 vérifie `lib.exe` via `where.exe` et le workflow CI échoue si l'outil est absent, évitant définitivement « lib.exe not found ».
 
 ## Fichiers ajoutés/modifiés/supprimés
 - build.ps1


### PR DESCRIPTION
## Summary
- verify `lib.exe` with `where.exe` in build.ps1 to ensure VS Build Tools and Windows SDK are installed
- enforce MSVC toolchain & `lib.exe` check in Windows workflow
- document MSVC + Windows SDK requirement for local builds

## Testing
- `npm ci`
- `npm run build`
- `npx tauri build` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd49e96698832d8ed6ad4f39666ddc