### PR TITLE
Track SQLite migrations

### DIFF
--- a/scripts/sqlite-apply.js
+++ b/scripts/sqlite-apply.js
@@ -1,19 +1,47 @@
+// scripts/sqlite-apply.js
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 import Database from "better-sqlite3";
-const root = process.cwd();
-const MIGS = [
-  "db/sqlite/001_schema.sql",
-  "db/sqlite/002_seed.sql",
-  "db/sqlite/003_pmp_valeur_stock.sql",
-];
-const dbFile = path.join(process.env.USERPROFILE, "MamaStock", "data", "mamastock.db");
+
+function appDataBase() {
+  const p = os.platform();
+  if (p === "win32") return process.env.APPDATA;
+  if (p === "darwin") return path.join(process.env.HOME ?? os.homedir(), "Library", "Application Support");
+  return path.join(process.env.HOME ?? os.homedir(), ".config");
+}
+
+const base = appDataBase();
+const dbFile = path.join(base, "com.mamastock.local", "MamaStock", "data", "mamastock.db");
 fs.mkdirSync(path.dirname(dbFile), { recursive: true });
+
 const db = new Database(dbFile);
 db.pragma("journal_mode = WAL");
-for (const mig of MIGS) {
-  const sql = fs.readFileSync(path.join(root, mig), "utf8");
-  db.exec(sql);
-  console.info("applied", mig);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS __migrations__ (
+    filename   TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL
+  );
+`);
+
+const migDir = path.join(process.cwd(), "db", "sqlite");
+const files = fs.readdirSync(migDir)
+  .filter(f => f.endsWith(".sql"))
+  .sort();
+
+const hasStmt = db.prepare("SELECT 1 FROM __migrations__ WHERE filename = ?");
+const insStmt = db.prepare("INSERT INTO __migrations__ (filename, applied_at) VALUES (?, datetime('now'))");
+
+for (const file of files) {
+  if (hasStmt.get(file)) {
+    // déjà appliqué
+    continue;
+  }
+  const sql = fs.readFileSync(path.join(migDir, file), "utf8");
+  db.exec(sql); // si le SQL est bien idempotent, aucun souci ; sinon, on l’applique une seule fois
+  insStmt.run(file);
+  console.log("applied", path.join("db/sqlite", file));
 }
-console.info("OK:", dbFile);
+
+console.log("OK:", dbFile);


### PR DESCRIPTION
## Summary
- Ensure SQLite migrations only run once by tracking applied files
- Automatically run SQL scripts in db/sqlite directory when applying migrations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`
- `npm run db:apply`

------
https://chatgpt.com/codex/tasks/task_e_68c1379590cc832d8666c01baeefbc7b