### PR TITLE
feat: guard tauri plugin calls

### DIFF
--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,17 +1,15 @@
-import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { appDataDir, join } from "@tauri-apps/api/path";
-import { open } from "@tauri-apps/plugin-shell";
 import { isTauri } from "@/tauriEnv";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;
   if (!show) return null;
 
-  const openDev = () => {
+  const openDev = async () => {
     if (!isTauri()) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
+      const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
       getCurrentWebviewWindow().openDevtools();
     } catch {}
   };
@@ -21,6 +19,8 @@ export default function DebugRibbon() {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
+      const { appDataDir, join } = await import("@tauri-apps/api/path");
+      const { open } = await import("@tauri-apps/plugin-shell");
       const dir = await appDataDir();
       const logDir = await join(dir, "logs");
       await open(logDir);

--- a/src/debug/ErrorBoundary.jsx
+++ b/src/debug/ErrorBoundary.jsx
@@ -1,5 +1,4 @@
 import { Component } from "react";
-import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { log } from "../tauriLog";
 import { isTauri } from "@/tauriEnv";
 
@@ -18,11 +17,12 @@ export default class ErrorBoundary extends Component {
     console.error(error, info);
   }
 
-  openDevTools() {
+  async openDevTools() {
     if (!isTauri()) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
+      const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
       getCurrentWebviewWindow().openDevtools();
     } catch {}
   }

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -7,7 +7,6 @@ import LanguageSelector from "@/components/ui/LanguageSelector";
 import { shutdownDbSafely } from "@/lib/shutdown";
 import { releaseLock } from "@/lib/lock";
 import { getDataDir } from "@/lib/db";
-import { appWindow } from "@tauri-apps/api/window";
 import { isTauri } from "@/tauriEnv";
 
 export default function Navbar() {
@@ -47,6 +46,7 @@ export default function Navbar() {
       if (!isTauri()) {
         return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
       }
+      const { appWindow } = await import("@tauri-apps/api/window");
       const dir = await getDataDir();
       await shutdownDbSafely();
       await releaseLock(dir);

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -4,19 +4,22 @@ import 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { dump } from 'js-yaml';
-import { writeFile, mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
-import { save } from '@tauri-apps/plugin-dialog';
 import { getExportDir } from '@/lib/db';
 import { isTauri } from '@/tauriEnv';
 
 async function resolveExportPath(filename) {
   const dir = await getExportDir();
-  await mkdir(dir, { dir: BaseDirectory.AppData, recursive: true });
+  if (isTauri()) {
+    const { mkdir, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await mkdir(dir, { dir: BaseDirectory.AppData, recursive: true });
+  }
   return `${dir}/${filename}`;
 }
 
 async function saveBlob(blob, filename, useDialog = true) {
   if (isTauri()) {
+    const { writeFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    const { save } = await import('@tauri-apps/plugin-dialog');
     const defaultPath = await resolveExportPath(filename);
     const path = useDialog ? (await save({ defaultPath })) || defaultPath : defaultPath;
     const buf = await blob.arrayBuffer();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,3 @@
-import { emit } from '@tauri-apps/api/event';
 import { isTauri } from "./tauriEnv";
 import { log, initLog } from "./tauriLog";
 // MamaStock Â© 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
@@ -13,6 +12,7 @@ window.process = process;
 // Raccourci clavier F12 pour demander au backend d'ouvrir DevTools
 if (isTauri()) {
   await initLog();
+  const { emit } = await import('@tauri-apps/api/event');
   window.addEventListener('keydown', async (e) => {
     if (e.key === 'F12') {
       try {

--- a/src/pages/parametrage/DataFolder.jsx
+++ b/src/pages/parametrage/DataFolder.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { open } from "@tauri-apps/plugin-dialog";
 import { setDataDir, getDataDir, getExportDir, setExportDir } from "@/lib/db";
 import { isTauri } from "@/tauriEnv";
 
@@ -22,6 +21,7 @@ export default function DataFolder() {
     if (!isTauri()) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
+    const { open } = await import("@tauri-apps/plugin-dialog");
     const selected = await open({ directory: true });
     if (selected) setDir(String(selected));
   };
@@ -30,6 +30,7 @@ export default function DataFolder() {
     if (!isTauri()) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
+    const { open } = await import("@tauri-apps/plugin-dialog");
     const selected = await open({ directory: true });
     if (selected) setExportDirState(String(selected));
   };

--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -1,5 +1,3 @@
-import { open } from "@tauri-apps/plugin-dialog";
-import { relaunch } from "@tauri-apps/plugin-process";
 import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
 import { toast } from "sonner";
 import { isTauri } from "@/tauriEnv";
@@ -22,6 +20,8 @@ export default function SystemTools() {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const { relaunch } = await import("@tauri-apps/plugin-process");
       const file = await open({ filters: [{ name: "Base", extensions: ["db"] }] });
       if (file && window.confirm("Restaurer cette sauvegarde ? L'application redémarrera.")) {
         await restoreDb(String(file));


### PR DESCRIPTION
## Summary
- guard database helpers with lazy-loaded Tauri plugins
- dynamically import plugin APIs in lock management and UI components
- wrap system tools and exports to run only when `isTauri()` is true

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Tauri plugins not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c016218420832db8d98fa65649219c