### PR TITLE
feat: add SQLite migration system

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,15 @@
+import Database from "@tauri-apps/plugin-sql";
+import { appDataPath } from "@/lib/paths";
+import { exists, mkdir } from "@tauri-apps/plugin-fs";
+import { dirname } from "@tauri-apps/api/path";
+
+let _db: Database | null = null;
+
+export async function getDb(): Promise<Database> {
+  if (_db) return _db;
+  const file = await appDataPath("mamastock.db");
+  const dir = await dirname(file);
+  if (!(await exists(dir))) await mkdir(dir, { recursive: true });
+  _db = await Database.load(`sqlite:${file}`);
+  return _db!;
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,84 @@
+import { getDb } from "./client";
+import { migrations } from "./migrationsList";
+import { appDataPath } from "@/lib/paths";
+import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+
+/** Splitter SQL qui respecte CREATE TRIGGER ... BEGIN ... END; */
+function splitSql(script: string): string[] {
+  const lines = script.replace(/\r\n/g, "\n").split("\n");
+  const chunks: string[] = [];
+  let cur = "";
+  let inTrigger = false;
+
+  const pushIfNotEmpty = () => {
+    const s = cur.trim();
+    if (s) chunks.push(s);
+    cur = "";
+  };
+
+  for (let raw of lines) {
+    const line = raw.replace(/--.*$/, ""); // strip commentaires ligne
+    if (!inTrigger && /^\s*CREATE\s+TRIGGER/i.test(line)) {
+      inTrigger = true;
+    }
+    cur += line + "\n";
+
+    if (inTrigger) {
+      if (/END\s*;\s*$/i.test(line)) {
+        pushIfNotEmpty();
+        inTrigger = false;
+      }
+    } else {
+      if (/;\s*$/.test(line)) {
+        pushIfNotEmpty();
+      }
+    }
+  }
+  pushIfNotEmpty();
+  return chunks;
+}
+
+type MigState = { applied: string[] };
+
+async function readState(): Promise<MigState> {
+  const path = await appDataPath("migrations.json");
+  if (!(await exists(path))) return { applied: [] };
+  try {
+    const txt = await readTextFile(path);
+    const json = JSON.parse(txt);
+    return { applied: Array.isArray(json.applied) ? json.applied : [] };
+  } catch {
+    return { applied: [] };
+  }
+}
+
+async function writeState(state: MigState) {
+  const path = await appDataPath("migrations.json");
+  await writeTextFile(path, JSON.stringify(state, null, 2));
+}
+
+export async function applyMigrations(): Promise<void> {
+  const db = await getDb();
+  const state = await readState();
+
+  for (const m of migrations) {
+    if (state.applied.includes(m.id)) continue;
+
+    const statements = splitSql(m.sql);
+    // exécute en “transaction” best-effort
+    try {
+      await db.execute("BEGIN;");
+      for (const stmt of statements) {
+        await db.execute(stmt);
+      }
+      await db.execute("COMMIT;");
+      state.applied.push(m.id);
+      await writeState(state);
+      console.info(`[migrate] applied ${m.id}`);
+    } catch (e) {
+      try { await db.execute("ROLLBACK;"); } catch {}
+      console.error(`[migrate] failed ${m.id}:`, e);
+      throw e;
+    }
+  }
+}

--- a/src/db/migrationsList.ts
+++ b/src/db/migrationsList.ts
@@ -1,0 +1,9 @@
+import MIG_001 from "@/migrations/001_schema.sql?raw";
+import MIG_002 from "@/migrations/002_seed.sql?raw";
+import MIG_003 from "@/migrations/003_pmp_valeur_stock.sql?raw";
+
+export const migrations = [
+  { id: "001_schema", sql: MIG_001 },
+  { id: "002_seed", sql: MIG_002 },
+  { id: "003_pmp_valeur_stock", sql: MIG_003 },
+];

--- a/src/migrations/001_schema.sql
+++ b/src/migrations/001_schema.sql
@@ -1,0 +1,97 @@
+-- Base SQLite locale pour MamaStock
+PRAGMA journal_mode=WAL;
+
+-- Table de version du schéma pour idempotence
+CREATE TABLE IF NOT EXISTS meta (
+  schema_version TEXT PRIMARY KEY
+);
+INSERT INTO meta(schema_version)
+  SELECT '1'
+  WHERE NOT EXISTS (SELECT 1 FROM meta);
+
+-- Table des utilisateurs
+CREATE TABLE IF NOT EXISTS utilisateurs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  mot_de_passe_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'admin',
+  actif INTEGER NOT NULL DEFAULT 1
+);
+
+-- Table des fournisseurs
+CREATE TABLE IF NOT EXISTS fournisseurs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  nom TEXT NOT NULL,
+  email TEXT,
+  actif INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(nom)
+);
+
+-- Table des produits
+CREATE TABLE IF NOT EXISTS produits (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  nom TEXT NOT NULL,
+  unite TEXT,
+  famille TEXT,
+  actif INTEGER NOT NULL DEFAULT 1,
+  pmp REAL NOT NULL DEFAULT 0,
+  stock_theorique REAL NOT NULL DEFAULT 0,
+  UNIQUE(nom)
+);
+
+-- Table des factures
+CREATE TABLE IF NOT EXISTS factures (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  fournisseur_id INTEGER NOT NULL,
+  date_iso TEXT NOT NULL,
+  FOREIGN KEY(fournisseur_id) REFERENCES fournisseurs(id)
+);
+
+-- Table des lignes de facture
+CREATE TABLE IF NOT EXISTS facture_lignes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  facture_id INTEGER NOT NULL,
+  produit_id INTEGER NOT NULL,
+  quantite REAL NOT NULL,
+  prix_unitaire REAL NOT NULL,
+  FOREIGN KEY(facture_id) REFERENCES factures(id),
+  FOREIGN KEY(produit_id) REFERENCES produits(id)
+);
+
+-- Index pour la recherche
+CREATE INDEX IF NOT EXISTS idx_fournisseurs_nom ON fournisseurs(nom);
+CREATE INDEX IF NOT EXISTS idx_produits_nom ON produits(nom);
+CREATE INDEX IF NOT EXISTS idx_factures_date ON factures(date_iso);
+CREATE INDEX IF NOT EXISTS idx_facture_lignes_produit ON facture_lignes(produit_id);
+CREATE INDEX IF NOT EXISTS idx_facture_lignes_facture ON facture_lignes(facture_id);
+
+-- Trigger: mise à jour du PMP et du stock lors de l'insertion d'une ligne de facture
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_insert
+AFTER INSERT ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    pmp = CASE
+      WHEN stock_theorique + NEW.quantite = 0 THEN pmp
+      ELSE ((pmp * stock_theorique) + (NEW.prix_unitaire * NEW.quantite)) / (stock_theorique + NEW.quantite)
+    END,
+    stock_theorique = stock_theorique + NEW.quantite
+  WHERE id = NEW.produit_id;
+END;
+
+-- Trigger: mise à jour du stock lors de la modification d'une ligne de facture
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_update
+AFTER UPDATE ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock_theorique = stock_theorique - OLD.quantite + NEW.quantite
+  WHERE id = NEW.produit_id;
+END;
+
+-- Trigger: mise à jour du stock lors de la suppression d'une ligne de facture
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_delete
+AFTER DELETE ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock_theorique = stock_theorique - OLD.quantite
+  WHERE id = OLD.produit_id;
+END;

