### PR TITLE
feat(auth): add sqlite auth via tauri sql plugin

### DIFF
--- a/src-tauri/capabilities/sql.json
+++ b/src-tauri/capabilities/sql.json
@@ -3,10 +3,5 @@
   "identifier": "sql",
   "description": "Permissions for SQL plugin",
   "windows": ["main"],
-  "permissions": [
-    "sql:default",
-    "sql:allow-load",
-    "sql:allow-execute",
-    "sql:allow-select"
-  ]
+  "permissions": ["sql:default", "sql:allow-load"]
 }

--- a/src/auth/sqliteAuth.ts
+++ b/src/auth/sqliteAuth.ts
@@ -1,0 +1,64 @@
+// src/auth/sqliteAuth.ts
+import { appDataDir, join } from "@tauri-apps/api/path";
+import Database from "@tauri-apps/plugin-sql";
+import bcrypt from "bcryptjs";
+
+export type DbUser = {
+  id: string;
+  email: string;
+  mama_id: string;
+  mot_de_passe_hash: string;
+  salt: string | null;
+  created_at: string;
+};
+
+async function dbPath() {
+  const base = await appDataDir();
+  return await join(base, "MamaStock", "data", "mamastock.db");
+}
+
+async function openDb() {
+  const p = await dbPath();
+  // nécessite permission "sql:allow-load"
+  return await Database.load(`sqlite:${p}`);
+}
+
+export async function loginSqlite(email: string, password: string) {
+  email = email.trim().toLowerCase();
+  const db = await openDb();
+  const rows = await db.select<DbUser[]>(
+    "SELECT id,email,mama_id,mot_de_passe_hash,salt,created_at FROM users WHERE email = ? LIMIT 1",
+    [email]
+  );
+  const u = rows?.[0];
+  if (!u) throw new Error("Utilisateur introuvable.");
+
+  if (!u.mot_de_passe_hash) {
+    throw new Error("Compte non initialisé (mot de passe manquant).");
+  }
+  const ok = await bcrypt.compare(password, u.mot_de_passe_hash);
+  if (!ok) throw new Error("Mot de passe invalide.");
+
+  return { id: u.id, email: u.email, mama_id: u.mama_id };
+}
+
+export async function registerSqlite(email: string, password: string) {
+  email = email.trim().toLowerCase();
+  const db = await openDb();
+  const exists = await db.select<{ cnt: number }[]>(
+    "SELECT COUNT(*) as cnt FROM users WHERE email = ?",
+    [email]
+  );
+  if ((exists?.[0]?.cnt ?? 0) > 0) throw new Error("Email déjà utilisé.");
+
+  const hash = await bcrypt.hash(password, 10);
+  const mama_id = "local-" + Math.random().toString(36).slice(2, 8);
+  const id = crypto.randomUUID();
+
+  await db.execute(
+    "INSERT INTO users(id,email,mama_id,mot_de_passe_hash,salt,created_at) VALUES(?,?,?,?,?,datetime('now'))",
+    [id, email, mama_id, hash, ""]
+  );
+
+  return { id, email, mama_id };
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { loginSqlite, registerSqlite } from "@/auth/sqliteAuth";
 
 export type User = { id: string; email: string; mama_id: string };
 
@@ -10,6 +11,8 @@ type Ctx = {
   isAuthenticated: boolean;
   signIn: (u: User) => void;
   signOut: () => void;
+  loginWithDb?: (email: string, password: string) => Promise<void>;
+  registerWithDb?: (email: string, password: string) => Promise<void>;
 };
 
 const defaultAuth: Ctx = {
@@ -20,6 +23,8 @@ const defaultAuth: Ctx = {
   isAuthenticated: false,
   signIn: () => {},
   signOut: () => {},
+  loginWithDb: async () => {},
+  registerWithDb: async () => {},
 };
 
 const AuthContext = createContext<Ctx>(defaultAuth);
@@ -47,6 +52,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       isAuthenticated: !!user,
       signIn: (u: User) => setUser(u),
       signOut: () => setUser(null),
+      loginWithDb: async (email, password) => {
+        const u = await loginSqlite(email, password);
+        setUser(u);
+      },
+      registerWithDb: async (email, password) => {
+        const u = await registerSqlite(email, password);
+        setUser(u);
+      },
     }),
     [user]
   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { useAuthAdapter } from "@/auth/authAdapter";
+import { useAuth } from "@/context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import "./login.css";
 
 export default function LoginPage() {
   const nav = useNavigate();
-  const { login, register } = useAuthAdapter();
+  const { loginWithDb, registerWithDb } = useAuth();
   const [email, setEmail] = useState("admin@mamastock.local");
   const [password, setPassword] = useState("Admin123!");
   const [error, setError] = useState("");
@@ -14,8 +14,8 @@ export default function LoginPage() {
     e.preventDefault();
     setError("");
     try {
-      const u = await login(email, password);
-      console.info("[login] OK", u);
+      await loginWithDb(email, password);
+      console.info("[login] OK");
       nav("/"); // redirige vers le tableau de bord
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -26,8 +26,8 @@ export default function LoginPage() {
     e.preventDefault();
     setError("");
     try {
-      const u = await register(email, password);
-      console.info("[register] OK", u);
+      await registerWithDb(email, password);
+      console.info("[register] OK");
       nav("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary
- allow SQL plugin to load databases
- add SQLite-based auth helper with bcrypt password checks
- expose DB login/register helpers in auth context and login screen

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c13db14d5c832d90bafe556b4e76b0