### PR TITLE
feat: seed admin user for local app

### DIFF
--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -1,34 +1,73 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import os from 'os';
-import { createHash, randomUUID } from 'crypto';
+// scripts/seed-admin.js
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
 
-async function main() {
-  const base = process.env.APPDATA || path.join(os.homedir(), '.config');
-  const dir = path.join(base, 'MamaStock');
-  await fs.mkdir(dir, { recursive: true });
-  const file = path.join(dir, 'users.json');
-  let users = [];
-  try {
-    const txt = await fs.readFile(file, 'utf8');
-    users = JSON.parse(txt);
-  } catch {
-    // ignore
-  }
-  if (users.find(u => u.email === 'admin@mamastock.local')) {
-    console.log('Admin user already exists');
-    return;
-  }
-  const salt = randomUUID();
-  const password_hash = createHash('sha256').update(`Admin123!:${salt}`).digest('hex');
-  const id = randomUUID();
-  const mama_id = 'admin';
-  users.push({ id, email: 'admin@mamastock.local', mama_id, password_hash, salt });
-  await fs.writeFile(file, JSON.stringify(users, null, 2));
-  console.log('Admin user created');
+/** Renvoie le dossier AppData conforme à Tauri appDataDir:
+ *  - Windows: %APPDATA% (ex: C:\Users\...\AppData\Roaming)
+ *  - macOS:   ~/Library/Application Support
+ *  - Linux:   ~/.config
+ */
+function appDataBase() {
+  const p = os.platform();
+  if (p === "win32") return process.env.APPDATA;
+  if (p === "darwin") return path.join(process.env.HOME ?? os.homedir(), "Library", "Application Support");
+  return path.join(process.env.HOME ?? os.homedir(), ".config");
 }
 
-main().catch(err => {
-  console.error(err);
+// Même hiérarchie que appDataDir() côté Tauri:
+const base = appDataBase();
+if (!base) {
+  console.error("APPDATA/HOME introuvable. Abandon.");
   process.exit(1);
-});
+}
+const appRoot = path.join(base, "com.mamastock.local", "MamaStock");
+const usersFile = path.join(appRoot, "users.json");
+
+fs.mkdirSync(appRoot, { recursive: true });
+
+function sha256Hex(input) {
+  return crypto.createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+function randomId() {
+  return crypto.randomUUID();
+}
+function randomMamaId() {
+  return "local-" + Math.random().toString(36).slice(2, 8);
+}
+
+const adminEmail = "admin@mamastock.local";
+const adminPassword = "Admin123!";
+
+let users = [];
+if (fs.existsSync(usersFile)) {
+  try { users = JSON.parse(fs.readFileSync(usersFile, "utf8")); }
+  catch { users = []; }
+}
+
+let user = users.find(u => u.email === adminEmail);
+const salt = crypto.randomUUID();
+const hash = sha256Hex(`${adminPassword}:${salt}`);
+
+if (!user) {
+  user = {
+    id: randomId(),
+    email: adminEmail,
+    mama_id: randomMamaId(),
+    passwordHash: hash,
+    salt,
+    createdAt: new Date().toISOString()
+  };
+  users.push(user);
+  console.info("✔ Admin créé:", adminEmail);
+} else {
+  // met à jour le mot de passe si l’admin existe déjà
+  user.salt = salt;
+  user.passwordHash = hash;
+  console.info("✔ Admin mis à jour:", adminEmail);
+}
+
+fs.writeFileSync(usersFile, JSON.stringify(users, null, 2));
+console.info("OK users.json ->", usersFile);


### PR DESCRIPTION
## Summary
- rewrite admin seeding script to handle cross-platform app data paths and update existing admin credentials

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c11ae18714832da4758f022fcefd28