### PR TITLE
fix: move tauri plugin deps

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2021"
 tauri = { version = "2", features = ["tray-icon"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri-plugin-fs = { version = "2" }
-tauri-plugin-shell = { version = "2" }
-tauri-plugin-dialog = { version = "2" }
-tauri-plugin-process = { version = "2" }
-tauri-plugin-log = { version = "2" }
-tauri-plugin-devtools = { version = "2" }
-tauri-plugin-sql = { version = "2", features = ["sqlite"] }
+tauri-plugin-fs = "2"
+tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
+tauri-plugin-process = "2"
+tauri-plugin-log = "2"
+tauri-plugin-devtools = "2"
+tauri-plugin-sql = { version = "2.3", features = ["sqlite"] }
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 


### PR DESCRIPTION
## Summary
- ensure Tauri plugin dependencies are only declared in `[dependencies]`
- bump `tauri-plugin-sql` to v2.3 with `sqlite` feature

## Testing
- `cargo check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0063b07f0832d9b3ee808405bc2d5