### PR TITLE
feat: add auth adapter for local login and registration

### DIFF
--- a/src/auth/authAdapter.ts
+++ b/src/auth/authAdapter.ts
@@ -1,0 +1,24 @@
+// src/auth/authAdapter.ts
+import { loginLocal, registerLocal } from "@/auth/localAccount";
+import { useAuth } from "@/context/AuthContext";
+
+export function useAuthAdapter() {
+  const { signIn, signOut, user } = useAuth();
+
+  return {
+    user,
+    async login(email: string, password: string) {
+      const u = await loginLocal(email, password);
+      signIn({ id: u.id, email: u.email, mama_id: u.mama_id });
+      return u;
+    },
+    async register(email: string, password: string) {
+      const u = await registerLocal(email, password);
+      signIn({ id: u.id, email: u.email, mama_id: u.mama_id });
+      return u;
+    },
+    logout() {
+      signOut();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add useAuthAdapter hook to bridge local login/register with auth context

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c13a9e96cc832d912ad9cb1589f261