### PR TITLE
fix: refine Tauri devtools handling for Windows build

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["MamaStock"]
 license = "MIT"
 
 [dependencies]
-tauri = { version = "2", features = ["wry", "tray-icon", "devtools"] }
+tauri = { version = "2", features = ["wry", "tray-icon"] }
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
@@ -23,6 +23,7 @@ tauri-build = { version = "2", features = [] }
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+devtools = ["tauri/devtools"]
 
 [[bin]]
 name = "mamastock"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,56 +1,25 @@
-// src-tauri/src/main.rs
-
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::{
-  Manager,            // get_webview_window, set_menu, etc.
-  Listener,           // .listen(...)
-  menu::{MenuBuilder, SubmenuBuilder, MenuItemBuilder},
-};
+use tauri::{Listener, Manager};
 
 fn main() -> tauri::Result<()> {
-  tauri::Builder::default()
-    .setup(|app| {
-      // ----- Menu "Débogage" -----
-      let open_devtools = MenuItemBuilder::with_id("open-devtools", "Ouvrir DevTools")
-        .accelerator("F12")
-        .build(app)?; // <= passer app ici
-
-      let debug_submenu = SubmenuBuilder::new(app, "Débogage")
-        .item(&open_devtools)     // <= .item (pas .add_item)
-        .build(app)?;             // <= passer app ici
-
-      let app_menu = MenuBuilder::new(app)
-        .submenu(&debug_submenu)  // <= .submenu (pas .add_submenu)
-        .build(app)?;             // <= passer app ici
-
-      app.set_menu(app_menu)?;
-
-      // ----- Écoute des clics de menu -----
-      app.on_menu_event(|app, event| {
-        if event.id() == "open-devtools" {
-          if let Some(w) = app.get_webview_window("main") {
-            #[cfg(feature = "devtools")]
-            {
-              let _ = w.open_devtools();
-            }
-            let _ = w.set_focus();
-          }
-        }
-      });
-
-      // ----- Événement custom depuis le front (emit('open-devtools')) -----
-      app.listen("open-devtools", move |_payload| {
-        if let Some(w) = app.get_webview_window("main") {
-          #[cfg(feature = "devtools")]
-          {
-            let _ = w.open_devtools();
-          }
-          let _ = w.set_focus();
-        }
-      });
-
-      Ok(())
-    })
-    .run(tauri::generate_context!())
+    tauri::Builder::default()
+        // Plugin de logs (écrit côté disque via la config par défaut)
+        .plugin(tauri_plugin_log::Builder::default().build())
+        .setup(|app| {
+            // Écoute un évènement envoyé depuis le front: emit('open-devtools')
+            let handle = app.handle().clone();
+            app.listen("open-devtools", move |_payload| {
+                if let Some(w) = handle.get_webview_window("main") {
+                    // Ouvre DevTools uniquement si la feature 'devtools' est activée côté Rust
+                    #[cfg(feature = "devtools")]
+                    {
+                        let _ = w.open_devtools();
+                    }
+                    let _ = w.set_focus();
+                }
+            });
+            Ok(())
+        })
+        .run(tauri::generate_context!())
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,6 +10,14 @@ window.process = process;
 import { attachConsole, info as logInfo } from "@tauri-apps/plugin-log";
 import { emit } from "@tauri-apps/api/event";
 
+// Raccourci clavier F12 pour demander au backend d'ouvrir DevTools
+window.addEventListener("keydown", (e) => {
+  if (e.key === "F12") {
+    emit("open-devtools");
+    e.preventDefault();
+  }
+});
+
 attachConsole()
   .then(() => {
     logInfo("Frontend booted and console attached");
@@ -89,20 +97,6 @@ import {
 } from "@/lib/lock";
 import { shutdownDbSafely } from "@/lib/shutdown";
 import { getDataDir } from "@/lib/db";
-
-window.addEventListener("keydown", (e) => {
-  const isF12 = e.key === "F12";
-  const isCtrlF12 = e.key === "F12" && (e.ctrlKey || e.metaKey);
-  const isCtrlShiftI = (e.key?.toLowerCase?.() === "i") && e.ctrlKey && e.shiftKey;
-
-  if (isF12 || isCtrlF12 || isCtrlShiftI) {
-    emit("open-devtools").catch((err) =>
-      console.error("Failed to emit open-devtools:", err),
-    );
-    e.preventDefault();
-    e.stopPropagation();
-  }
-});
 
 // Avoid noisy output in production by disabling debug logs
 if (!import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- remove Tauri menu and add open-devtools listener
- gate devtools behind optional feature
- emit `open-devtools` from frontend on F12

## Testing
- `npm test` *(fails: Test Files 17 failed | 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be988a65ec832db91f1fc38135b4e4