### PR TITLE
feat: add SQLite backend and initialization

### DIFF
--- a/src/auth/sqlAccount.ts
+++ b/src/auth/sqlAccount.ts
@@ -1,0 +1,35 @@
+import { openDb } from "@/db/index";
+
+async function sha256Hex(input: string) {
+  const enc = new TextEncoder();
+  const digest = await crypto.subtle.digest("SHA-256", enc.encode(input));
+  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2,"0")).join("");
+}
+
+export async function registerSql(email: string, password: string) {
+  email = email.trim().toLowerCase();
+  const db = await openDb();
+  const exists = await db.select("SELECT 1 as ok FROM users WHERE email = $1", [email]);
+  if (exists.length) throw new Error("Email déjà utilisé.");
+  const id = crypto.randomUUID();
+  const mama_id = "local-" + Math.random().toString(36).slice(2,8);
+  const salt = crypto.randomUUID();
+  const password_hash = await sha256Hex(`${password}:${salt}`);
+  const created_at = new Date().toISOString();
+  await db.execute(
+    "INSERT INTO users (id,email,mama_id,password_hash,salt,created_at) VALUES ($1,$2,$3,$4,$5,$6)",
+    [id, email, mama_id, password_hash, salt, created_at]
+  );
+  return { id, email, mama_id };
+}
+
+export async function loginSql(email: string, password: string) {
+  email = email.trim().toLowerCase();
+  const db = await openDb();
+  const r = await db.select("SELECT * FROM users WHERE email = $1", [email]);
+  if (!r.length) throw new Error("Utilisateur introuvable.");
+  const u = r[0] as any;
+  const check = await sha256Hex(`${password}:${u.salt}`);
+  if (check !== u.password_hash) throw new Error("Mot de passe invalide.");
+  return { id: u.id, email: u.email, mama_id: u.mama_id };
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,67 @@
+/// <reference types="vite/client" />
+import { appDataDir, join } from "@tauri-apps/api/path";
+import { exists, mkdir } from "@tauri-apps/plugin-fs";
+import Database from "@tauri-apps/plugin-sql";
+
+const isTauri = !!import.meta.env.TAURI_PLATFORM;
+const APP_DIR = "MamaStock";
+const DB_FILE = "mamastock.db";
+
+async function dbPath() {
+  if (!isTauri) throw new Error("Lance l'app via Tauri (npx tauri dev).");
+  const base = await appDataDir();
+  const dir = await join(base, APP_DIR);
+  if (!(await exists(dir))) await mkdir(dir, { recursive: true });
+  return await join(dir, DB_FILE);
+}
+
+export async function openDb() {
+  const path = await dbPath();
+  return await Database.load("sqlite:" + path);
+}
+
+/** Crée les tables minimales si absentes */
+export async function initSchema() {
+  const db = await openDb();
+  await db.execute(`
+    PRAGMA journal_mode = WAL;
+
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      mama_id TEXT NOT NULL,
+      password_hash TEXT NOT NULL,
+      salt TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS items (
+      id TEXT PRIMARY KEY,
+      sku TEXT UNIQUE NOT NULL,
+      name TEXT NOT NULL,
+      category TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS stock_movements (
+      id TEXT PRIMARY KEY,
+      item_id TEXT NOT NULL,
+      qty INTEGER NOT NULL,            -- +entrée / -sortie
+      reason TEXT NOT NULL,            -- "init","purchase","sale","adjust"
+      meta JSON,
+      created_at TEXT NOT NULL,
+      FOREIGN KEY(item_id) REFERENCES items(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_items_sku ON items(sku);
+    CREATE INDEX IF NOT EXISTS idx_mov_item ON stock_movements(item_id);
+    CREATE INDEX IF NOT EXISTS idx_mov_created ON stock_movements(created_at);
+  `);
+  return db;
+}
+
+export async function sumStock(itemId: string): Promise<number> {
+  const db = await openDb();
+  const rows = await db.select("SELECT COALESCE(SUM(qty),0) AS s FROM stock_movements WHERE item_id = $1", [itemId]);
+  return Number(rows?.[0]?.s ?? 0);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -86,6 +86,7 @@ import App from "./App";
 import ErrorBoundary from "@/debug/ErrorBoundary";
 import { AuthProvider } from "@/context/AuthContext";
 import { HelpProvider } from "@/context/HelpProvider";
+import { initSchema } from "@/db/index";
 import "./globals.css";
 import "nprogress/nprogress.css";
 import "@/i18n/i18n";
@@ -134,6 +135,7 @@ if (isTauri()) {
   );
 }
 
+await initSchema();
 const root = createRoot(document.getElementById("root"));
 root.render(
   <ErrorBoundary>

--- a/src/services/inventory.ts
+++ b/src/services/inventory.ts
@@ -1,0 +1,42 @@
+import { openDb, sumStock } from "@/db/index";
+
+export type Item = { id: string; sku: string; name: string; category?: string|null; created_at: string; };
+
+export async function createItem(sku: string, name: string, category?: string|null): Promise<Item> {
+  const db = await openDb();
+  const id = crypto.randomUUID();
+  const created_at = new Date().toISOString();
+  await db.execute(
+    "INSERT INTO items (id,sku,name,category,created_at) VALUES ($1,$2,$3,$4,$5)",
+    [id, sku.trim(), name.trim(), category ?? null, created_at]
+  );
+  return { id, sku: sku.trim(), name: name.trim(), category: category ?? null, created_at };
+}
+
+export async function getItemBySku(sku: string): Promise<Item|null> {
+  const db = await openDb();
+  const rows = await db.select("SELECT * FROM items WHERE sku = $1", [sku.trim()]);
+  return rows.length ? (rows[0] as Item) : null;
+}
+
+export async function listItems(): Promise<Array<Item & { stock: number }>> {
+  const db = await openDb();
+  const rows = await db.select("SELECT * FROM items ORDER BY created_at DESC");
+  const out: Array<Item & { stock: number }> = [];
+  for (const r of rows as Item[]) {
+    out.push({ ...r, stock: await sumStock(r.id) });
+  }
+  return out;
+}
+
+export async function adjustStock(itemId: string, qty: number, reason: string, meta?: any) {
+  if (!Number.isInteger(qty) || qty === 0) throw new Error("qty doit être un entier non nul");
+  const db = await openDb();
+  const id = crypto.randomUUID();
+  const created_at = new Date().toISOString();
+  await db.execute(
+    "INSERT INTO stock_movements (id,item_id,qty,reason,meta,created_at) VALUES ($1,$2,$3,$4,$5,$6)",
+    [id, itemId, qty, reason, meta ? JSON.stringify(meta) : null, created_at]
+  );
+  return { id, item_id: itemId, qty, reason, created_at };
+}


### PR DESCRIPTION
## Summary
- add SQLite helper with schema initialization
- implement inventory service for items and stock movements
- add SQLite-based auth account management
- initialize database during app startup

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c043affc00832d91a7ba95ab09c5da