### PR TITLE
refactor: unify database access helpers

### DIFF
--- a/src/appFs.ts
+++ b/src/appFs.ts
@@ -1,12 +1,12 @@
 import { configPath } from "@/lib/paths";
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 
 export type Config = Record<string, any>;
 const LS_KEY = "config.json";
 
 export async function readConfig(): Promise<Config | null> {
-  if (!isTauri()) {
+  if (!isTauri) {
     const v = localStorage.getItem(LS_KEY);
     return v ? JSON.parse(v) : null;
   }
@@ -21,7 +21,7 @@ export async function readConfig(): Promise<Config | null> {
 }
 
 export async function writeConfig(cfg: Config): Promise<void> {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.setItem(LS_KEY, JSON.stringify(cfg));
     return;
   }

--- a/src/auth/localAccount.ts
+++ b/src/auth/localAccount.ts
@@ -1,4 +1,4 @@
-import { isTauri } from "@/lib/runtime";
+import { isTauri } from "@/lib/db/sql";
 const APP_DIR = "MamaStock";
 const USERS_FILE = "users.json";
 

--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,11 +1,11 @@
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;
   if (!show) return null;
 
   const openDev = async () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
@@ -15,7 +15,7 @@ export default function DebugRibbon() {
   };
 
   const openLogs = async () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
@@ -31,10 +31,10 @@ export default function DebugRibbon() {
 
   return (
     <div className="fixed top-0 right-0 m-2 flex gap-2 z-50 text-xs bg-black/50 text-white rounded p-1">
-      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openDev} disabled={!isTauri()}>
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openDev} disabled={!isTauri}>
         Ouvrir DevTools
       </button>
-      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openLogs} disabled={!isTauri()}>
+      <button className="px-2 py-1 hover:bg-black/30 rounded" onClick={openLogs} disabled={!isTauri}>
         Voir le fichier de logs
       </button>
     </div>

--- a/src/debug/dbSmoke.ts
+++ b/src/debug/dbSmoke.ts
@@ -1,5 +1,4 @@
-import { getDb } from "@/lib/sql";
-import { isTauri } from "@/lib/runtime";
+import { getDb, isTauri } from "@/lib/db/sql";
 
 (async () => {
   if (!isTauri) return;

--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export default function useAlerteStockFaible() {
   const { mama_id } = useAuth();

--- a/src/hooks/gadgets/useConsoMoyenne.js
+++ b/src/hooks/gadgets/useConsoMoyenne.js
@@ -1,10 +1,41 @@
 import { useState, useEffect, useCallback } from 'react';
-import { requisitions_quantites_since } from "@/lib/db";
-
 import { useAuth } from '@/hooks/useAuth';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export async function fetchConsoMoyenne(mamaId, sinceISO) {
-  return await requisitions_quantites_since(mamaId, sinceISO);
+  if (!isTauri) {
+    console.info('fetchConsoMoyenne: ignoré hors Tauri');
+    return { conso: 0 };
+  }
+  try {
+    const db = await getDb();
+    const rows = await db.select(
+      `SELECT rl.quantite, r.date_requisition
+         FROM requisition_lignes rl
+         JOIN requisitions r ON r.id = rl.requisition_id
+        WHERE r.mama_id = ?
+          AND r.statut = 'réalisée'
+          AND r.date_requisition >= ?
+        ORDER BY r.date_requisition ASC`,
+      [mamaId, sinceISO]
+    );
+    const daily = {};
+    (rows || []).forEach((m) => {
+      const d = m.date_requisition?.slice(0, 10);
+      if (!daily[d]) daily[d] = 0;
+      daily[d] += Number(m.quantite || 0);
+    });
+    const values = Object.values(daily);
+    const avg = values.length ? values.reduce((a, b) => a + b, 0) / values.length : 0;
+    return { conso: avg };
+  } catch (e) {
+    const msg = String(e?.message || e);
+    if (msg.includes('sql.load not allowed')) {
+      console.warn('fetchConsoMoyenne: sql.load not allowed – TODO vérifier src-tauri/capabilities/sql.json');
+      return { conso: 0 };
+    }
+    throw e;
+  }
 }
 
 export default function useConsoMoyenne() {
@@ -20,21 +51,12 @@ export default function useConsoMoyenne() {
     try {
       const start = new Date();
       start.setDate(start.getDate() - 7);
-      const data = await fetchConsoMoyenne(mama_id, start.toISOString());
-
-      const daily = {};
-      (data || []).forEach((m) => {
-        const d = m.date_requisition?.slice(0, 10);
-        if (!daily[d]) daily[d] = 0;
-        daily[d] += Number(m.quantite || 0);
-      });
-      const values = Object.values(daily);
-      const avgValue = values.length ? values.reduce((a, b) => a + b, 0) / values.length : 0;
-      setAvg(avgValue);
+      const { conso } = await fetchConsoMoyenne(mama_id, start.toISOString());
+      setAvg(conso);
       if (import.meta.env.DEV) {
         console.debug('Chargement dashboard terminé');
       }
-      return avgValue;
+      return conso;
     } catch (e) {
       console.warn('useConsoMoyenne', e);
       setError(e);

--- a/src/hooks/gadgets/useDerniersAcces.js
+++ b/src/hooks/gadgets/useDerniersAcces.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export default function useDerniersAcces() {
   const { mama_id } = useAuth();

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -1,8 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { createAsyncState } from '../_shared/createAsyncState';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export default function useEvolutionAchats() {
   const { mama_id, loading: authLoading } = useAuth() || {};

--- a/src/hooks/gadgets/useProduitsUtilises.js
+++ b/src/hooks/gadgets/useProduitsUtilises.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export default function useProduitsUtilises() {
   const { mama_id } = useAuth();

--- a/src/hooks/gadgets/useTachesUrgentes.js
+++ b/src/hooks/gadgets/useTachesUrgentes.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export default function useTachesUrgentes() {
   const { mama_id } = useAuth();

--- a/src/hooks/useAdvancedStats.js
+++ b/src/hooks/useAdvancedStats.js
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { isTauri } from "@/lib/runtime";
-import { getDb } from "@/lib/sql";
+import { getDb, isTauri } from "@/lib/db/sql";
 
 export function useAdvancedStats() {
   const [data, setData] = useState([]);

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 /**
  * Hook for low stock alerts based on v_alertes_rupture_api view.

--- a/src/hooks/useFournisseurStats.js
+++ b/src/hooks/useFournisseurStats.js
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { isTauri } from '@/lib/runtime';
-import { getDb } from '@/lib/sql';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 // Stats d’évolution d’achats (tous fournisseurs ou par fournisseur)
 export function useFournisseurStats() {

--- a/src/hooks/useInventaireZones.js
+++ b/src/hooks/useInventaireZones.js
@@ -3,8 +3,7 @@ import { useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { zones_stock_list } from '@/lib/db';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 import { toast } from 'sonner';
 
 export function useInventaireZones() {

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -12,8 +12,7 @@ import {
   inventaire_cloture,
   inventaire_last_closed,
 } from '@/lib/db';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export function useInventaires() {
   const { mama_id } = useAuth();

--- a/src/hooks/useProduitLineDefaults.js
+++ b/src/hooks/useProduitLineDefaults.js
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { isTauri } from "@/lib/runtime";
-import { getDb } from "@/lib/sql";
+import { getDb, isTauri } from "@/lib/db/sql";
 
 // Returns defaults for an invoice line when a product is selected.
 // In the local offline mode we only provide PMP from the produits table.

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { isTauri } from "@/lib/runtime";
-import { getDb } from "@/lib/sql";
+import { getDb, isTauri } from "@/lib/db/sql";
 
 export function useProduitsFournisseur() {
   const [cache, setCache] = useState({});

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -1,6 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export function useRuptureAlerts() {
   const { mama_id } = useAuth();

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -7,8 +7,7 @@ import {
   inventaires_list,
   inventaire_create,
 } from '@/lib/db';
-import { getDb } from '@/lib/sql';
-import { isTauri } from '@/lib/runtime';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 export function useStock() {
   const { mama_id } = useAuth();

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -7,7 +7,7 @@ import LanguageSelector from "@/components/ui/LanguageSelector";
 import { shutdownDbSafely } from "@/lib/shutdown";
 import { releaseLock } from "@/lib/lock";
 import { getDataDir } from "@/lib/db";
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 
 export default function Navbar() {
   const { t } = useTranslation();
@@ -43,7 +43,7 @@ export default function Navbar() {
     }, []);
 
     const handleQuit = useCallback(async () => {
-      if (!isTauri()) {
+      if (!isTauri) {
         return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
       }
       const { appWindow } = await import("@tauri-apps/api/window");
@@ -115,7 +115,7 @@ export default function Navbar() {
               <button
                 onClick={handleQuit}
                 className="text-sm bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded-md transition"
-                disabled={!isTauri()}
+                disabled={!isTauri}
               >
         Quitter & synchroniser
       </button>

--- a/src/lib/dal/fournisseurs.ts
+++ b/src/lib/dal/fournisseurs.ts
@@ -1,5 +1,4 @@
-import { getDb } from "@/lib/sql";
-import { isTauri } from "@/lib/runtime";
+import { getDb, isTauri } from "@/lib/db/sql";
 import type { Fournisseur } from "@/lib/types";
 
 export async function listFournisseurs(): Promise<Fournisseur[]> {

--- a/src/lib/dal/produits.ts
+++ b/src/lib/dal/produits.ts
@@ -1,5 +1,4 @@
-import { getDb } from "@/lib/sql";
-import { isTauri } from "@/lib/runtime";
+import { getDb, isTauri } from "@/lib/db/sql";
 import type { Produit } from "@/lib/types";
 
 export async function listProduits(actif?: boolean): Promise<Produit[]> {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,7 @@
 import { getDb as baseGetDb, closeDb as baseCloseDb } from "@/lib/db/sql";
 import { dataDbPath, inAppDir } from "@/lib/paths";
 import { readConfig, writeConfig } from "@/appFs";
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 
 export async function getDb() {
   return baseGetDb();
@@ -534,7 +534,7 @@ export async function maintenanceDb() {
 
 // Config helpers for data/export directories
 export async function getDataDir() {
-  if (!isTauri()) return "";
+  if (!isTauri) return "";
   const cfg = (await readConfig()) || {};
   return cfg.dataDir || (await inAppDir("data"));
 }
@@ -546,7 +546,7 @@ export async function setDataDir(dir: string) {
 }
 
 export async function getExportDir() {
-  if (!isTauri()) return "";
+  if (!isTauri) return "";
   const cfg = (await readConfig()) || {};
   return cfg.exportDir || (await inAppDir("export"));
 }

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -5,11 +5,11 @@ import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { dump } from 'js-yaml';
 import { getExportDir } from '@/lib/db';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 
 async function resolveExportPath(filename) {
   const dir = await getExportDir();
-  if (!isTauri()) return filename;
+  if (!isTauri) return filename;
   const fs = await import('@tauri-apps/plugin-fs');
   const { join } = await import('@tauri-apps/api/path');
   await fs.mkdir(dir, { recursive: true });
@@ -17,7 +17,7 @@ async function resolveExportPath(filename) {
 }
 
 async function saveBlob(blob, filename, useDialog = true) {
-  if (isTauri()) {
+  if (isTauri) {
     const fs = await import('@tauri-apps/plugin-fs');
     const { save } = await import('@tauri-apps/plugin-dialog');
     const defaultPath = await resolveExportPath(filename);

--- a/src/lib/familles.ts
+++ b/src/lib/familles.ts
@@ -1,4 +1,4 @@
-import { getDb } from "@/lib/sql";
+import { getDb } from "@/lib/db/sql";
 
 export interface Famille {
   id: number;

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { shutdownDbSafely } from "./shutdown";
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 import { locksPath, inAppDir } from "@/lib/paths";
 
 const TTL = 20_000; // 20s
@@ -11,7 +11,7 @@ const instanceId = uuidv4();
 let heartbeat: ReturnType<typeof setInterval> | null = null;
 
 async function readLock() {
-  if (!isTauri()) {
+  if (!isTauri) {
     const v = localStorage.getItem(`${BROWSER_NS}:db.lock.json`);
     return v ? JSON.parse(v) : null;
   }
@@ -23,7 +23,7 @@ async function readLock() {
 }
 
 async function writeLock(data: any) {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.setItem(`${BROWSER_NS}:db.lock.json`, JSON.stringify(data));
     return;
   }
@@ -34,7 +34,7 @@ async function writeLock(data: any) {
 }
 
 async function removeLock() {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.removeItem(`${BROWSER_NS}:db.lock.json`);
     return;
   }
@@ -44,7 +44,7 @@ async function removeLock() {
 }
 
 async function readShutdownRequest() {
-  if (!isTauri()) {
+  if (!isTauri) {
     const v = localStorage.getItem(`${BROWSER_NS}:shutdown.request.json`);
     return v ? JSON.parse(v) : null;
   }
@@ -56,7 +56,7 @@ async function readShutdownRequest() {
 }
 
 async function writeShutdownRequest(data: any) {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.setItem(`${BROWSER_NS}:shutdown.request.json`, JSON.stringify(data));
     return;
   }
@@ -67,7 +67,7 @@ async function writeShutdownRequest(data: any) {
 }
 
 async function removeShutdownRequest() {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.removeItem(`${BROWSER_NS}:shutdown.request.json`);
     return;
   }
@@ -77,7 +77,7 @@ async function removeShutdownRequest() {
 }
 
 export async function ensureSingleOwner(waitMs = 30_000) {
-  if (!isTauri()) {
+  if (!isTauri) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
   const start = Date.now();
@@ -116,7 +116,7 @@ export async function ensureSingleOwner(waitMs = 30_000) {
 }
 
 export async function monitorShutdownRequests() {
-  if (!isTauri()) {
+  if (!isTauri) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
   const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
@@ -139,14 +139,14 @@ export async function monitorShutdownRequests() {
 }
 
 export async function requestRemoteShutdown() {
-  if (!isTauri()) {
+  if (!isTauri) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
   await writeShutdownRequest({ ts: Date.now(), requester: instanceId });
 }
 
 export async function releaseLock() {
-  if (!isTauri()) {
+  if (!isTauri) {
     return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
   }
   if (heartbeat) {

--- a/src/lib/sousFamilles.ts
+++ b/src/lib/sousFamilles.ts
@@ -1,4 +1,4 @@
-import { getDb } from "@/lib/sql";
+import { getDb } from "@/lib/db/sql";
 
 export async function listSousFamilles() {
   const db = await getDb();

--- a/src/lib/unites.ts
+++ b/src/lib/unites.ts
@@ -1,4 +1,4 @@
-import { getDb } from "@/lib/sql";
+import { getDb } from "@/lib/db/sql";
 
 export interface Unite {
   id: number;

--- a/src/pages/DossierDonnees.jsx
+++ b/src/pages/DossierDonnees.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 
 export default function DossierDonnees() {
   const [baseDir, setBaseDir] = useState('');
@@ -8,7 +8,7 @@ export default function DossierDonnees() {
   const [dbExists, setDbExists] = useState(false);
 
   const refresh = async () => {
-    if (!isTauri()) return;
+    if (!isTauri) return;
     const { appDataDir, join } = await import('@tauri-apps/api/path');
     const { exists, mkdir } = await import('@tauri-apps/plugin-fs');
     const root = await appDataDir();
@@ -27,13 +27,13 @@ export default function DossierDonnees() {
   }, []);
 
   const openDir = async () => {
-    if (!isTauri()) return;
+    if (!isTauri) return;
     const { open } = await import('@tauri-apps/plugin-shell');
     await open(baseDir);
   };
 
   const ensureDir = async () => {
-    if (!isTauri()) return;
+    if (!isTauri) return;
     const { mkdir, exists } = await import('@tauri-apps/plugin-fs');
     const { join } = await import('@tauri-apps/api/path');
     await mkdir(baseDir, { recursive: true });
@@ -54,8 +54,8 @@ export default function DossierDonnees() {
         )}
       </div>
       <div className="flex gap-2">
-        <Button onClick={openDir} disabled={!isTauri()}>Ouvrir le dossier</Button>
-        <Button onClick={ensureDir} disabled={!isTauri()}>Créer si manquant</Button>
+        <Button onClick={openDir} disabled={!isTauri}>Ouvrir le dossier</Button>
+        <Button onClick={ensureDir} disabled={!isTauri}>Créer si manquant</Button>
       </div>
     </div>
   );

--- a/src/pages/Parametrage/Familles.tsx
+++ b/src/pages/Parametrage/Familles.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getDb } from '@/lib/sql';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 interface Famille {
   id: number;
@@ -13,6 +13,10 @@ export default function Familles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTauri) {
+      setError('Base de données indisponible');
+      return;
+    }
     getDb()
       .then(setDb)
       .catch(() => setError('Base de données indisponible'));

--- a/src/pages/Parametrage/SousFamilles.tsx
+++ b/src/pages/Parametrage/SousFamilles.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getDb } from '@/lib/sql';
+import { getDb, isTauri } from '@/lib/db/sql';
 
 interface Famille { id: number; nom: string; }
 interface SousFamille { id: number; nom: string; famille_id: number; famille: string; }
@@ -13,6 +13,10 @@ export default function SousFamilles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTauri) {
+      setError('Base de données indisponible');
+      return;
+    }
     getDb()
       .then(setDb)
       .catch(() => setError('Base de données indisponible'));

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import TableHeader from '@/components/ui/TableHeader';
 import GlassCard from '@/components/ui/GlassCard';
@@ -178,7 +178,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'excel' })
                     }
-                    disabled={exporting || !isTauri()}
+                    disabled={exporting || !isTauri}
                   >
                     Export Excel
                   </Button>
@@ -187,7 +187,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'csv' })
                     }
-                    disabled={exporting || !isTauri()}
+                    disabled={exporting || !isTauri}
                   >
                     Export CSV
                   </Button>
@@ -196,7 +196,7 @@ export default function Factures() {
                     onClick={() =>
                       exportData({ type: 'factures', format: 'pdf' })
                     }
-                    disabled={exporting || !isTauri()}
+                    disabled={exporting || !isTauri}
                   >
                     Export PDF
                   </Button>
@@ -223,7 +223,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'excel' })
                       }
-                      disabled={exporting || !isTauri()}
+                      disabled={exporting || !isTauri}
                     >
                       Export Excel
                     </DropdownMenuItem>
@@ -231,7 +231,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'csv' })
                       }
-                      disabled={exporting || !isTauri()}
+                      disabled={exporting || !isTauri}
                     >
                       Export CSV
                     </DropdownMenuItem>
@@ -239,7 +239,7 @@ export default function Factures() {
                       onSelect={() =>
                         exportData({ type: 'factures', format: 'pdf' })
                       }
-                      disabled={exporting || !isTauri()}
+                      disabled={exporting || !isTauri}
                     >
                       Export PDF
                     </DropdownMenuItem>

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -17,7 +17,7 @@ import FournisseurRow from '@/components/fournisseurs/FournisseurRow';
 import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
 import { toast } from 'sonner';
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 import {
   ResponsiveContainer,
   LineChart,
@@ -216,13 +216,13 @@ export default function Fournisseurs() {
                 <PlusCircle className="mr-2" size={18} /> Ajouter fournisseur
               </Button>
             )}
-            <Button className="w-auto" onClick={() => handleExport('excel')} disabled={exporting || !isTauri()}>
+            <Button className="w-auto" onClick={() => handleExport('excel')} disabled={exporting || !isTauri}>
               Export Excel
             </Button>
-            <Button className="w-auto" onClick={() => handleExport('csv')} disabled={exporting || !isTauri()}>
+            <Button className="w-auto" onClick={() => handleExport('csv')} disabled={exporting || !isTauri}>
               Export CSV
             </Button>
-            <Button className="w-auto" onClick={() => handleExport('pdf')} disabled={exporting || !isTauri()}>
+            <Button className="w-auto" onClick={() => handleExport('pdf')} disabled={exporting || !isTauri}>
               Export PDF
             </Button>
             <Button className="w-auto" onClick={handleDiag}>

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import TableContainer from '@/components/ui/TableContainer';
 import useExportCompta from '@/hooks/useExportCompta';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 
 export default function ExportComptaPage() {
   const { generateJournalCsv, exportToERP, loading } = useExportCompta();
@@ -20,7 +20,7 @@ export default function ExportComptaPage() {
   };
 
   const handleDownload = () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     return generateJournalCsv(mois, true);
@@ -57,7 +57,7 @@ export default function ExportComptaPage() {
         <Button onClick={handlePreview} disabled={loading}>
           Aperçu
         </Button>
-        <Button onClick={handleDownload} disabled={loading || !isTauri()}>
+        <Button onClick={handleDownload} disabled={loading || !isTauri}>
           Télécharger
         </Button>
       </div>

--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -1,10 +1,10 @@
 import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
 import { toast } from "sonner";
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 
 export default function SystemTools() {
   const backup = async () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
@@ -16,7 +16,7 @@ export default function SystemTools() {
   };
 
   const restore = async () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
@@ -34,7 +34,7 @@ export default function SystemTools() {
   };
 
   const maintain = async () => {
-    if (!isTauri()) {
+    if (!isTauri) {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
@@ -49,9 +49,9 @@ export default function SystemTools() {
     <div className="p-4 space-y-4">
       <h1 className="text-xl">Outils système</h1>
       <div className="flex gap-2">
-        <button onClick={backup} className="border px-2 py-1" disabled={!isTauri()}>Sauvegarder</button>
-        <button onClick={restore} className="border px-2 py-1" disabled={!isTauri()}>Restaurer</button>
-        <button onClick={maintain} className="border px-2 py-1" disabled={!isTauri()}>Maintenance</button>
+        <button onClick={backup} className="border px-2 py-1" disabled={!isTauri}>Sauvegarder</button>
+        <button onClick={restore} className="border px-2 py-1" disabled={!isTauri}>Restaurer</button>
+        <button onClick={maintain} className="border px-2 py-1" disabled={!isTauri}>Maintenance</button>
       </div>
     </div>
   );

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -20,7 +20,7 @@ import { useAuth } from '@/hooks/useAuth';
 import ProduitRow from "@/components/produits/ProduitRow";
 import ModalImportProduits from "@/components/produits/ModalImportProduits";
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/tauriEnv';
+import { isTauri } from '@/lib/db/sql';
 
 const PAGE_SIZE = 50;
 
@@ -235,7 +235,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('excel')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting || !isTauri()}
+              disabled={rows.length === 0 || exporting || !isTauri}
             >
               Export Excel
             </Button>
@@ -243,7 +243,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('csv')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting || !isTauri()}
+              disabled={rows.length === 0 || exporting || !isTauri}
             >
               Export CSV
             </Button>
@@ -251,7 +251,7 @@ export default function Produits() {
               className="min-w-[140px]"
               onClick={() => handleExport('pdf')}
               icon={FileDownIcon}
-              disabled={rows.length === 0 || exporting || !isTauri()}
+              disabled={rows.length === 0 || exporting || !isTauri}
             >
               Export PDF
             </Button>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,7 +13,7 @@ import Unites from "@/pages/parametrage/Unites";
 import DossierDonnees from "@/pages/DossierDonnees";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import Sidebar from "@/components/Sidebar";
-import { isTauri } from "@/lib/runtime";
+import { isTauri } from "@/lib/db/sql";
 
 function AppLayout() {
   return (

--- a/src/tauri/fsStore.ts
+++ b/src/tauri/fsStore.ts
@@ -1,4 +1,4 @@
-import { isTauri } from "./isTauri";
+import { isTauri } from "@/lib/db/sql";
 import { inAppDir } from "@/lib/paths";
 
 type Json = unknown;
@@ -8,7 +8,7 @@ const BROWSER_NS = "mamastock";
 function lsKey(rel: string) { return `${BROWSER_NS}:${rel.replace(/\\/g,'/')}`; }
 
 export async function readJsonFile(rel: string): Promise<Json | null> {
-  if (!isTauri()) {
+  if (!isTauri) {
     const v = localStorage.getItem(lsKey(rel));
     return v ? JSON.parse(v) : null;
   }
@@ -24,7 +24,7 @@ export async function readJsonFile(rel: string): Promise<Json | null> {
 }
 
 export async function writeJsonFile(rel: string, data: Json): Promise<string> {
-  if (!isTauri()) {
+  if (!isTauri) {
     localStorage.setItem(lsKey(rel), JSON.stringify(data));
     return rel;
   }
@@ -39,7 +39,7 @@ export async function writeJsonFile(rel: string, data: Json): Promise<string> {
 }
 
 export async function ensureDataDir(): Promise<string> {
-  if (!isTauri()) return "localStorage://" + BROWSER_NS;
+  if (!isTauri) return "localStorage://" + BROWSER_NS;
   const fs = await import("@tauri-apps/plugin-fs");
   const root = await inAppDir("data");
   const mkdir = (fs as any).createDir ?? (fs as any).mkdir;

--- a/src/tauriEnv.ts
+++ b/src/tauriEnv.ts
@@ -1,1 +1,1 @@
-export { isTauri } from "./tauri/isTauri";
+export { isTauri } from "@/lib/db/sql";

--- a/src/tauriLog.ts
+++ b/src/tauriLog.ts
@@ -8,10 +8,10 @@ export type LogApi = {
 
 let api: Partial<LogApi> | null = null;
 
-import { isTauri } from "@/tauriEnv";
+import { isTauri } from "@/lib/db/sql";
 
 export async function initLog() {
-  if (isTauri() && import.meta.env.PROD) {
+  if (isTauri && import.meta.env.PROD) {
     try {
       api = (await import("@tauri-apps/plugin-log")) as any;
     } catch {


### PR DESCRIPTION
## Summary
- replace legacy `@/lib/sql` imports with `@/lib/db/sql`
- centralize `isTauri` import and use boolean guards before DB access
- rewrite `useConsoMoyenne` to use `getDb()` with graceful error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check:tauri-imports`


------
https://chatgpt.com/codex/tasks/task_e_68c52df3b178832d83270f93da9a5518