### PR TITLE
fix(debug): ErrorBoundary visible + journalisation des erreurs dans un fichier local

### DIFF
--- a/README-offline.md
+++ b/README-offline.md
@@ -33,6 +33,11 @@ Assurez‑vous qu'un seul poste utilise la base à la fois.
 - Nettoyez les exports périmés dans `Documents/MamaStock/Exports`.
 - Conservez une sauvegarde avant toute mise à jour de l'application.
 
+## Diagnostiquer un écran bleu
+- Appuyez sur **F12** ou utilisez le menu/debug pour ouvrir les DevTools.
+- Les erreurs sont aussi enregistrées dans `%APPDATA%\\com.mamastock.local\\logs\\renderer.log`.
+- Ce fichier peut être ouvert via le bouton « Voir le fichier de logs » du ruban debug.
+
 ## Exports locaux
 - Par défaut, les fichiers d'export (CSV, Excel, PDF) sont enregistrés dans `Documents/MamaStock/Exports`.
 - Ce dossier peut être modifié depuis la page **Paramètres** en renseignant le « Dossier des exports ».

--- a/docs/reports/PR-040-WIN_report.json
+++ b/docs/reports/PR-040-WIN_report.json
@@ -1,0 +1,36 @@
+{
+  "pr_number": "040-WIN",
+  "title": "fix(debug): ErrorBoundary visible + journalisation des erreurs dans un fichier local",
+  "summary": "Affiche un panneau d'erreur et sauvegarde les logs dans %APPDATA%\\com.mamastock.local\\logs\\renderer.log.",
+  "files": {
+    "added": [
+      "src/debug/logger.ts",
+      "src/debug/ErrorBoundary.jsx",
+      "src/components/DebugRibbon.jsx",
+      "docs/reports/PR-040-WIN_report.md",
+      "docs/reports/PR-040-WIN_report.json"
+    ],
+    "modified": [
+      "src/main.jsx",
+      "src/App.jsx",
+      "README-offline.md"
+    ],
+    "removed": []
+  },
+  "tests": [
+    {
+      "name": "unit tests",
+      "command": "npm test",
+      "status": "fail",
+      "stdout": "Failed to resolve import ... node_modules._OLD/..."
+    },
+    {
+      "name": "web build",
+      "command": "npm run build",
+      "status": "pass",
+      "stdout": "\u2713 built in 18.32s"
+    }
+  ],
+  "todos": [],
+  "risks": []
+}

--- a/docs/reports/PR-040-WIN_report.md
+++ b/docs/reports/PR-040-WIN_report.md
@@ -1,0 +1,31 @@
+# PR-040-WIN Report
+
+## Résumé
+Affiche un panneau d'erreur global et écrit les erreurs JS dans un fichier local.
+
+## Fichiers ajoutés/modifiés/supprimés
+- src/debug/logger.ts
+- src/debug/ErrorBoundary.jsx
+- src/components/DebugRibbon.jsx
+- src/main.jsx
+- src/App.jsx
+- README-offline.md
+- docs/reports/PR-040-WIN_report.md
+- docs/reports/PR-040-WIN_report.json
+
+## Scripts/commandes exécutables pour tester
+```bash
+npm test
+npm run build
+```
+
+## Résultats de tests
+*(voir rapport JSON)*
+
+Fichier de log : `%APPDATA%\\com.mamastock.local\\logs\\renderer.log`.
+
+## Points encore ouverts
+- Aucun.
+
+## Impact utilisateur
+- En cas de crash React, un message s'affiche et les erreurs sont loguées sur disque.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { MultiMamaProvider } from "@/context/MultiMamaContext";
 import { ThemeProvider } from "@/context/ThemeProvider";
 import CookieConsent from "@/components/CookieConsent";
 import ToastRoot from "@/components/ToastRoot";