--- a/src/migrations/002_seed.sql
+++ b/src/migrations/002_seed.sql
@@ -1,0 +1,2 @@
+-- Données de départ pour l'application locale
+-- (admin user seeded via scripts/seed-admin.js)

--- a/src/migrations/003_pmp_valeur_stock.sql
+++ b/src/migrations/003_pmp_valeur_stock.sql
@@ -1,0 +1,47 @@
+-- Migration 003 : ajout de la valeur du stock et triggers complets
+ALTER TABLE produits ADD COLUMN valeur_stock REAL NOT NULL DEFAULT 0;
+
+-- Recréation des triggers pour gérer stock, valeur du stock et PMP
+DROP TRIGGER IF EXISTS trg_facture_ligne_insert;
+DROP TRIGGER IF EXISTS trg_facture_ligne_update;
+DROP TRIGGER IF EXISTS trg_facture_ligne_delete;
+
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_insert
+AFTER INSERT ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock_theorique = stock_theorique + NEW.quantite,
+    valeur_stock = valeur_stock + (NEW.quantite * NEW.prix_unitaire),
+    pmp = CASE
+      WHEN stock_theorique + NEW.quantite = 0 THEN 0
+      ELSE (valeur_stock + (NEW.quantite * NEW.prix_unitaire)) / (stock_theorique + NEW.quantite)
+    END
+  WHERE id = NEW.produit_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_update
+AFTER UPDATE ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock_theorique = stock_theorique - OLD.quantite + NEW.quantite,
+    valeur_stock = valeur_stock - (OLD.quantite * OLD.prix_unitaire) + (NEW.quantite * NEW.prix_unitaire),
+    pmp = CASE
+      WHEN stock_theorique - OLD.quantite + NEW.quantite = 0 THEN 0
+      ELSE (valeur_stock - (OLD.quantite * OLD.prix_unitaire) + (NEW.quantite * NEW.prix_unitaire)) /
+           (stock_theorique - OLD.quantite + NEW.quantite)
+    END
+  WHERE id = NEW.produit_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_facture_ligne_delete
+AFTER DELETE ON facture_lignes
+BEGIN
+  UPDATE produits SET
+    stock_theorique = stock_theorique - OLD.quantite,
+    valeur_stock = valeur_stock - (OLD.quantite * OLD.prix_unitaire),
+    pmp = CASE
+      WHEN stock_theorique - OLD.quantite = 0 THEN 0
+      ELSE (valeur_stock - (OLD.quantite * OLD.prix_unitaire)) / (stock_theorique - OLD.quantite)
+    END
+  WHERE id = OLD.produit_id;
+END;


### PR DESCRIPTION
## Summary
- move SQL migrations into `src/migrations`
- add database client for app data SQLite file
- introduce migration list and runner

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Top-level await is not available in the configured target environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c04687bd40832daf3e8bcd4953d3c4