### PR TITLE
chore(debug): activer DevTools + handlers d’erreurs globales (temporaire)

### DIFF
--- a/docs/reports/PR-034-WIN_report.json
+++ b/docs/reports/PR-034-WIN_report.json
@@ -1,0 +1,38 @@
+{
+  "pr_number": "034-WIN",
+  "title": "chore(debug): activer DevTools + handlers d’erreurs globales (temporaire)",
+  "summary": "Active DevTools par défaut et journalise les erreurs globales pour faciliter le debug.",
+  "files": {
+    "added": [
+      "docs/reports/PR-034-WIN_report.md",
+      "docs/reports/PR-034-WIN_report.json"
+    ],
+    "modified": [
+      "src-tauri/tauri.conf.json",
+      "src/main.jsx"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "web build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "\u2713 built in 22.44s"
+    },
+    {
+      "name": "tauri build",
+      "command": "npx tauri build",
+      "status": "warn",
+      "stdout": "The system library `glib-2.0` required by crate `glib-sys` was not found."
+    },
+    {
+      "name": "run app",
+      "command": "./src-tauri/target/release/mamastock",
+      "status": "warn",
+      "stdout": "No such file or directory"
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-034-WIN_report.md
+++ b/docs/reports/PR-034-WIN_report.md
@@ -1,0 +1,28 @@
+# PR-034-WIN Report
+
+## Résumé
+Active temporairement les DevTools et journalise les erreurs globales pour faciliter le debug des écrans bleus.
+
+## Fichiers ajoutés/modifiés/supprimés
+- src-tauri/tauri.conf.json
+- src/main.jsx
+- docs/reports/PR-034-WIN_report.md
+- docs/reports/PR-034-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm run build
+npx tauri build
+./src-tauri/target/release/mamastock
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+DevTools : `Ctrl+Shift+I` → onglet **Console**.
+
+## Points encore ouverts
+- Retirer ce mode de debug une fois l'enquête terminée.
+
+## Impact utilisateur
+- Permet d'inspecter les erreurs JavaScript derrière l'écran bleu via les DevTools.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
         "width": 1200,
         "height": 800,
         "resizable": true,
-        "center": true
+        "center": true,
+        "devtools": true
       }
     ],
     "security": { "csp": null }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,12 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+// === Debug global errors (temp) ===
+window.addEventListener('error', (e) => {
+  console.error('[GlobalError]', e?.error || e?.message || e);
+});
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('[UnhandledRejection]', e?.reason || e);
+});
+// === /Debug ===
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";


### PR DESCRIPTION
## Summary
- force l'ouverture des DevTools dans la fenêtre principale
- log toutes les erreurs et promesses rejetées globalement
- ajouter le rapport PR-034-WIN

## Testing
- `npm run build`
- `npx tauri build` *(échoue: glib-2.0 manquant)*
- `./src-tauri/target/release/mamastock` *(échoue: binaire absent après échec de build)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82e599a4832dabf22b834296b9a2