### PR TITLE
chore: enforce Windows-only execution everywhere (no Linux/WSL fallback)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,14 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
     steps:
+      - name: Assert Windows
+        run: |
+          $isWin = $env:OS -eq "Windows_NT"
+          if (-not $isWin) { Write-Error "Not Windows"; exit 1 }
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/verify-local.yml
+++ b/.github/workflows/verify-local.yml
@@ -6,7 +6,14 @@ on:
 jobs:
   verify:
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
     steps:
+      - name: Assert Windows
+        run: |
+          $isWin = $env:OS -eq "Windows_NT"
+          if (-not $isWin) { Write-Error "Not Windows"; exit 1 }
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Système supporté : Windows 11 (x64) uniquement**
 
+**Exécuter build et dev dans PowerShell Windows (Administrateur), pas WSL/Git Bash.**
+
 Cette variante, basée sur **Tauri v2**, embarque une base SQLite locale pour fonctionner hors ligne.
 
 ## Installation

--- a/build.ps1
+++ b/build.ps1
@@ -8,6 +8,11 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 
 $ErrorActionPreference = 'Stop'
 
+if ($env:WSL_DISTRO_NAME -or $env:MSYSTEM -or $env:TERM -match "xterm") {
+    Write-Error "Build Windows: exécuter dans PowerShell Windows, pas WSL/Git Bash"
+    exit 1
+}
+
 # Log everything
 $logPath = Join-Path $PSScriptRoot 'build.log'
 Start-Transcript -Path $logPath -Append | Out-Null

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,5 +1,7 @@
 # QA
 
+Exécuter build et dev dans **PowerShell Windows** (Administrateur), pas WSL/Git Bash.
+
 Parcours manuel pour valider une release candidate Windows.
 
 1. Lancer l'application puis se connecter avec l'administrateur créé via `npm run seed:admin`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,6 +28,7 @@ This document tracks the global progress of the project.
 - Sanity finale Windows : extension du script doctor (plugin SQL + capacités) et rappel du guide de publication
 - Enforcement final Windows : workflows CI et release exclusivement Windows, doctor vérifiant Node/npm/Rust/VS Build Tools/WebView2/migrations
 - Vérification MSVC/SDK : build.ps1 et CI installent VS Build Tools + Windows 11 SDK et vérifient `lib.exe` pour éviter « lib.exe not found »
+- Exécution forcée Windows : workflows assertent Windows, build.ps1 bloque WSL/Git Bash et la doc impose PowerShell
 
 ### En cours
 - TBD

--- a/docs/reports/PR-026-WIN_report.json
+++ b/docs/reports/PR-026-WIN_report.json
@@ -1,0 +1,41 @@
+{
+  "pr_number": "026-WIN",
+  "title": "chore: enforce Windows-only execution everywhere (no Linux/WSL fallback)",
+  "summary": "Blocage Linux/WSL en imposant PowerShell Windows pour build et CI.",
+  "files": {
+    "added": [],
+    "modified": [
+      "build.ps1",
+      ".github/workflows/verify-local.yml",
+      ".github/workflows/build-windows.yml",
+      "README.md",
+      "docs/QA.md",
+      "docs/STATUS.md",
+      "docs/reports/PR-026-WIN_report.md",
+      "docs/reports/PR-026-WIN_report.json"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "npm test",
+      "command": "npm test",
+      "status": "pass",
+      "stdout": "Test Files 4 passed (4)"
+    },
+    {
+      "name": "npm run build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "\u2713 built in 14.90s"
+    },
+    {
+      "name": "npx tauri build",
+      "command": "npx tauri build",
+      "status": "fail",
+      "stdout": "The system library `gobject-2.0` required by crate `gobject-sys` was not found."
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-026-WIN_report.md
+++ b/docs/reports/PR-026-WIN_report.md
@@ -1,0 +1,30 @@
+# PR-026-WIN Report
+
+## Résumé
+Blocage Linux/WSL : workflows et build.ps1 imposent l'exécution en PowerShell Windows uniquement, documentation ajustée.
+
+## Fichiers ajoutés/modifiés/supprimés
+- build.ps1
+- .github/workflows/verify-local.yml
+- .github/workflows/build-windows.yml
+- README.md
+- docs/QA.md
+- docs/STATUS.md
+- docs/reports/PR-026-WIN_report.md
+- docs/reports/PR-026-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm test
+npm run build
+npx tauri build
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- Aucun.
+
+## Impact utilisateur
+- Empêche toute exécution hors Windows et clarifie l'usage exclusif de PowerShell.


### PR DESCRIPTION
## Summary
- assert Windows runners in verify and release workflows
- block WSL/Git Bash usage in build.ps1
- document PowerShell-only build and dev and update status/report

## Testing
- `npm test`
- `npm run build`
- `npx tauri build` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found.)*


------
https://chatgpt.com/codex/tasks/task_e_68bd4c108c38832da8090e0879e0ce04