### PR TITLE
refactor: add Tauri-aware config helpers and guards

### DIFF
--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,7 +1,7 @@
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-shell";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;
@@ -31,10 +31,10 @@ export default function DebugRibbon() {
 
   return (
     <div className="fixed top-0 right-0 m-2 flex gap-2 z-50 text-xs bg-black/50 text-white rounded p-1">
-      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openDev}>
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openDev} disabled={!isTauri()}>
         Ouvrir DevTools
       </button>
-      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openLogs}>
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openLogs} disabled={!isTauri()}>
         Voir le fichier de logs
       </button>
     </div>

--- a/src/debug/ErrorBoundary.jsx
+++ b/src/debug/ErrorBoundary.jsx
@@ -1,7 +1,7 @@
 import { Component } from "react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { log } from "../tauriLog";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export default class ErrorBoundary extends Component {
   constructor(props) {

--- a/src/isTauri.ts
+++ b/src/isTauri.ts
@@ -1,3 +1,0 @@
-export function isTauri() {
-  return typeof window !== "undefined" && !!(window as any).__TAURI_INTERNALS__;
-}

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -8,7 +8,7 @@ import { shutdownDbSafely } from "@/lib/shutdown";
 import { releaseLock } from "@/lib/lock";
 import { getDataDir } from "@/lib/db";
 import { appWindow } from "@tauri-apps/api/window";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export default function Navbar() {
   const { t } = useTranslation();
@@ -115,6 +115,7 @@ export default function Navbar() {
               <button
                 onClick={handleQuit}
                 className="text-sm bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded-md transition"
+                disabled={!isTauri()}
               >
         Quitter & synchroniser
       </button>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,40 +1,21 @@
 import Database from "@tauri-apps/plugin-sql";
 import { readFile, writeFile, mkdir, exists, BaseDirectory } from "@tauri-apps/plugin-fs";
-import { ensureAppDir, writeAppText, readAppText } from "@/appFs";
-import { isTauri } from "@/isTauri";
+import { readConfig, writeConfig } from "@/appFs";
+import { isTauri } from "@/tauriEnv";
 
 const APP_DIR = "MamaStock";
 const APP_BASE = (BaseDirectory?.AppData ?? 0) as number;
 const DATA_DIR = `${APP_DIR}/data`;
 const EXPORT_DIR = `${APP_DIR}/Exports`;
 const BACKUP_DIR = `${APP_DIR}/Backups`;
-const CONFIG_FILE = "config.json";
-
 let dbPromise: Promise<Database> | null = null;
-
-async function readConfig(): Promise<any> {
-  const txt = await readAppText(CONFIG_FILE);
-  if (txt) {
-    try {
-      return JSON.parse(txt);
-    } catch (_) {
-      /* ignore */
-    }
-  }
-  return {};
-}
-
-async function writeConfig(data: any) {
-  await ensureAppDir();
-  await writeAppText(CONFIG_FILE, JSON.stringify(data, null, 2));
-}
 
 export async function getDataDir(): Promise<string> {
   if (!isTauri()) {
     console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     return DATA_DIR;
   }
-  const cfg = await readConfig();
+  const cfg = (await readConfig()) || {};
   return cfg.dataDir || DATA_DIR;
 }
 
@@ -42,7 +23,7 @@ export async function setDataDir(dir: string) {
   if (!isTauri()) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
-  const cfg = await readConfig();
+  const cfg = (await readConfig()) || {};
   await writeConfig({ ...cfg, dataDir: dir });
   dbPromise = null; // force reload
 }
@@ -52,7 +33,7 @@ export async function getExportDir(): Promise<string> {
     console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     return EXPORT_DIR;
   }
-  const cfg = await readConfig();
+  const cfg = (await readConfig()) || {};
   return cfg.exportDir || EXPORT_DIR;
 }
 
@@ -60,7 +41,7 @@ export async function setExportDir(dir: string) {
   if (!isTauri()) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
-  const cfg = await readConfig();
+  const cfg = (await readConfig()) || {};
   await writeConfig({ ...cfg, exportDir: dir });
 }
 

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -7,7 +7,7 @@ import { dump } from 'js-yaml';
 import { writeFile, mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { save } from '@tauri-apps/plugin-dialog';
 import { getExportDir } from '@/lib/db';
-import { isTauri } from '@/isTauri';
+import { isTauri } from '@/tauriEnv';
 
 async function resolveExportPath(filename) {
   const dir = await getExportDir();

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -3,7 +3,7 @@ import { exists, readTextFile, writeTextFile, remove, BaseDirectory } from "@tau
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { v4 as uuidv4 } from "uuid";
 import { shutdownDbSafely } from "./shutdown";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 const appWindow = isTauri() ? getCurrentWebviewWindow() : null;
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
 import { emit } from '@tauri-apps/api/event';
-import { isTauri } from "./isTauri";
+import { isTauri } from "./tauriEnv";
 import { log, initLog } from "./tauriLog";
 // MamaStock Â© 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // Polyfills Node â†’ navigateur

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import useExport from '@/hooks/useExport';
+import { isTauri } from '@/tauriEnv';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import TableHeader from '@/components/ui/TableHeader';
 import GlassCard from '@/components/ui/GlassCard';
@@ -177,7 +178,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'excel' })
                     }
-                    disabled={exporting}
+                    disabled={exporting || !isTauri()}
                   >
                     Export Excel
                   </Button>
@@ -186,7 +187,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'csv' })
                     }
