### PR TITLE
feat: add postinstall check script and test walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cette variante, basée sur **Tauri v2**, embarque une base SQLite locale pour f
 - L'exécuter.
 
 ## Vérification post-installation
-Après l'installation, le script suivant vérifie la présence de la configuration et de la base de données :
+Après l'installation, le script suivant vérifie Node, npm, Rust (MSVC), WebView2 et la présence/lecture de la configuration et de la base de données :
 
 ```powershell
 pwsh scripts/postinstall-check.ps1
@@ -84,14 +84,14 @@ S'assurer que **VS Build Tools (C++ x64)** et le **Windows 11 SDK** sont instal
 
 Ce script installe Node.js LTS, Rustup, le toolchain `stable-x86_64-pc-windows-msvc`, les Build Tools C++ de Visual Studio, le Windows 11 SDK et le WiX Toolset via `winget`, puis lance `npm ci`, `npm run build` et `npx tauri build` (qui génère `src-tauri/icons` si nécessaire).
 
-## QA final
-Avant de publier, vérifier ce parcours :
+## Parcours test
 
-1. Se connecter avec l’administrateur créé via `npm run seed:admin`.
-2. Créer un fournisseur puis un produit.
-3. Émettre une facture (quantité 10, prix 2.5) et contrôler un PMP de 2.5 avec un stock de 10.
-4. Exporter les données, sauvegarder la base, la restaurer et vérifier le redémarrage.
-5. Démarrer une seconde instance : la première se ferme automatiquement.
+1. `npm run seed:admin` (admin@mamastock.local / Admin123!)
+2. `npm run db:apply` puis `npm run db:smoke`
+3. Lancer Vite + Tauri, se connecter
+4. Créer fournisseur + produit
+5. Créer facture (qty=10, prix=2.5) → vérifier pmp=2.5, stock=10
+6. Export CSV/XLSX, backup + restore DB, relancer app
 
 ## Publier une release Windows
 ```powershell

--- a/scripts/postinstall-check.ps1
+++ b/scripts/postinstall-check.ps1
@@ -4,49 +4,74 @@ Param(
 )
 
 $ErrorActionPreference = 'Stop'
+$exitCode = 0
 
-try {
-  # App data directory
-  if ([string]::IsNullOrWhiteSpace($AppDataDir)) {
-    Write-Warning 'AppDataDir not specified (APPDATA missing).'
-  } else {
-    if (-not (Test-Path $AppDataDir)) {
-      Write-Warning "Directory $AppDataDir not found. Creating..."
-      New-Item -ItemType Directory -Force -Path $AppDataDir | Out-Null
+function Test-Tool {
+  param(
+    [string]$Name,
+    [ScriptBlock]$Cmd
+  )
+  try {
+    $result = & $Cmd
+    if ($result) {
+      Write-Host "$Name: $result" -ForegroundColor Green
     } else {
-      Write-Host "Directory $AppDataDir exists." -ForegroundColor Green
+      Write-Host "$Name OK" -ForegroundColor Green
     }
-    $configPath = Join-Path $AppDataDir 'config.json'
-    if (Test-Path $configPath) {
-      Write-Host "config.json found at $configPath." -ForegroundColor Green
-      $configExists = $true
-    } else {
-      Write-Warning "config.json not found at $configPath."
-      $configExists = $false
-    }
+  } catch {
+    Write-Host "$Name KO" -ForegroundColor Red
+    $script:exitCode = 1
   }
-
-  # Database check
-  if ([string]::IsNullOrWhiteSpace($DataDir)) {
-    Write-Warning 'DataDir not specified (USERPROFILE missing).'
-  }
-  $dbPath = Join-Path $DataDir 'mamastock.db'
-  if (Test-Path $dbPath) {
-    Write-Host "Database found at $dbPath." -ForegroundColor Green
-    $dbExists = $true
-  } else {
-    Write-Warning "Database not found at $dbPath."
-    $dbExists = $false
-  }
-
-  if ($configExists -or $dbExists) {
-    Write-Host 'Post-installation check passed.' -ForegroundColor Green
-    exit 0
-  } else {
-    Write-Host 'Application appears to have never been launched. Run it once before rerunning this check.' -ForegroundColor Red
-    exit 1
-  }
-} catch {
-  Write-Host $_.Exception.Message -ForegroundColor Red
-  exit 1
 }
+
+Test-Tool 'Node' { node --version }
+Test-Tool 'npm' { npm --version }
+Test-Tool 'Rust (MSVC)' {
+  $host = (& rustc -Vv) | Where-Object { $_ -like 'host:*' }
+  if ($host -notmatch 'msvc') { throw "host $host" }
+}
+Test-Tool 'WebView2' {
+  Get-ItemPropertyValue -Path 'HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F1FDD2EA-9555-4F2B-86A5-EBE55007A7E2}' -Name 'pv' | Out-Null
+}
+
+Write-Host "Data directory: $DataDir"
+Write-Host "App data directory: $AppDataDir"
+
+$configPath = Join-Path $AppDataDir 'config.json'
+$dbPath = Join-Path $DataDir 'mamastock.db'
+
+Write-Host "Config file: $configPath"
+Write-Host "Database file: $dbPath"
+
+if (Test-Path $configPath) {
+  Write-Host 'config.json present.' -ForegroundColor Green
+} else {
+  Write-Warning 'config.json missing.'
+}
+
+if (Test-Path $dbPath) {
+  try {
+    [IO.File]::OpenRead($dbPath).Close()
+    Write-Host 'Database accessible.' -ForegroundColor Green
+  } catch {
+    Write-Host "Database not readable: $_" -ForegroundColor Red
+    $exitCode = 1
+  }
+} else {
+  Write-Warning 'Database not found. Running npm run db:apply...'
+  try {
+    npm run db:apply | Out-Host
+    if (Test-Path $dbPath) {
+      Write-Host "Database created at $dbPath." -ForegroundColor Green
+    } else {
+      Write-Host 'Database creation failed.' -ForegroundColor Red
+      $exitCode = 1
+    }
+  } catch {
+    Write-Host "npm run db:apply failed: $_" -ForegroundColor Red
+    $exitCode = 1
+  }
+}
+
+exit $exitCode
+


### PR DESCRIPTION
## Summary
- expand postinstall check to validate Node, npm, Rust MSVC and WebView2, print paths, and create DB if missing
- document a full test walkthrough in the README

## Testing
- `npm run db:smoke` *(fails: Cannot find package 'better-sqlite3')*
- `pwsh -NoLogo -File scripts/postinstall-check.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05aed317c832da7ef11d25e32d772