### PR TITLE
Restrict main capability to app data directory

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -13,8 +13,9 @@
     "fs:default",
     "fs:allow-mkdir",
     "fs:create-app-specific-dirs",
+    "fs:allow-appdata-read",
+    "fs:allow-appdata-read-recursive",
     "fs:allow-appdata-write",
-    "fs:allow-appdata-write-recursive",
-    "fs:write-all"
+    "fs:allow-appdata-write-recursive"
   ]
 }


### PR DESCRIPTION
## Summary
- remove broad `fs:write-all` permission from main window capability
- allow explicit app data read/write access for the main window

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c028ff081c832daae7cef8bca1b919