### PR TITLE
feat: add dashboard sql helpers

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -40,3 +40,42 @@ export async function closeDb() {
   }
 }
 
+// --- ident safe (pas d'injection d'identifiants) ---
+function _assertIdent(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid identifier: ${name}`);
+  }
+  return name;
+}
+
+/** Compte les lignes d'une table */
+export async function tableCount(table: string): Promise<number> {
+  const db = await getDb();
+  const t = _assertIdent(table);
+  const rows = await db.select(`SELECT COUNT(*) AS c FROM ${t}`);
+  const n = rows?.[0]?.c ?? 0;
+  return Number(n);
+}
+
+/** Compte plusieurs tables d'un coup */
+export async function tableCounts(tables: string[]): Promise<Record<string, number>> {
+  const db = await getDb();
+  const out: Record<string, number> = {};
+  for (const tname of tables) {
+    const t = _assertIdent(tname);
+    const r = await db.select(`SELECT COUNT(*) AS c FROM ${t}`);
+    out[tname] = Number(r?.[0]?.c ?? 0);
+  }
+  return out;
+}
+
+/** Récupère les KPI depuis la vue si elle existe */
+export async function getDashboardKPI(): Promise<any[]> {
+  const db = await getDb();
+  try {
+    return await db.select(`SELECT * FROM v_dashboard_kpi`);
+  } catch {
+    return [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- add helper to safely validate SQL table identifiers
- expose helpers to count rows across tables
- expose KPI fetcher from optional view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c532da8298832db83dc8538c232132