### PR TITLE
fix: MSI icon sans binaires (SVG source + génération au build)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,7 +42,8 @@ jobs:
           cargo -Vv
           where lib.exe
       - run: npm ci
-      - run: npm run icon:gen --if-present
+      - name: Generate icons
+        run: npm run icon:gen
       - name: Build (Web)
         run: npm run build
       - name: Tauri Build (verbose)

--- a/.github/workflows/verify-local.yml
+++ b/.github/workflows/verify-local.yml
@@ -35,6 +35,8 @@ jobs:
           cargo -Vv
           where lib.exe
       - run: npm ci
+      - name: Generate icons
+        run: npm run icon:gen
       - run: npm run build
       - run: npm run db:smoke
       - run: npm run check:tauri --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ backup_*.json
 invoices_*.xlsx
 
 # Tauri generated icons (not tracked)
-src-tauri/icons/
+/src-tauri/icons/
+/src-tauri/target/

--- a/README-offline.md
+++ b/README-offline.md
@@ -42,6 +42,14 @@ Assurez‑vous qu'un seul poste utilise la base à la fois.
 - `npm run db:apply` applique les migrations SQLite.
 - `npm run db:smoke` vérifie les triggers et la valeur du stock.
 
+## Icônes
+Les icônes binaires (`.ico`/`.png`) ne sont pas versionnées. Elles sont générées depuis `assets/logo.svg` lors du build :
+
+- localement via `npm run tauri:build` ;
+- dans la CI via l'étape **Generate icons**.
+
+Le paquet MSI est disponible dans `src-tauri/target/release/bundle/msi/*.msi`.
+
 ## Build local
 Exécuter dans **PowerShell** :
 
