### PR TITLE
feat: add Tauri guard to configuration pages

### DIFF
--- a/src/pages/DossierDonnees.jsx
+++ b/src/pages/DossierDonnees.jsx
@@ -3,6 +3,16 @@ import { Button } from '@/components/ui/button';
 import { isTauri } from '@/lib/db/sql';
 
 export default function DossierDonnees() {
+  if (!isTauri) {
+    return (
+      <div className="p-6 text-sm">
+        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
+        <p>
+          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
+        </p>
+      </div>
+    );
+  }
   const [baseDir, setBaseDir] = useState('');
   const [dbPath, setDbPath] = useState('');
   const [dbExists, setDbExists] = useState(false);

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -8,8 +8,19 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
+import { isTauri } from '@/lib/db/sql';
 
 export default function Familles() {
+  if (!isTauri) {
+    return (
+      <div className="p-6 text-sm">
+        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
+        <p>
+          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
+        </p>
+      </div>
+    );
+  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [familles, setFamilles] = useState([]);

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -9,8 +9,19 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
+import { isTauri } from '@/lib/db/sql';
 
 export default function SousFamilles() {
+  if (!isTauri) {
+    return (
+      <div className="p-6 text-sm">
+        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
+        <p>
+          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
+        </p>
+      </div>
+    );
+  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [sousFamilles, setSousFamilles] = useState([]);

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -8,8 +8,19 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
+import { isTauri } from '@/lib/db/sql';
 
 export default function Unites() {
+  if (!isTauri) {
+    return (
+      <div className="p-6 text-sm">
+        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
+        <p>
+          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
+        </p>
+      </div>
+    );
+  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [unites, setUnites] = useState([]);


### PR DESCRIPTION
## Summary
- add Tauri-only UI guard to Units, Families, Subfamilies and data folder pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5307ce828832d920f71f881d753ee