-                    disabled={exporting}
+                    disabled={exporting || !isTauri()}
                   >
                     Export CSV
                   </Button>
@@ -195,7 +196,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'pdf' })
                     }
-                    disabled={exporting}
+                    disabled={exporting || !isTauri()}
                   >
                     Export PDF
                   </Button>
@@ -222,7 +223,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'excel' })
                       }
-                      disabled={exporting}
+                      disabled={exporting || !isTauri()}
                     >
                       Export Excel
                     </DropdownMenuItem>
@@ -230,7 +231,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'csv' })
                       }
-                      disabled={exporting}
+                      disabled={exporting || !isTauri()}
                     >
                       Export CSV
                     </DropdownMenuItem>
@@ -238,7 +239,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'pdf' })
                       }
-                      disabled={exporting}
+                      disabled={exporting || !isTauri()}
                     >
                       Export PDF
                     </DropdownMenuItem>

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -17,6 +17,7 @@ import FournisseurRow from '@/components/fournisseurs/FournisseurRow';
 import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
 import { toast } from 'sonner';
 import useExport from '@/hooks/useExport';
+import { isTauri } from '@/tauriEnv';
 import {
   ResponsiveContainer,
   LineChart,
@@ -215,13 +216,13 @@ export default function Fournisseurs() {
                 <PlusCircle className="mr-2" size={18} /> Ajouter fournisseur
               </Button>
             )}
-            <Button className="w-auto" onClick={() => handleExport('excel')} disabled={exporting}>
+            <Button className="w-auto" onClick={() => handleExport('excel')} disabled={exporting || !isTauri()}>
               Export Excel
             </Button>
-            <Button className="w-auto" onClick={() => handleExport('csv')} disabled={exporting}>
+            <Button className="w-auto" onClick={() => handleExport('csv')} disabled={exporting || !isTauri()}>
               Export CSV
             </Button>
-            <Button className="w-auto" onClick={() => handleExport('pdf')} disabled={exporting}>
+            <Button className="w-auto" onClick={() => handleExport('pdf')} disabled={exporting || !isTauri()}>
               Export PDF
             </Button>
             <Button className="w-auto" onClick={handleDiag}>

