### PR TITLE
chore: define sql plugin capabilities

### DIFF
--- a/src-tauri/capabilities/sql.json
+++ b/src-tauri/capabilities/sql.json
@@ -3,10 +3,5 @@
   "identifier": "sql",
   "description": "Permissions for SQL plugin",
   "windows": ["main"],
-  "permissions": [
-    "sql:default",
-    "sql:allow-load",
-    "sql:allow-execute",
-    "sql:allow-select"
-  ]
+  "permissions": ["sql:default", "sql:allow-load", "sql:allow-select", "sql:allow-execute"]
 }


### PR DESCRIPTION
## Summary
- define SQL plugin permissions for the main window

## Testing
- `for f in src-tauri/capabilities/*.json; do jq empty "$f" && echo "$f valid"; done`
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c520f43518832d9c414589dfe252fe