### PR TITLE
Ensure Dashboard imports isTauri and tableCount

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -8,7 +8,7 @@ import GadgetTachesUrgentes from '@/components/gadgets/GadgetTachesUrgentes';
 import GadgetConsoMoyenne from '@/components/gadgets/GadgetConsoMoyenne';
 import GadgetDerniersAcces from '@/components/gadgets/GadgetDerniersAcces';
 import React, { useEffect, useState } from 'react';
-import { tableCount, isTauri } from '@/lib/db/sql';
+import { isTauri, tableCount } from '@/lib/db/sql';
 
 export default function Dashboard() {
   const [needsOnboarding, setNeedsOnboarding] = useState(false);


### PR DESCRIPTION
## Summary
- Keep both `isTauri` and `tableCount` imports in `Dashboard.jsx` to guarantee Tauri-aware onboarding logic.

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c532ff4678832d95814c489be6e623