### PR TITLE
refactor: dynamic sql plugin import

### DIFF
--- a/src/pages/Parametrage/Familles.tsx
+++ b/src/pages/Parametrage/Familles.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import Database from '@tauri-apps/plugin-sql';
+import { getDb } from '@/lib/sql';
 
 interface Famille {
   id: number;
@@ -13,7 +13,7 @@ export default function Familles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    Database.load('sqlite:mamastock.db')
+    getDb()
       .then(setDb)
       .catch(() => setError('Base de données indisponible'));
   }, []);

--- a/src/pages/Parametrage/SousFamilles.tsx
+++ b/src/pages/Parametrage/SousFamilles.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import Database from '@tauri-apps/plugin-sql';
+import { getDb } from '@/lib/sql';
 
 interface Famille { id: number; nom: string; }
 interface SousFamille { id: number; nom: string; famille_id: number; famille: string; }
@@ -13,7 +13,7 @@ export default function SousFamilles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    Database.load('sqlite:mamastock.db')
+    getDb()
       .then(setDb)
       .catch(() => setError('Base de données indisponible'));
   }, []);


### PR DESCRIPTION
## Summary
- use dynamic import for Tauri SQL plugin with caching helper
- access DB through getDb in Parametrage pages

## Testing
- `npm test` (fails: Missing script)
- `npm run check:tauri-imports`
- `npm run check:tauri-plugins`


------
https://chatgpt.com/codex/tasks/task_e_68c528d2d4b4832db0889d43b5c6d0e9