### PR TITLE
feat: bootstrap admin user in development

### DIFF
--- a/src/debug/ensureLocalAdmin.ts
+++ b/src/debug/ensureLocalAdmin.ts
@@ -1,0 +1,26 @@
+// src/debug/ensureLocalAdmin.ts
+import { registerLocal } from "@/auth/localAccount";
+
+const ADMIN_EMAIL = "admin@mamastock.local";
+const ADMIN_PASS  = "Admin123!";
+
+export async function ensureLocalAdmin() {
+  try {
+    await registerLocal(ADMIN_EMAIL, ADMIN_PASS);
+    console.info("[ensureLocalAdmin] admin local créé.");
+  } catch (e: any) {
+    // si déjà créé → on ignore "Email déjà utilisé."
+    if (String(e?.message || e).includes("Email déjà utilisé")) {
+      console.info("[ensureLocalAdmin] admin local déjà présent.");
+    } else {
+      console.warn("[ensureLocalAdmin] impossible de créer l’admin local:", e);
+    }
+  }
+}
+
+(async () => {
+  // en dev uniquement
+  if (import.meta.env.DEV) {
+    ensureLocalAdmin();
+  }
+})();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import { AuthProvider } from "@/context/AuthContext";
+import "@/debug/ensureLocalAdmin";
 import "@/debug/devAuth";
 import "./globals.css";
 import "nprogress/nprogress.css";


### PR DESCRIPTION
## Summary
- auto-register local admin account during dev startup
- import ensureLocalAdmin bootstrap in main entry

## Testing
- `npm test` (fails: Missing script)
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c13d8f5d3c832d954d83f467a51e12