### PR TITLE
Enable disk logging and update Tauri config

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,6 +625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1184,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
+ "colored",
  "log",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,13 +7,13 @@ authors = ["MamaStock"]
 license = "MIT"
 
 [dependencies]
-tauri = { version = "2", features = ["wry"] }
+tauri = { version = "2", features = ["wry", "tray-icon", "protocol-asset"] }
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 log = "0.4"
-tauri-plugin-log = "2"
+tauri-plugin-log = { version = "2", features = ["colored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,19 +5,20 @@ use tauri::{
     Manager,
 };
 use log::{info, warn};
-use tauri_plugin_log::{Target, Builder as LogBuilder};
+use tauri_plugin_log::{Builder as LogBuilder, Target, TargetKind};
 
 // Entrypoint for the Tauri v2 application
 fn main() {
     tauri::Builder::default()
         .plugin(
-            LogBuilder::default()
+            LogBuilder::new()
+                // write to the OS log dir + also to stdout and the webview console
                 .targets([
-                    Target::LogDir,
-                    Target::Stdout,
-                    // Target::Webview,
+                    Target::new(TargetKind::LogDir { file_name: None }),
+                    Target::new(TargetKind::Stdout),
+                    Target::new(TargetKind::Webview),
                 ])
-                .level(log::LevelFilter::Info)
+                .level(log::LevelFilter::Info) // set to Debug for more verbosity
                 .build(),
         )
         .plugin(tauri_plugin_fs::init())
@@ -44,21 +45,32 @@ fn main() {
             }
         })
         .setup(|app| {
-            info!("Tauri app starting…");
-            if let Some(_main) = app.get_webview_window("main") {
+            if let Ok(dir) = app.path().app_log_dir() {
+                info!("Log directory: {}", dir.display());
+            } else {
+                info!("No app_log_dir available (using defaults)");
+            }
+
+            if let Some(main) = app.get_webview_window("main") {
+                let _ = main.set_focus();
                 info!("Main webview acquired");
                 #[cfg(debug_assertions)]
                 {
-                    let _ = _main.set_focus();
-                    tauri::async_runtime::spawn(async {
+                    let main_cloned = main.clone();
+                    tauri::async_runtime::spawn(async move {
                         tauri::async_runtime::sleep(std::time::Duration::from_millis(150)).await;
-                        let _ = _main.emit("app:ready", "tauri-main-ready");
+                        let _ = main_cloned.emit("app:ready", "tauri-main-ready");
                     });
                     println!("[mamastock] main window ready (debug)");
                 }
             } else {
                 warn!("Main webview not found at setup.");
             }
+
+            info!(
+                "MamaStock Local started (v{})",
+                app.package_info().version
+            );
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
- configure Tauri dependencies for tray icons and colored logging
- add log plugin writing to log dir, stdout, and webview
- log resolved log directory and start banner on setup

## Testing
- `npm run build`
- `npx tauri build`


------
https://chatgpt.com/codex/tasks/task_e_68be79e83094832da02ee90ce59e9276