### PR TITLE
feat: refine sidebar and routing for parametrage and debug

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -174,7 +174,7 @@ export default function Sidebar() {
               )}
               {canData && (
                 <NavLink
-                  to="/parametrage/data"
+                  to="/parametrage/dossier-donnees"
                   className={({ isActive }) =>
                     isActive ? "text-mamastockGold" : ""
                   }
@@ -185,15 +185,15 @@ export default function Sidebar() {
             </div>
           </details>
         )}
-
-        <a href="#/onboarding">Onboarding</a>
-        <Link to="/aide">Aide</Link>
         {has("feedback") && <Link to="/feedback">Feedback</Link>}
-        {import.meta.env.DEV && (
-          <Link to="/debug/auth" className="text-xs opacity-50 mt-4">
-            Debug Auth
-          </Link>
-        )}
+        <NavLink
+          to="/debug/auth"
+          className={({ isActive }) =>
+            `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`
+          }
+        >
+          Debug Auth
+        </NavLink>
       </nav>
     </aside>
   );

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { Link, useLocation } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 // Le menu latéral n'affiche que les modules pour lesquels
 // l'utilisateur possède le droit "peut_voir". Les droits proviennent
 // du contexte d'authentification (merge utilisateur + rôle).
@@ -91,9 +91,46 @@ export default function Sidebar() {
           <details open={pathname.startsWith("/parametrage")}>
             <summary className="cursor-pointer">Paramétrage</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
-              {canConfigure && <Link to="/parametrage/familles">Familles</Link>}
-              {canConfigure && <Link to="/parametrage/sous-familles">Sous-familles</Link>}
-              {canConfigure && <Link to="/parametrage/unites">Unités</Link>}
+              {canConfigure && (
+                <NavLink
+                  to="/parametrage/familles"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Familles
+                </NavLink>
+              )}
+              {canConfigure && (
+                <NavLink
+                  to="/parametrage/sous-familles"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Sous-familles
+                </NavLink>
+              )}
+              {canConfigure && (
+                <NavLink
+                  to="/parametrage/unites"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Unités
+                </NavLink>
+              )}
+              {canConfigure && (
+                <NavLink
+                  to="/parametrage/dossier-donnees"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Dossier données
+                </NavLink>
+              )}
               {has("utilisateurs") && <Link to="/parametrage/utilisateurs">Utilisateurs</Link>}
               {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
               {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}
@@ -102,10 +139,15 @@ export default function Sidebar() {
             </div>
           </details>
         )}
-
-        <a href="#/onboarding">Onboarding</a>
-        <Link to="/aide">Aide</Link>
         {has("feedback") && <Link to="/feedback">Feedback</Link>}
+        <NavLink
+          to="/debug/auth"
+          className={({ isActive }) =>
+            `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`
+          }
+        >
+          Debug Auth
+        </NavLink>
       </nav>
     </aside>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,11 @@ import {
 } from "react-router-dom";
 import Dashboard from "@/pages/Dashboard";
 import Onboarding from "@/pages/Onboarding";
+import Familles from "@/pages/parametrage/Familles";
+import SousFamilles from "@/pages/parametrage/SousFamilles";
+import Unites from "@/pages/parametrage/Unites";
+import DataFolder from "@/pages/parametrage/DataFolder";
+import AuthDebug from "@/pages/debug/AuthDebug";
 import Sidebar from "@/components/Sidebar";
 
 const isTauri = !!import.meta.env.TAURI_PLATFORM;
@@ -31,6 +36,11 @@ const routes = [
       { index: true, element: <Dashboard /> },
       { path: "dashboard", element: <Dashboard /> },
       { path: "onboarding", element: <Onboarding /> },
+      { path: "parametrage/familles", element: <Familles /> },
+      { path: "parametrage/sous-familles", element: <SousFamilles /> },
+      { path: "parametrage/unites", element: <Unites /> },
+      { path: "parametrage/dossier-donnees", element: <DataFolder /> },
+      { path: "debug/auth", element: <AuthDebug /> },
       { path: "*", element: <Navigate to="/" replace /> },
     ],
   },


### PR DESCRIPTION
## Summary
- update sidebars to remove obsolete links and add parametrage shortcuts
- wire up router with parametrage and debug auth routes using HashRouter for Tauri

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c51a353b34832d883944f934f46d77