+import DebugRibbon from "@/components/DebugRibbon";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -65,6 +66,7 @@ export default function App() {
         <MultiMamaProvider>
           <ThemeProvider>
             <ToastRoot />
+            <DebugRibbon />
             <Router />
             <CookieConsent />
           </ThemeProvider>

--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,0 +1,35 @@
+import { getCurrent } from "@tauri-apps/api/window";
+import { appDataDir, join } from "@tauri-apps/api/path";
+import { open } from "@tauri-apps/api/shell";
+
+export default function DebugRibbon() {
+  const show = import.meta.env.DEV || window.DEBUG;
+  if (!show) return null;
+
+  const openDev = () => {
+    try {
+      getCurrent().openDevtools();
+    } catch {}
+  };
+
+  const openLogs = async () => {
+    try {
+      const dir = await appDataDir();
+      const logDir = await join(dir, "logs");
+      await open(logDir);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="fixed top-0 right-0 m-2 flex gap-2 z-50 text-xs bg-black/50 text-white rounded p-1">
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openDev}>
+        Ouvrir DevTools
+      </button>
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openLogs}>
+        Voir le fichier de logs
+      </button>
+    </div>
+  );
+}

--- a/src/debug/ErrorBoundary.jsx
+++ b/src/debug/ErrorBoundary.jsx
@@ -1,0 +1,43 @@
+import { Component } from "react";
+import { getCurrent } from "@tauri-apps/api/window";
+import { appendLog } from "./logger";
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  async componentDidCatch(error, info) {
+    await appendLog(`[ErrorBoundary] ${error?.stack || error}`);
+    console.error(error, info);
+  }
+
+  openDevTools() {
+    try {
+      getCurrent().openDevtools();
+    } catch {}
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center gap-4 p-4 text-center">
+          <h1 className="text-lg font-bold">Une erreur est survenue</h1>
+          <p>Ouvrez les DevTools pour plus de détails.</p>
+          <button
+            className="px-3 py-1 border rounded"
+            onClick={() => this.openDevTools()}
+          >
+            Ouvrir DevTools
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/debug/logger.ts
+++ b/src/debug/logger.ts
@@ -1,0 +1,17 @@
+import { appDataDir, join } from "@tauri-apps/api/path";
+import { exists, mkdir, writeFile } from "@tauri-apps/plugin-fs";
+
+export async function appendLog(line: string) {
+  try {
+    const dir = await appDataDir();
+    const logDir = await join(dir, "logs");
+    if (!(await exists(logDir))) {
+      await mkdir(logDir, { recursive: true });
+    }
+    const file = await join(logDir, "renderer.log");
+    const msg = new TextEncoder().encode(line + "\n");
+    await writeFile(file, msg, { append: true });
+  } catch (e) {
+    console.error("appendLog failed", e);
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,15 +1,19 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-// === Debug global errors (temp) ===
+// === Debug global errors ===
+import { appendLog } from "@/debug/logger";
 window.addEventListener('error', (e) => {
+  appendLog('[GlobalError] ' + (e?.error?.stack || e?.message));
   console.error('[GlobalError]', e?.error || e?.message || e);
 });
 window.addEventListener('unhandledrejection', (e) => {
+  appendLog('[UnhandledRejection] ' + (e?.reason?.stack || e?.reason));
   console.error('[UnhandledRejection]', e?.reason || e);
 });
 // === /Debug ===
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import ErrorBoundary from "@/debug/ErrorBoundary";
 import "./globals.css";
 import 'nprogress/nprogress.css';
 import "@/i18n/i18n";
@@ -68,7 +72,9 @@ root.render(
   <StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </AuthProvider>
     </BrowserRouter>
   </StrictMode>


### PR DESCRIPTION
## Summary
- log renderer errors to `%APPDATA%/com.mamastock.local/logs/renderer.log`
- display a fallback panel with devtools button when React crashes
- add a debug ribbon with shortcuts to DevTools and log folder

## Testing
- `npm test` *(fails: Failed to resolve import ...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda2b27bb4832dbe32330742f85fea