@@ -49,7 +57,7 @@ Exécuter dans **PowerShell** :
 ./build.ps1
 ```
 
-Ce script installe Node.js LTS, Rustup, les Build Tools C++ de Visual Studio et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run icon:gen`, `npm run build` et `npx tauri build`.
+Ce script installe Node.js LTS, Rustup, les Build Tools C++ de Visual Studio et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run build` et `npx tauri build` (qui génère `src-tauri/icons` si nécessaire).
 
 ## Release
 - Créez et poussez un tag `v1.0.0` (exemple).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Assurez‑vous qu'un seul poste utilise la base à la fois.
 - `npm run db:apply` applique les migrations SQLite.
 - `npm run db:smoke` vérifie les triggers et la valeur du stock.
 
+## Icônes
+Les icônes binaires (`.ico`/`.png`) ne sont pas versionnées. Elles sont générées à partir de `assets/logo.svg` lors du build :
+
+- en local avec `npm run tauri:build` ;
+- en CI via l'étape **Generate icons**.
+
+L'installateur MSI résultant se trouve dans `src-tauri/target/release/bundle/msi/*.msi`.
+
 ## Build local
 Exécuter `build.ps1` en **PowerShell Administrateur** (jamais depuis Git Bash ou WSL) :
 
@@ -67,7 +75,7 @@ Exécuter `build.ps1` en **PowerShell Administrateur** (jamais depuis Git Bash o
 
 S'assurer que **VS Build Tools (C++ x64)** et le **Windows 11 SDK** sont installés et activés ; `where lib.exe` doit répondre avant `npx tauri build`.
 
-Ce script installe Node.js LTS, Rustup, le toolchain `stable-x86_64-pc-windows-msvc`, les Build Tools C++ de Visual Studio, le Windows 11 SDK et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run icon:gen`, `npm run build` et `npx tauri build`.
+Ce script installe Node.js LTS, Rustup, le toolchain `stable-x86_64-pc-windows-msvc`, les Build Tools C++ de Visual Studio, le Windows 11 SDK et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run build` et `npx tauri build` (qui génère `src-tauri/icons` si nécessaire).
 
 ## QA final
 Avant de publier, vérifier ce parcours :

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,7 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <title>MamaStock Local logo</title>
-  <rect x="96" y="64" width="320" height="384" rx="40" ry="40" fill="none" stroke="#0d9488" stroke-width="24"/>
-  <rect x="96" y="256" width="320" height="192" rx="40" ry="40" fill="#0d9488"/>
-  <text x="256" y="200" font-size="72" font-family="Arial, Helvetica, sans-serif" text-anchor="middle" fill="#0d9488">MamaStock</text>
-  <text x="256" y="280" font-size="60" font-family="Arial, Helvetica, sans-serif" text-anchor="middle" fill="#0d9488">Local</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#0ea5e9"/>
+  <text x="50%" y="54%" text-anchor="middle"
+        font-family="Segoe UI, Arial, sans-serif"
+        font-size="240" fill="white" font-weight="700">M</text>
 </svg>

--- a/build.ps1
+++ b/build.ps1
@@ -72,13 +72,10 @@ try {
 
     npm ci
 
-    if (Select-String '"icon:gen"' -Path package.json -Quiet) {
-        npm run icon:gen
-    }
-
     npm run build
     where.exe lib.exe
     if ($LASTEXITCODE -ne 0) { Write-Error "lib.exe introuvable"; exit 1 }
+    if (-not (Test-Path "src-tauri\\icons\\icon.ico")) { npm run icon:gen }
     npx tauri build
 
     $bundlePath = Join-Path $PSScriptRoot 'src-tauri\\target\\release\\bundle'

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -34,6 +34,7 @@ This document tracks the global progress of the project.
 - Stabilisation du build Windows : caches npm/cargo, timeout allongé et logs détaillés (CI + transcript PowerShell)
 - Script postinstall-check : valeurs par défaut pour les chemins et vérifications non bloquantes de `config.json` et `mamastock.db`
 - Hard-forcing MSVC target et purge des variables Linux/MinGW (build.ps1 + CI)
+- Icône MSI sans binaires : logo SVG unique et génération d'icônes au build (local `npm run tauri:build`, CI étape "Generate icons")
 
 ### En cours
 - TBD

--- a/docs/reports/PR-033-WIN_report.json
+++ b/docs/reports/PR-033-WIN_report.json
@@ -1,0 +1,58 @@
+{
+  "pr_number": "033-WIN",
+  "title": "fix: MSI icon sans binaires (SVG source + génération au build)",
+  "summary": "Commit un logo SVG texte et génère les icônes au build sans inclure de binaires.",
+  "files": {
+    "added": [
+      "docs/reports/PR-033-WIN_report.md",
+      "docs/reports/PR-033-WIN_report.json"
+    ],
+    "modified": [
+      "assets/logo.svg",
+      ".gitignore",
+      "package.json",
+      "src-tauri/tauri.conf.json",
+      "build.ps1",
+      ".github/workflows/build-windows.yml",
+      ".github/workflows/verify-local.yml",
+      "README.md",
+      "README-offline.md",
+      "docs/STATUS.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "npm ci",
+      "command": "npm ci",
+      "status": "pass",
+      "stdout": "added 1134 packages, and audited 1141 packages in 13s"
+    },
+    {
+      "name": "web build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "✓ built in 18.35s"
+    },
+    {
+      "name": "generate icons",
+      "command": "npm run icon:gen",
+      "status": "pass",
+      "stdout": "ICO Creating icon.ico"
+    },
+    {
+      "name": "tauri version",
+      "command": "npx tauri --version",
+      "status": "pass",
+      "stdout": "tauri-cli 2.8.4"
+    },
+    {
+      "name": "tauri build",
+      "command": "npx tauri build",
+      "status": "warn",
+      "stdout": "Built application at: /workspace/MAMASTOCK-LOCAL/src-tauri/target/release/mamastock"
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-033-WIN_report.md
+++ b/docs/reports/PR-033-WIN_report.md
@@ -1,0 +1,36 @@
+# PR-033-WIN Report
+
+## Résumé
+Remplace le logo par un SVG texte et génère les icônes Tauri au build sans committer les binaires.
+
+## Fichiers ajoutés/modifiés/supprimés
+- assets/logo.svg
+- .gitignore
+- package.json
+- src-tauri/tauri.conf.json
+- build.ps1
+- .github/workflows/build-windows.yml
+- .github/workflows/verify-local.yml
+- README.md
+- README-offline.md
+- docs/STATUS.md
+- docs/reports/PR-033-WIN_report.md
+- docs/reports/PR-033-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm ci
+npm run build
+npm run icon:gen
+npx tauri --version
+npx tauri build
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+## Points encore ouverts
+- L'environnement Linux ne produit pas l'installateur MSI.
+
+## Impact utilisateur
+- Un seul logo SVG est versionné et toutes les icônes MSI sont générées automatiquement au build ou dans la CI.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "seed:admin": "node scripts/seed-admin.js",
     "icon:gen": "tauri icon assets/logo.svg -o src-tauri/icons",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
+    "tauri:build": "npm run icon:gen && tauri build",
     "doctor": "pwsh scripts/doctor.ps1",
     "front:audit": "node scripts/front-audit.js",
     "check:tauri": "node scripts/check-tauri-imports.js"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,13 @@
   "bundle": {
     "active": true,
     "targets": ["msi"],
+    "icon": [
+      "icons/icon.ico",
+      "icons/32x32.png",
+      "icons/64x64.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png"
+    ],
     "windows": { "webviewInstallMode": { "type": "embedBootstrapper" } }
   }
 }


### PR DESCRIPTION
## Summary
- replace old logo with minimal SVG source
- generate all Tauri icons at build time and on CI
- document icon generation and installer location

## Testing
- `npm ci`
- `npm run build`
- `npm run icon:gen`
- `npx tauri --version`
- `npx tauri build` *(fails to create MSI in Linux environment)*


------
https://chatgpt.com/codex/tasks/task_e_68bd75b2cd68832d8ef1e429af09685e