### PR TITLE
feat: expand sql plugin permissions

### DIFF
--- a/src-tauri/capabilities/sql.json
+++ b/src-tauri/capabilities/sql.json
@@ -3,5 +3,10 @@
   "identifier": "sql",
   "description": "Permissions for SQL plugin",
   "windows": ["main"],
-  "permissions": ["sql:default"]
+  "permissions": [
+    "sql:default",
+    "sql:allow-load",
+    "sql:allow-execute",
+    "sql:allow-select"
+  ]
 }


### PR DESCRIPTION
## Summary
- expand SQL plugin capability permissions to allow load, execute, and select

## Testing
- `npm test` (fails: Missing script: "test")
- `cargo test` (fails: The system library `glib-2.0` required by crate `glib-sys` was not found)


------
https://chatgpt.com/codex/tasks/task_e_68c13785d1e4832db5035bdaa9969efd