### PR TITLE
fix: align front SQLite path with Node scripts

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -1,5 +1,6 @@
 // src/lib/db/sql.ts
 import { isTauri, requireTauri } from "../runtime";
+import { homeDir, join } from "@tauri-apps/api/path";
 
 // Cache db unique
 let _db: any | null = null;
@@ -16,7 +17,9 @@ export async function getDb() {
 
   try {
     // fichier dans AppData/Roaming/MamaStock/data/mamastock.db (côté plugin)
-    _db = await Database.load("sqlite:mamastock.db");
+    const base = await homeDir();
+    const abs  = await join(base, "MamaStock", "data", "mamastock.db");
+    _db = await Database.load(`sqlite:${abs}`);
     return _db;
   } catch (e: any) {
     const msg = String(e?.message || e);


### PR DESCRIPTION
## Summary
- use `homeDir` and `join` to compute absolute SQLite path
- load SQLite DB from absolute path to match Node scripts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: Tauri required: run via `npx tauri dev` to access SQLite)*

------
https://chatgpt.com/codex/tasks/task_e_68c5305fd0f8832d8728428ab6378c6b