### PR TITLE
feat: add devtools menu and shortcut

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -20,7 +20,7 @@ attachConsole()
 // === Debug global errors ===
 import { appendLog } from "@/debug/logger";
 function installGlobalErrorOverlay() {
-  const style = document.createElement('style');
+  const style = document.createElement("style");
   style.textContent = `
     #__debug_overlay {
       position: fixed; inset: 0; background: rgba(0,0,0,0.7);
@@ -31,38 +31,41 @@ function installGlobalErrorOverlay() {
     #__debug_overlay .close { position:absolute; top:8px; right:12px; cursor:pointer; }
   `;
   document.head.appendChild(style);
-  const el = document.createElement('div');
-  el.id = '__debug_overlay';
+  const el = document.createElement("div");
+  el.id = "__debug_overlay";
   el.innerHTML = `<div class="close">✕</div><h3>Runtime error</h3><pre id="__debug_overlay_log"></pre>`;
   document.body.appendChild(el);
-  el.querySelector('.close')?.addEventListener('click', () => (el.style.display = 'none'));
+  el.querySelector(".close")?.addEventListener(
+    "click",
+    () => (el.style.display = "none"),
+  );
 
   function show(type, err) {
-    const pre = document.getElementById('__debug_overlay_log');
+    const pre = document.getElementById("__debug_overlay_log");
     const msg =
       (err && (err.stack || err.message || String(err))) ?? String(err);
     if (pre) {
       pre.textContent = msg;
-      el.style.display = 'block';
+      el.style.display = "block";
     }
     appendLog(`[${type}] ${msg}`);
-    console.error('[Overlay]', err);
+    console.error("[Overlay]", err);
   }
 
-  window.addEventListener('error', (e) =>
-    show('GlobalError', e.error || e.message || e)
+  window.addEventListener("error", (e) =>
+    show("GlobalError", e.error || e.message || e),
   );
-  window.addEventListener('unhandledrejection', (e) =>
-    show('UnhandledRejection', e.reason || e)
+  window.addEventListener("unhandledrejection", (e) =>
+    show("UnhandledRejection", e.reason || e),
   );
   // Raccourci: F10 pour toggle
-  window.addEventListener('keydown', (e) => {
-    if (e.key === 'F10') {
-      const visible = el.style.display !== 'none';
-      el.style.display = visible ? 'none' : 'block';
+  window.addEventListener("keydown", (e) => {
+    if (e.key === "F10") {
+      const visible = el.style.display !== "none";
+      el.style.display = visible ? "none" : "block";
     }
   });
-  console.log('[debug] overlay installed');
+  console.log("[debug] overlay installed");
 }
 
 installGlobalErrorOverlay();
@@ -72,22 +75,23 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import ErrorBoundary from "@/debug/ErrorBoundary";
 import "./globals.css";
-import 'nprogress/nprogress.css';
+import "nprogress/nprogress.css";
 import "@/i18n/i18n";
 import "./registerSW.js";
 import { HashRouter } from "react-router-dom";
 import AuthProvider from "@/contexts/AuthContext";
-import { toast } from 'sonner';
-import { ensureSingleOwner, monitorShutdownRequests, releaseLock } from "@/lib/lock";
+import { toast } from "sonner";
+import {
+  ensureSingleOwner,
+  monitorShutdownRequests,
+  releaseLock,
+} from "@/lib/lock";
 import { shutdownDbSafely } from "@/lib/shutdown";
 import { getDataDir } from "@/lib/db";
-import { getCurrent } from "@tauri-apps/api/window";
 
 window.addEventListener("keydown", (e) => {
   if (e.key === "F12") {
-    try {
-      getCurrent().openDevtools?.();
-    } catch {}
+    document.dispatchEvent(new CustomEvent("open-devtools"));
   }
 });
 
@@ -96,14 +100,12 @@ if (!import.meta.env.DEV) {
   console.debug = () => {};
 }
 
-if (import.meta?.env?.DEV && 'serviceWorker' in navigator) {
+if (import.meta?.env?.DEV && "serviceWorker" in navigator) {
   navigator.serviceWorker
     .getRegistrations()
     .then((regs) => regs.forEach((r) => r.unregister()));
   if (window.caches?.keys) {
-    caches
-      .keys()
-      .then((keys) => keys.forEach((k) => caches.delete(k)));
+    caches.keys().then((keys) => keys.forEach((k) => caches.delete(k)));
   }
 }
 
@@ -134,5 +136,5 @@ root.render(
         </ErrorBoundary>
       </AuthProvider>
     </HashRouter>
-  </StrictMode>
+  </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add Tauri menu to open devtools and listen to custom event
- send `open-devtools` event from frontend on F12 keypress

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `apt-get install -y libglib2.0-dev` *(fails: Package 'libglib2.0-dev' has no installation candidate)*
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68be8015f6b0832d9e1d5fd5010f4c6b