### PR TITLE
feat: add basic local pages for sqlite

### DIFF
--- a/src/pages/Debug/Auth.tsx
+++ b/src/pages/Debug/Auth.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from '@/hooks/useAuth';
+
+export default function AuthDebug() {
+  const { id, email, mama_id, signOut } = useAuth();
+
+  return (
+    <div>
+      <h1>Debug Auth</h1>
+      <p>ID: {id}</p>
+      <p>Email: {email}</p>
+      <p>Mama ID: {mama_id}</p>
+      <button onClick={signOut}>Se déconnecter</button>
+    </div>
+  );
+}

--- a/src/pages/Parametrage/DossierDonnees.tsx
+++ b/src/pages/Parametrage/DossierDonnees.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { appDataDir, join } from '@tauri-apps/api/path';
+import { open } from '@tauri-apps/plugin-shell';
+
+export default function DossierDonnees() {
+  const [path, setPath] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const base = await appDataDir();
+        const p = await join(base, 'MamaStock', 'data');
+        setPath(p);
+      } catch {
+        setError('Chemin introuvable');
+      }
+    })();
+  }, []);
+
+  async function handleOpen() {
+    try {
+      await open(path);
+    } catch {
+      alert('Ouverture impossible');
+    }
+  }
+
+  if (error) return <div>{error}</div>;
+
+  return (
+    <div>
+      <h1>Dossier données</h1>
+      <p>{path || '...'}</p>
+      <button onClick={handleOpen}>Ouvrir</button>
+    </div>
+  );
+}

