### PR TITLE
feat: run migrations before app render

### DIFF
--- a/src/debug/devAuth.ts
+++ b/src/debug/devAuth.ts
@@ -1,0 +1,3 @@
+if (import.meta.env.DEV) {
+  console.info("[devAuth] development auth enabled");
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -86,7 +86,8 @@ import App from "./App";
 import ErrorBoundary from "@/debug/ErrorBoundary";
 import { AuthProvider } from "@/context/AuthContext";
 import { HelpProvider } from "@/context/HelpProvider";
-import { initSchema } from "@/db/index";
+import { applyMigrations } from "@/db/migrate";
+import "@/debug/devAuth";
 import "./globals.css";
 import "nprogress/nprogress.css";
 import "@/i18n/i18n";
@@ -135,7 +136,12 @@ if (isTauri()) {
   );
 }
 
-await initSchema();
+try {
+  await applyMigrations();
+  console.info("[boot] migrations ok");
+} catch (e) {
+  console.error("[boot] migrations failed", e);
+}
 const root = createRoot(document.getElementById("root"));
 root.render(
   <ErrorBoundary>


### PR DESCRIPTION
## Summary
- apply database migrations before rendering the app
- add development auth stub module

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c04a1095f0832d991d2de255220982