### PR TITLE
fix: add browser crypto shim and absolute alias

### DIFF
--- a/src/shims/crypto.ts
+++ b/src/shims/crypto.ts
@@ -1,14 +1,12 @@
-function hexOf(bytes: Uint8Array) {
+function toHex(bytes: Uint8Array) {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("");
 }
-
 export function randomBytes(len: number, cb?: (err: Error|null, buf: Uint8Array) => void): Uint8Array | void {
   const out = new Uint8Array(len);
   (globalThis.crypto || window.crypto).getRandomValues(out);
-  // decorate with toString('hex') because some libs expect Buffer-like
-  (out as any).toString = (enc?: string) => enc === "hex" ? hexOf(out) : Object.prototype.toString.call(out);
+  // Provide Buffer-like toString('hex') for libs that use it
+  (out as any).toString = (enc?: string) => enc === "hex" ? toHex(out) : Object.prototype.toString.call(out);
   if (cb) { cb(null, out); return; }
   return out;
 }
-
 export default { randomBytes };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,22 +4,17 @@ import path from "node:path";
 
 export default defineConfig({
   plugins: [react()],
-  base: "/",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
-      crypto: "/src/shims/crypto.ts",
+      crypto: path.resolve(__dirname, "src/shims/crypto.ts"),
+      "node:crypto": path.resolve(__dirname, "src/shims/crypto.ts"),
     },
   },
-  define: {
-    global: "globalThis",
-  },
+  define: { global: "globalThis" },
   optimizeDeps: {
-    // bcryptjs sometimes breaks if pre-bundled with a hard 'crypto' require
-    exclude: ["bcryptjs"],
-    esbuildOptions: {
-      define: { global: "globalThis" },
-    },
+    exclude: ["bcryptjs", "crypto-js"],
+    esbuildOptions: { define: { global: "globalThis" } },
   },
   server: { port: 5173, strictPort: true, host: true },
 });


### PR DESCRIPTION
## Summary
- provide crypto.randomBytes shim for browsers
- wire crypto alias with absolute path and exclude bcryptjs and crypto-js from prebundle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Top-level await is not available in the configured target environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f75e0bc832d9d5ac78336a2e610