### PR TITLE
feat: replace node crypto with web crypto

### DIFF
--- a/src/crypto/random.ts
+++ b/src/crypto/random.ts
@@ -1,5 +1,12 @@
 export function randomBytes(len: number): Uint8Array {
   const out = new Uint8Array(len);
+  // Web Crypto in the browser & Tauri webview
   crypto.getRandomValues(out);
   return out;
+}
+
+export async function sha256(data: Uint8Array | string): Promise<Uint8Array> {
+  const bytes = typeof data === "string" ? new TextEncoder().encode(data) : data;
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return new Uint8Array(hash);
 }


### PR DESCRIPTION
## Summary
- add Web Crypto wrapper for random bytes and SHA-256

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Top-level await not available in target environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c02b6b2e88832d9be8d8d4bbbb5d1f