--- a/src/pages/Parametrage/Familles.tsx
+++ b/src/pages/Parametrage/Familles.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import Database from '@tauri-apps/plugin-sql';
+
+interface Famille {
+  id: number;
+  nom: string;
+}
+
+export default function Familles() {
+  const [db, setDb] = useState<any>(null);
+  const [items, setItems] = useState<Famille[]>([]);
+  const [nom, setNom] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Database.load('sqlite:mamastock.db')
+      .then(setDb)
+      .catch(() => setError('Base de données indisponible'));
+  }, []);
+
+  useEffect(() => {
+    if (db) reload();
+  }, [db]);
+
+  async function reload() {
+    try {
+      const rows = await db.select<Famille[]>(
+        'SELECT id, nom FROM familles ORDER BY nom'
+      );
+      setItems(rows);
+    } catch {
+      setError('Lecture impossible');
+    }
+  }
+
+  async function add() {
+    if (!nom) return;
+    try {
+      await db.execute('INSERT INTO familles(nom) VALUES (?)', [nom]);
+      setNom('');
+      reload();
+    } catch (e: any) {
+      if (String(e).includes('UNIQUE')) {
+        alert('Cette famille existe déjà');
+      } else {
+        alert('Erreur lors de l\'ajout');
+      }
+    }
+  }
+
+  async function remove(id: number) {
+    try {
+      await db.execute('DELETE FROM familles WHERE id = ?', [id]);
+      reload();
+    } catch {
+      alert('Suppression impossible');
+    }
+  }
+
+  if (error) return <div>{error}</div>;
+  if (!db) return <div>Chargement...</div>;
+
+  return (
+    <div>
+      <h1>Familles</h1>
+      <div>
+        <input
+          placeholder="Nom"
+          value={nom}
+          onChange={(e) => setNom(e.target.value)}
+        />
+        <button onClick={add}>Ajouter</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Nom</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((f) => (
+            <tr key={f.id}>
+              <td>{f.nom}</td>
+              <td>
+                <button onClick={() => remove(f.id)}>Supprimer</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/Parametrage/SousFamilles.tsx
+++ b/src/pages/Parametrage/SousFamilles.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import Database from '@tauri-apps/plugin-sql';
+
+interface Famille { id: number; nom: string; }
+interface SousFamille { id: number; nom: string; famille_id: number; famille: string; }
+
+export default function SousFamilles() {
+  const [db, setDb] = useState<any>(null);
+  const [items, setItems] = useState<SousFamille[]>([]);
+  const [familles, setFamilles] = useState<Famille[]>([]);
+  const [familleId, setFamilleId] = useState('');
+  const [nom, setNom] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Database.load('sqlite:mamastock.db')
+      .then(setDb)
+      .catch(() => setError('Base de données indisponible'));
+  }, []);
+
+  useEffect(() => {
+    if (db) {
+      reload();
+      loadFamilles();
+    }
+  }, [db]);
+
+  async function loadFamilles() {
+    try {
+      const rows = await db.select<Famille[]>(
+        'SELECT id, nom FROM familles ORDER BY nom'
+      );
+      setFamilles(rows);
+    } catch {
+      setError('Lecture impossible');
+    }
+  }
+
+  async function reload() {
+    try {
+      const rows = await db.select<SousFamille[]>(
+        `SELECT s.id, s.nom, s.famille_id, f.nom AS famille
+         FROM sous_familles s
+         JOIN familles f ON f.id = s.famille_id
+         ORDER BY f.nom, s.nom`
+      );
+      setItems(rows);
+    } catch {
+      setError('Lecture impossible');
+    }
+  }
+
+  async function add() {
+    if (!familleId || !nom) return;
+    try {
+      await db.execute('INSERT INTO sous_familles(famille_id, nom) VALUES (?, ?)', [
+        Number(familleId),
+        nom,
+      ]);
+      setNom('');
+      setFamilleId('');
+      reload();
+    } catch (e: any) {
+      if (String(e).includes('UNIQUE')) {
+        alert('Cette sous-famille existe déjà');
+      } else {
+        alert('Erreur lors de l\'ajout');
+      }
+    }
+  }
+
+  async function remove(id: number) {
+    try {
+      await db.execute('DELETE FROM sous_familles WHERE id = ?', [id]);
+      reload();
+    } catch {
+      alert('Suppression impossible');
+    }
+  }
+
+  if (error) return <div>{error}</div>;
+  if (!db) return <div>Chargement...</div>;
+
+  return (
+    <div>
+      <h1>Sous-familles</h1>
+      <div>
+        <select value={familleId} onChange={(e) => setFamilleId(e.target.value)}>
+          <option value="">Choisir une famille</option>
+          {familles.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.nom}
+            </option>
+          ))}
+        </select>
+        <input
+          placeholder="Nom"
+          value={nom}
+          onChange={(e) => setNom(e.target.value)}
+        />
+        <button onClick={add}>Ajouter</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Famille</th>
+            <th>Nom</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((s) => (
+            <tr key={s.id}>
+              <td>{s.famille}</td>
+              <td>{s.nom}</td>
+              <td>
+                <button onClick={() => remove(s.id)}>Supprimer</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/Parametrage/Unites.tsx
+++ b/src/pages/Parametrage/Unites.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import Database from '@tauri-apps/plugin-sql';
+
+interface Unite {
+  id: number;
+  code: string;
+  libelle: string;
+}
+
+export default function Unites() {
+  const [db, setDb] = useState<any>(null);
+  const [items, setItems] = useState<Unite[]>([]);
+  const [code, setCode] = useState('');
+  const [libelle, setLibelle] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Database.load('sqlite:mamastock.db')
+      .then(setDb)
+      .catch(() => setError('Base de données indisponible'));
+  }, []);
+
+  useEffect(() => {
+    if (db) reload();
+  }, [db]);
+
+  async function reload() {
+    try {
+      const rows = await db.select<Unite[]>(
+        'SELECT id, code, libelle FROM unites ORDER BY libelle'
+      );
+      setItems(rows);
+    } catch (e) {
+      setError('Lecture impossible');
+    }
+  }
+
+  async function add() {
+    if (!code || !libelle) return;
+    try {
+      await db.execute('INSERT INTO unites(code, libelle) VALUES (?, ?)', [
+        code,
+        libelle,
+      ]);
+      setCode('');
+      setLibelle('');
+      reload();
+    } catch (e: any) {
+      if (String(e).includes('UNIQUE')) {
+        alert('Ce code existe déjà');
+      } else {
+        alert('Erreur lors de l\'ajout');
+      }
+    }
+  }
+
+  async function remove(id: number) {
+    try {
+      await db.execute('DELETE FROM unites WHERE id = ?', [id]);
+      reload();
+    } catch {
+      alert('Suppression impossible');
+    }
+  }
+
+  if (error) return <div>{error}</div>;
+  if (!db) return <div>Chargement...</div>;
+
+  return (
+    <div>
+      <h1>Unités</h1>
+      <div>
+        <input
+          placeholder="Code"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+        />
+        <input
+          placeholder="Libellé"
+          value={libelle}
+          onChange={(e) => setLibelle(e.target.value)}
+        />
+        <button onClick={add}>Ajouter</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>Libellé</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((u) => (
+            <tr key={u.id}>
+              <td>{u.code}</td>
+              <td>{u.libelle}</td>
+              <td>
+                <button onClick={() => remove(u.id)}>Supprimer</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add standalone parametrage pages for units, families and sub-families using tauri sqlite
- expose data folder opener and auth debug page for local use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check:tauri-imports`
- `npm run check:tauri-plugins`


------
https://chatgpt.com/codex/tasks/task_e_68c51a779c88832da5fd1c6c30e596c9