### PR TITLE
fix(tauri): remove open_devtools, use set_focus in v2 + startup log

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,13 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
         .menu(|app| {
-            let open = MenuItem::with_id(app, "open_devtools", "Ouvrir DevTools (F12)", true, None::<&str>)?;
+            let open = MenuItem::with_id(
+                app,
+                "open_devtools",
+                "Ouvrir DevTools (F12)",
+                true,
+                None::<&str>,
+            )?;
             let help = Submenu::new(app, "Aide", true)?;
             help.append_items(&[&open])?;
             Menu::with_items(app, &[&help])
@@ -21,10 +27,23 @@ fn main() {
         .on_menu_event(|app, event| {
             if event.id().as_ref() == "open_devtools" {
                 if let Some(w) = app.get_webview_window("main") {
-                    w.open_devtools();
-                    let _ = w.focus();
+                    let _ = w.set_focus();
                 }
             }
+        })
+        .setup(|app| {
+            if let Some(w) = app.get_webview_window("main") {
+                #[cfg(debug_assertions)]
+                {
+                    let _ = w.set_focus();
+                    tauri::async_runtime::spawn(async {
+                        tauri::async_runtime::sleep(std::time::Duration::from_millis(150)).await;
+                        let _ = w.emit("app:ready", "tauri-main-ready");
+                    });
+                    println!("[mamastock] main window ready (debug)");
+                }
+            }
+            Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- replace removed `open_devtools` call and use `set_focus`
- focus main window on startup and emit `app:ready` event in debug builds
- add debug startup log for easier troubleshooting

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm run build`
- `npx tauri build` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda711ebc0832d9c646e7d12649e17