### PR TITLE
chore: align fs capabilities and bcrypt randomness

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -7,6 +7,8 @@
     "core:default",
     "fs:default",
     "fs:allow-mkdir",
-    "fs:write-all"
+    "fs:create-app-specific-dirs",
+    "fs:allow-appdata-write",
+    "fs:allow-appdata-write-recursive"
   ]
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,9 +1,9 @@
 import { createContext, useContext, useEffect, useState, useMemo } from 'react';
 import bcrypt from 'bcryptjs';
 import users from '@/db/users.json';
-import { randomBytes } from '@/lib/random';
-
-bcrypt.setRandomFallback((len) => Array.from(randomBytes(len)));
+bcrypt.setRandomFallback((len) =>
+  Array.from(crypto.getRandomValues(new Uint8Array(len)))
+);
 
 const AuthCtx = createContext(null);
 export const useAuth = () => useContext(AuthCtx);

--- a/src/lib/random.ts
+++ b/src/lib/random.ts
@@ -1,5 +1,0 @@
-export function randomBytes(len: number): Uint8Array {
-  const u8 = new Uint8Array(len);
-  crypto.getRandomValues(u8);
-  return u8;
-}


### PR DESCRIPTION
## Summary
- add explicit AppData FS permissions to main capability
- secure bcrypt fallback using `crypto.getRandomValues`
- drop unused random helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bfdef120f0832d9f6200b2bfcea140