--- a/src/pages/parametrage/DataFolder.jsx
+++ b/src/pages/parametrage/DataFolder.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { setDataDir, getDataDir, getExportDir, setExportDir } from "@/lib/db";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export default function DataFolder() {
   const [dir, setDir] = useState("");
@@ -65,10 +65,10 @@ export default function DataFolder() {
           className="border p-1 w-full"
         />
         <div className="flex gap-2">
-          <button onClick={choose} className="border px-2 py-1">
+          <button onClick={choose} className="border px-2 py-1" disabled={!isTauri()}>
             Choisir...
           </button>
-          <button onClick={save} className="border px-2 py-1">
+          <button onClick={save} className="border px-2 py-1" disabled={!isTauri()}>
             Enregistrer
           </button>
         </div>
@@ -87,10 +87,10 @@ export default function DataFolder() {
           className="border p-1 w-full"
         />
         <div className="flex gap-2">
-          <button onClick={chooseExport} className="border px-2 py-1">
+          <button onClick={chooseExport} className="border px-2 py-1" disabled={!isTauri()}>
             Choisir...
           </button>
-          <button onClick={saveExport} className="border px-2 py-1">
+          <button onClick={saveExport} className="border px-2 py-1" disabled={!isTauri()}>
             Enregistrer
           </button>
         </div>

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import TableContainer from '@/components/ui/TableContainer';
 import useExportCompta from '@/hooks/useExportCompta';
+import { isTauri } from '@/tauriEnv';
 
 export default function ExportComptaPage() {
   const { generateJournalCsv, exportToERP, loading } = useExportCompta();
@@ -18,7 +19,12 @@ export default function ExportComptaPage() {
     setPreview(rows);
   };
 
-  const handleDownload = () => generateJournalCsv(mois, true);
+  const handleDownload = () => {
+    if (!isTauri()) {
+      return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
+    }
+    return generateJournalCsv(mois, true);
+  };
 
   const handleSend = () => exportToERP(mois, endpoint, token);
 
@@ -51,7 +57,7 @@ export default function ExportComptaPage() {
         <Button onClick={handlePreview} disabled={loading}>
           Aperçu
         </Button>
-        <Button onClick={handleDownload} disabled={loading}>
+        <Button onClick={handleDownload} disabled={loading || !isTauri()}>
           Télécharger
         </Button>
       </div>

--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -2,7 +2,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
 import { toast } from "sonner";
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export default function SystemTools() {
   const backup = async () => {
@@ -49,9 +49,9 @@ export default function SystemTools() {
     <div className="p-4 space-y-4">
       <h1 className="text-xl">Outils système</h1>
       <div className="flex gap-2">
-        <button onClick={backup} className="border px-2 py-1">Sauvegarder</button>
-        <button onClick={restore} className="border px-2 py-1">Restaurer</button>
-        <button onClick={maintain} className="border px-2 py-1">Maintenance</button>
+        <button onClick={backup} className="border px-2 py-1" disabled={!isTauri()}>Sauvegarder</button>
+        <button onClick={restore} className="border px-2 py-1" disabled={!isTauri()}>Restaurer</button>
+        <button onClick={maintain} className="border px-2 py-1" disabled={!isTauri()}>Maintenance</button>
       </div>
     </div>
   );

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -20,6 +20,7 @@ import { useAuth } from '@/hooks/useAuth';
 import ProduitRow from "@/components/produits/ProduitRow";
 import ModalImportProduits from "@/components/produits/ModalImportProduits";
 import useExport from '@/hooks/useExport';
+import { isTauri } from '@/tauriEnv';
 
 const PAGE_SIZE = 50;
 
@@ -234,7 +235,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('excel')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting}
+              disabled={rows.length === 0 || exporting || !isTauri()}
             >
               Export Excel
             </Button>
@@ -242,7 +243,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('csv')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting}
+              disabled={rows.length === 0 || exporting || !isTauri()}
             >
               Export CSV
             </Button>
@@ -250,7 +251,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('pdf')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting}
+              disabled={rows.length === 0 || exporting || !isTauri()}
             >
               Export PDF
             </Button>

--- a/src/tauriEnv.ts
+++ b/src/tauriEnv.ts
@@ -1,0 +1,2 @@
+export const isTauri = () =>
+  typeof window !== "undefined" && !!(window as any).__TAURI_INTERNALS__;

--- a/src/tauriLog.ts
+++ b/src/tauriLog.ts
@@ -8,7 +8,7 @@ export type LogApi = {
 
 let api: Partial<LogApi> | null = null;
 
-import { isTauri } from "@/isTauri";
+import { isTauri } from "@/tauriEnv";
 
 export async function initLog() {
   if (isTauri() && import.meta.env.PROD) {


### PR DESCRIPTION
## Summary
- add `tauriEnv` helper to detect runtime
- persist config via `appFs` with Tauri path and localStorage fallback
- guard filesystem actions and replace direct `config.json` access

## Testing
- `npm test` (fails: Missing script)
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c012e2ffa4832d8c38a6a7db6668cd