### PR TITLE
feat: enable tauri log plugin

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -1,8 +1,15 @@
-﻿{
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main",
-  "description": "Permissions pour la fenêtre principale",
+  "description": "Permissions for main window",
+  "windows": ["main"],
   "permissions": [
-    "core:default",
+    "core:app:default",
+    "core:event:default",
+    "core:path:default",
+    "core:window:default",
+    "core:resources:default",
     "log:default"
   ]
 }
+

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,6 @@
-﻿#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-use tauri::{Manager, Listener};
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 use tauri::menu::{MenuBuilder, SubmenuBuilder, MenuItemBuilder};
-use tauri::{AppHandle, Wry};
+use tauri::{AppHandle, Manager, Wry};
 
 fn build_menu(app: &AppHandle<Wry>) -> tauri::Result<()> {
     let open_devtools = MenuItemBuilder::new("Ouvrir DevTools")
@@ -27,6 +26,7 @@ fn on_menu(app: &AppHandle<Wry>, ev: &tauri::menu::MenuEvent) {
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_log::Builder::default().build())
         .plugin(tauri_plugin_devtools::init())
         .plugin(tauri_plugin_shell::init())
         .setup(|app| {
@@ -40,5 +40,4 @@ fn main() {
         .run(tauri::generate_context!())
         .expect("erreur au lancement de Tauri");
 }
-
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,54 +1,49 @@
-﻿{
-    "$schema":  "https://schema.tauri.app/config/2",
-    "productName":  "MamaStock Local",
-    "identifier":  "com.mamastock.local",
-    "version":  "0.1.0",
-    "build":  {
-                  "devUrl":  "http://localhost:5173",
-                  "frontendDist":  "../dist"
-              },
-    "app":  {
-                "windows":  [
-                                {
-                                    "title":  "MamaStock Local",
-                                    "width":  1200,
-                                    "height":  800,
-                                    "resizable":  true,
-                                    "center":  true,
-                                    "devtools":  true
-                                }
-                            ],
-                "security":  {
-                                 "csp":  null,
-                                 "capabilities":  [
-                                                      "main"
-                                                  ]
-                             }
-            },
-    "bundle":  {
-                   "targets":  [
-                                   "msi"
-                               ],
-                   "icon":  [
-                                "icons/icon.ico",
-                                "icons/32x32.png",
-                                "icons/64x64.png",
-                                "icons/128x128.png",
-                                "icons/128x128@2x.png"
-                            ],
-                   "windows":  {
-                                   "wix":  {
-                                               "language":  "en-US"
-                                           }
-                               }
-               },
-    "plugins":  {
-                    "log":  {
-                                "targets":  [
-                                                "webview",
-                                                "console"
-                                            ],
-                                "level":  "debug"
-                            }
-                }
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "MamaStock Local",
+  "identifier": "com.mamastock.local",
+  "version": "0.1.0",
+  "build": {
+    "devUrl": "http://localhost:5173",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "security": {
+      "csp": null,
+      "capabilities": ["main"]
+    },
+    "windows": [
+      {
+        "label": "main",
+        "title": "MamaStock Local",
+        "width": 1200,
+        "height": 800,
+        "resizable": true,
+        "center": true,
+        "devtools": true
+      }
+    ]
+  },
+  "bundle": {
+    "targets": ["msi"],
+    "icon": [
+      "icons/icon.ico",
+      "icons/32x32.png",
+      "icons/64x64.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png"
+    ],
+    "windows": {
+      "wix": {
+        "language": "en-US"
+      }
+    }
+  },
+  "plugins": {
+    "log": {
+      "targets": ["webview", "console"],
+      "level": "debug"
+    }
+  }
 }
+

--- a/src/debug/logger.js
+++ b/src/debug/logger.js
@@ -1,19 +1,36 @@
-﻿/** Logger Tauri sûr (no-op si plugin absent) */
-export async function appendLog(msg, level = "info") {
-  let text = typeof msg === "string" ? msg : (() => { try { return JSON.stringify(msg); } catch { return String(msg); } })();
+export async function setupLogger() {
   try {
-    const mod = await import("@tauri-apps/plugin-log");
-    if (level === "error" && typeof mod.error === "function") return mod.error(text);
-    if (level === "warn"  && typeof mod.warn  === "function")  return mod.warn(text);
-    if (typeof mod.info === "function") return mod.info(text);
+    const log = await import('@tauri-apps/plugin-log');
+    // En dev: voir les logs dans la console
+    await log.attachConsole();
+    // Optionnel: activer un fichier de log natif
+    // await log.attachLogger();
+    log.info?.('Logger initialisé');
+  } catch (e) {
+    console.warn('[log] plugin non dispo – logging désactivé', e);
+  }
+}
+
+export async function appendLog(msg, level = 'info') {
+  const text =
+    typeof msg === 'string'
+      ? msg
+      : (() => {
+          try {
+            return JSON.stringify(msg);
+          } catch {
+            return String(msg);
+          }
+        })();
+  try {
+    const log = await import('@tauri-apps/plugin-log');
+    if (level === 'error' && typeof log.error === 'function') return log.error(text);
+    if (level === 'warn' && typeof log.warn === 'function') return log.warn(text);
+    if (typeof log.info === 'function') return log.info(text);
   } catch {
-    if (level === "error") return console.error(text);
-    if (level === "warn")  return console.warn(text);
+    if (level === 'error') return console.error(text);
+    if (level === 'warn') return console.warn(text);
     return console.log(text);
   }
 }
-export async function attachConsoleSafe() {
-  try { const { attachConsole } = await import("@tauri-apps/plugin-log"); if (attachConsole) await attachConsole(); } catch {}
-}
-attachConsoleSafe();
-export default { appendLog, attachConsoleSafe };
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 ﻿import { emit } from '@tauri-apps/api/event';
-
-import '@/debug/logger';
+import { setupLogger, appendLog } from './debug/logger';
 // MamaStock Â© 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // Polyfills Node â†’ navigateur
 import { Buffer } from "buffer";
@@ -10,7 +9,7 @@ window.Buffer = Buffer;
 // @ts-ignore
 window.process = process;
 
-import { attachConsole, info as logInfo } from "@tauri-apps/plugin-log";
+setupLogger();
 // Raccourci clavier F12 pour demander au backend d'ouvrir DevTools
 if (window.__TAURI__) {
   window.addEventListener('keydown', async (e) => {
@@ -22,16 +21,7 @@ if (window.__TAURI__) {
 
 
 
-attachConsole()
-  .then(() => {
-    logInfo("Frontend booted and console attached");
-  })
-  .catch((e) => {
-    console.error("Failed to attach console to tauri-plugin-log", e);
-  });
-
 // === Debug global errors ===
-import { appendLog } from "@/debug/logger";
 function installGlobalErrorOverlay() {
   const style = document.createElement("style");
   style.textContent = `


### PR DESCRIPTION
## Summary
- register `tauri-plugin-log` in the Rust builder
- add dynamic logger utility and use it from the main React entry
- declare log capability and main window ACL in Tauri config

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "@tauri-apps/plugin-shell")*
- `npx tauri build --bundles msi` *(fails: invalid value 'msi' for '--bundles')*

------
https://chatgpt.com/codex/tasks/task_e_68bed8c00bfc832d9d6b585b6eb2b8c0