### PR TITLE
refactor: guard tauri APIs and use AppData fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite --port 5173 --strictPort --host",
     "tauri:dev": "tauri dev",
+    "build": "vite build",
     "tauri:build": "tauri build --bundles msi"
   },
   "dependencies": {

--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,18 +1,25 @@
-﻿import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-shell";
+import { isTauri } from "@/tauriEnv";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;
   if (!show) return null;
 
   const openDev = () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       getCurrentWebviewWindow().openDevtools();
     } catch {}
   };
 
   const openLogs = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       const dir = await appDataDir();
       const logDir = await join(dir, "logs");
@@ -33,5 +40,3 @@ export default function DebugRibbon() {
     </div>
   );
 }
-
-

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, useEffect, useState, useMemo } from 'react';
 import bcrypt from 'bcryptjs';
 import users from '@/db/users.json';
+import { randomBytes } from '@/lib/random';
+
+bcrypt.setRandomFallback((len) => Array.from(randomBytes(len)));
 
 const AuthCtx = createContext(null);
 export const useAuth = () => useContext(AuthCtx);

--- a/src/debug/ErrorBoundary.jsx
+++ b/src/debug/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 ﻿import { Component } from "react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { appendLog } from "./logger";
+import { isTauri } from "@/tauriEnv";
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -18,6 +19,9 @@ export default class ErrorBoundary extends Component {
   }
 
   openDevTools() {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       getCurrentWebviewWindow().openDevtools();
     } catch {}

--- a/src/debug/logger.js
+++ b/src/debug/logger.js
@@ -2,7 +2,10 @@ import { isTauri } from '../tauriEnv'
 
 export async function setupLogging() {
   // Pas de plugins si pas dans Tauri
-  if (!isTauri()) return
+  if (!isTauri) {
+    console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.')
+    return
+  }
 
   // On évite le plugin log en dev pour supprimer les collisions d'init
   if (import.meta.env.MODE === 'development') {
@@ -14,8 +17,8 @@ export async function setupLogging() {
     const log = await import('@tauri-apps/plugin-log')
     // await log.attachConsole() // seulement si besoin
     await log.info('logging initialized (release)')
-  } catch (e) {
-    console.warn('[log] plugin log not available:', e)
+  } catch {
+    console.warn('plugin log not available in dev')
   }
 }
 
@@ -31,7 +34,7 @@ export async function appendLog(msg, level = 'info') {
       })()
 
   // Fallback console si pas de plugin ou en dev
