### PR TITLE
feat: add web crypto shim and import linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/check-node-native.js && vite build",
+    "lint:node": "node scripts/check-node-native.js",
     "preview": "vite preview",
     "db:apply": "node scripts/sqlite-apply.js",
     "db:smoke": "node scripts/migration-smoke.js"

--- a/scripts/check-node-native.js
+++ b/scripts/check-node-native.js
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+
+const modules = ['fs', 'path', 'crypto'];
+const ignore = ['-g', '!src/lib/patchSupabase.ts'];
+let failed = false;
+
+for (const mod of modules) {
+  const importPattern = `from ['\"](?:node:)?${mod}['\"]`;
+  const importRes = spawnSync('rg', ['--color=never', '-n', ...ignore, importPattern, 'src']);
+  const importOut = importRes.stdout.toString().trim();
+  if (importOut) {
+    console.error(`Forbidden import detected for module "${mod}":\n${importOut}`);
+    failed = true;
+  }
+  const requirePattern = `require\\(['\"](?:node:)?${mod}['\"]\\)`;
+  const requireRes = spawnSync('rg', ['--color=never', '-n', ...ignore, requirePattern, 'src']);
+  const requireOut = requireRes.stdout.toString().trim();
+  if (requireOut) {
+    console.error(`Forbidden import detected for module "${mod}":\n${requireOut}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/src/shims/crypto.ts
+++ b/src/shims/crypto.ts
@@ -1,10 +1,25 @@
-function toHex(bytes: Uint8Array) {
-  return Array.from(bytes).map(b => b.toString(16).padStart(2,"0")).join("");
+const cryptoObj = globalThis.crypto;
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
-export function randomBytes(len: number) {
+
+export function randomBytes(len: number): Uint8Array {
   const out = new Uint8Array(len);
-  (globalThis.crypto || window.crypto).getRandomValues(out);
-  (out as any).toString = (enc?: string) => enc === "hex" ? toHex(out) : Object.prototype.toString.call(out);
+  cryptoObj.getRandomValues(out);
   return out;
 }
-export default { randomBytes };
+
+export function randomUUID(): string {
+  return cryptoObj.randomUUID();
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const enc = new TextEncoder();
+  const digest = await cryptoObj.subtle.digest("SHA-256", enc.encode(input));
+  return toHex(new Uint8Array(digest));
+}
+
+export default { randomBytes, randomUUID, sha256Hex };

--- a/src/shims/selftest.ts
+++ b/src/shims/selftest.ts
@@ -1,5 +1,7 @@
 export async function testRandom() {
-  const { randomBytes } = (window as any).cryptoShim ?? await import("/src/shims/crypto");
-  const b = randomBytes(16) as Uint8Array;
-  if (!(b && b.length === 16)) throw new Error("randomBytes failed");
+  const shim = (window as any).cryptoShim ?? (await import("/src/shims/crypto"));
+  const uuid = shim.randomUUID();
+  if (!(uuid && typeof uuid === "string")) throw new Error("randomUUID failed");
+  const hash = await shim.sha256Hex("test");
+  if (!(hash && hash.length === 64)) throw new Error("sha256Hex failed");
 }


### PR DESCRIPTION
## Summary
- add Web Crypto shim with sha256Hex and randomUUID helpers
- update shim selftest
- fail build when Node native modules are imported in client

## Testing
- `node scripts/check-node-native.js`
- `npm run build` *(fails: `"produits_create" is not exported by "src/lib/db.ts"`)*

------
https://chatgpt.com/codex/tasks/task_e_68c05ada30b0832d87be76fbcce8d194