### PR TITLE
Ensure alias configuration for Vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "node:path";
+import { fileURLToPath, URL } from "node:url";
+
+const cryptoShim = fileURLToPath(new URL("./src/shims/crypto.ts", import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      crypto: path.resolve(__dirname, "src/shims/crypto.ts"),
-      "node:crypto": path.resolve(__dirname, "src/shims/crypto.ts"),
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      crypto: cryptoShim,
+      "node:crypto": cryptoShim,
     },
   },
   define: { global: "globalThis" },


### PR DESCRIPTION
## Summary
- map `@` to `src` in `vite.config.ts` using `fileURLToPath`
- reuse `crypto` shim via constant for both `crypto` and `node:crypto`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(interrupted during Vite build)*

------
https://chatgpt.com/codex/tasks/task_e_68c04697b780832daeab9a400ac4f051