### PR TITLE
feat: add web crypto random helper

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,9 +1,9 @@
 import { createContext, useContext, useEffect, useState, useMemo } from 'react';
 import bcrypt from 'bcryptjs';
 import users from '@/db/users.json';
-bcrypt.setRandomFallback((len) =>
-  Array.from(crypto.getRandomValues(new Uint8Array(len)))
-);
+import { randomBytes } from '@/crypto/random';
+
+bcrypt.setRandomFallback(randomBytes);
 
 const AuthCtx = createContext(null);
 export const useAuth = () => useContext(AuthCtx);

--- a/src/crypto/random.ts
+++ b/src/crypto/random.ts
@@ -1,0 +1,5 @@
+export function randomBytes(len: number): Uint8Array {
+  const arr = new Uint8Array(len);
+  crypto.getRandomValues(arr);
+  return arr;
+}


### PR DESCRIPTION
## Summary
- add `randomBytes` helper using Web Crypto
- use helper for bcrypt random fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c0152987f0832db73e5d9d1dc4a93c