-  if (!isTauri() || import.meta.env.MODE === 'development') {
+  if (!isTauri || import.meta.env.MODE === 'development') {
     if (level === 'error') return console.error(text)
     if (level === 'warn') return console.warn(text)
     return console.log(text)
@@ -42,7 +45,7 @@ export async function appendLog(msg, level = 'info') {
     if (level === 'error' && typeof log.error === 'function') return log.error(text)
     if (level === 'warn' && typeof log.warn === 'function') return log.warn(text)
     if (typeof log.info === 'function') return log.info(text)
-  } catch (e) {
-    console.warn('[log] plugin log not available:', e)
+  } catch {
+    console.warn('plugin log not available in dev')
   }
 }

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -8,6 +8,7 @@ import { shutdownDbSafely } from "@/lib/shutdown";
 import { releaseLock } from "@/lib/lock";
 import { getDataDir } from "@/lib/db";
 import { appWindow } from "@tauri-apps/api/window";
+import { isTauri } from "@/tauriEnv";
 
 export default function Navbar() {
   const { t } = useTranslation();
@@ -43,6 +44,9 @@ export default function Navbar() {
     }, []);
 
     const handleQuit = useCallback(async () => {
+      if (!isTauri) {
+        return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+      }
       const dir = await getDataDir();
       await shutdownDbSafely();
       await releaseLock(dir);

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,5 +1,5 @@
-﻿import { join } from "@tauri-apps/api/path";
-import { exists, readTextFile, writeTextFile, remove } from "@tauri-apps/plugin-fs";
+import { join } from "@tauri-apps/api/path";
+import { exists, readTextFile, writeTextFile, remove, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 const appWindow = getCurrentWebviewWindow();
 import { v4 as uuidv4 } from "uuid";
@@ -19,9 +19,9 @@ export async function ensureSingleOwner(syncDir: string, waitMs = 30_000) {
   const lockPath = await path(syncDir, "db.lock.json");
   const start = Date.now();
   let requested = false;
-  while (await exists(lockPath)) {
+  while (await exists(lockPath, { dir: BaseDirectory.AppData })) {
     try {
-      const { ts } = JSON.parse(await readTextFile(lockPath));
+      const { ts } = JSON.parse(await readTextFile(lockPath, { dir: BaseDirectory.AppData }));
       if (Date.now() - ts > TTL) {
         break; // stale lock
       }
@@ -37,26 +37,26 @@ export async function ensureSingleOwner(syncDir: string, waitMs = 30_000) {
     }
     await new Promise((r) => setTimeout(r, HEARTBEAT));
   }
-  await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }));
+  await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }), { dir: BaseDirectory.AppData });
   heartbeat = setInterval(async () => {
-    await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }));
+    await writeTextFile(lockPath, JSON.stringify({ ts: Date.now(), id: instanceId }), { dir: BaseDirectory.AppData });
   }, HEARTBEAT);
 }
 
 export async function monitorShutdownRequests(syncDir: string) {
   const shutdownPath = await path(syncDir, "shutdown.request.json");
   const check = async () => {
-    if (await exists(shutdownPath)) {
+    if (await exists(shutdownPath, { dir: BaseDirectory.AppData })) {
       try {
-        const { requester } = JSON.parse(await readTextFile(shutdownPath));
+        const { requester } = JSON.parse(await readTextFile(shutdownPath, { dir: BaseDirectory.AppData }));
         if (requester !== instanceId) {
           await shutdownDbSafely();
           await releaseLock(syncDir);
-          await remove(shutdownPath);
+          await remove(shutdownPath, { dir: BaseDirectory.AppData });
           await appWindow.close();
         }
       } catch {
-        await remove(shutdownPath);
+        await remove(shutdownPath, { dir: BaseDirectory.AppData });
       }
     }
   };
@@ -66,7 +66,7 @@ export async function monitorShutdownRequests(syncDir: string) {
 
 export async function requestRemoteShutdown(syncDir: string) {
   const shutdownPath = await path(syncDir, "shutdown.request.json");
-  await writeTextFile(shutdownPath, JSON.stringify({ ts: Date.now(), requester: instanceId }));
+  await writeTextFile(shutdownPath, JSON.stringify({ ts: Date.now(), requester: instanceId }), { dir: BaseDirectory.AppData });
 }
 
 export async function releaseLock(syncDir: string) {
@@ -75,8 +75,7 @@ export async function releaseLock(syncDir: string) {
     clearInterval(heartbeat);
     heartbeat = null;
   }
-  if (await exists(lockPath)) {
-    await remove(lockPath);
+  if (await exists(lockPath, { dir: BaseDirectory.AppData })) {
+    await remove(lockPath, { dir: BaseDirectory.AppData });
   }
 }
-

--- a/src/lib/random.ts
+++ b/src/lib/random.ts
@@ -1,0 +1,5 @@
+export function randomBytes(len: number): Uint8Array {
+  const u8 = new Uint8Array(len);
+  crypto.getRandomValues(u8);
+  return u8;
+}

--- a/src/pages/parametrage/DataFolder.jsx
+++ b/src/pages/parametrage/DataFolder.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { setDataDir, getDataDir, getExportDir, setExportDir } from "@/lib/db";
+import { isTauri } from "@/tauriEnv";
 
 export default function DataFolder() {
   const [dir, setDir] = useState("");
@@ -9,21 +10,34 @@ export default function DataFolder() {
   const [exportSaved, setExportSaved] = useState(false);
 
   useEffect(() => {
-    getDataDir().then(setDir);
-    getExportDir().then(setExportDirState);
+    if (isTauri) {
+      getDataDir().then(setDir);
+      getExportDir().then(setExportDirState);
+    } else {
+      console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
   }, []);
 
   const choose = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     const selected = await open({ directory: true });
     if (selected) setDir(String(selected));
   };
 
   const chooseExport = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     const selected = await open({ directory: true });
     if (selected) setExportDirState(String(selected));
   };
 
   const save = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     if (dir) {
       await setDataDir(dir);
       setSaved(true);
@@ -31,6 +45,9 @@ export default function DataFolder() {
   };
 
   const saveExport = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     if (exportDir) {
       await setExportDir(exportDir);
       setExportSaved(true);

--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -2,18 +2,25 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
 import { toast } from "sonner";
+import { isTauri } from "@/tauriEnv";
 
 export default function SystemTools() {
   const backup = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       const dest = await backupDb();
-    toast.success(`Sauvegarde effectuée : ${dest}`);
+      toast.success(`Sauvegarde effectuée : ${dest}`);
     } catch (_) {
       toast.error("Échec de la sauvegarde");
     }
   };
 
   const restore = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       const file = await open({ filters: [{ name: "Base", extensions: ["db"] }] });
       if (file && window.confirm("Restaurer cette sauvegarde ? L'application redémarrera.")) {
@@ -27,6 +34,9 @@ export default function SystemTools() {
   };
 
   const maintain = async () => {
+    if (!isTauri) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
     try {
       await maintenanceDb();
       toast.success("Maintenance effectuée");

--- a/src/tauriEnv.js
+++ b/src/tauriEnv.js
@@ -1,4 +1,2 @@
-export const isTauri = () => {
-  // Tauri v2 expose __TAURI_INTERNALS__ et __TAURI__
-  return !!(window.__TAURI__ || window.__TAURI_INTERNALS__)
-}
+export const isTauri =
+  typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window


### PR DESCRIPTION
## Summary
- gate all Tauri plugin calls behind an `isTauri` check
- move filesystem operations to `BaseDirectory.AppData` and remove hardcoded paths
- add browser-friendly random byte helper for bcrypt

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bfd9637434832dac96c30047012d7a