### PR TITLE
refactor: unify isTauri imports and remove UI guards

### DIFF
--- a/src/appFs.ts
+++ b/src/appFs.ts
@@ -1,5 +1,5 @@
 import { configPath } from "@/lib/paths";
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 
 export type Config = Record<string, any>;

--- a/src/auth/localAccount.ts
+++ b/src/auth/localAccount.ts
@@ -1,4 +1,4 @@
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 const APP_DIR = "MamaStock";
 const USERS_FILE = "users.json";
 

--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,4 +1,4 @@
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;

--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -48,7 +48,6 @@ export default function useAlerteStockFaible() {
   );
 
     useEffect(() => {
-      if (!isTauri) return;
       const controller = new AbortController();
       fetchData(controller.signal);
       return () => controller.abort();

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -37,7 +37,7 @@ export default function useEvolutionAchats() {
   );
 
     useEffect(() => {
-      if (authLoading || !isTauri) return;
+      if (authLoading) return;
       const controller = new AbortController();
       fetchData(controller.signal);
       return () => controller.abort();

--- a/src/hooks/gadgets/useTachesUrgentes.js
+++ b/src/hooks/gadgets/useTachesUrgentes.js
@@ -47,7 +47,6 @@ export default function useTachesUrgentes() {
   );
 
     useEffect(() => {
-      if (!isTauri) return;
       const controller = new AbortController();
       fetchData(controller.signal);
       return () => controller.abort();

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -50,7 +50,7 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
     );
 
     useEffect(() => {
-      if (!mama_id || !isTauri) return;
+      if (!mama_id) return;
       const controller = new AbortController();
       fetchData(controller.signal);
       return () => controller.abort();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,6 @@
-import { getDb as baseGetDb, closeDb as baseCloseDb } from "@/lib/db/sql";
+import { getDb as baseGetDb, closeDb as baseCloseDb, isTauri } from "@/lib/db/sql";
 import { dataDbPath, inAppDir } from "@/lib/paths";
 import { readConfig, writeConfig } from "@/appFs";
-import { isTauri } from "@/lib/db/sql";
 
 export async function getDb() {
   return baseGetDb();

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -5,7 +5,7 @@ import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { dump } from 'js-yaml';
 import { getExportDir } from '@/lib/db';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 async function resolveExportPath(filename) {
   const dir = await getExportDir();

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { shutdownDbSafely } from "./shutdown";
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 import { locksPath, inAppDir } from "@/lib/paths";
 
 const TTL = 20_000; // 20s

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -8,7 +8,7 @@ import GadgetTachesUrgentes from '@/components/gadgets/GadgetTachesUrgentes';
 import GadgetConsoMoyenne from '@/components/gadgets/GadgetConsoMoyenne';
 import GadgetDerniersAcces from '@/components/gadgets/GadgetDerniersAcces';
 import React, { useEffect, useState } from 'react';
-import { isTauri, tableCount } from '@/lib/db/sql';
+import { isTauri, getDb, tableCount } from '@/lib/db/sql';
 
 export default function Dashboard() {
   const [needsOnboarding, setNeedsOnboarding] = useState(false);

--- a/src/pages/DossierDonnees.jsx
+++ b/src/pages/DossierDonnees.jsx
@@ -1,35 +1,26 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 export default function DossierDonnees() {
-  if (!isTauri) {
-    return (
-      <div className="p-6 text-sm">
-        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
-        <p>
-          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
-        </p>
-      </div>
-    );
-  }
   const [baseDir, setBaseDir] = useState('');
   const [dbPath, setDbPath] = useState('');
   const [dbExists, setDbExists] = useState(false);
 
   const refresh = async () => {
-    if (!isTauri) return;
-    const { appDataDir, join } = await import('@tauri-apps/api/path');
-    const { exists, mkdir } = await import('@tauri-apps/plugin-fs');
-    const root = await appDataDir();
-    const appDir = await join(root, 'MamaStock');
-    setBaseDir(appDir);
-    const dbDir = await join(appDir, 'databases');
-    const file = await join(dbDir, 'mamastock.db');
-    setDbPath(file);
-    setDbExists(await exists(file));
-    // ensure directories exist when checking
-    await mkdir(appDir, { recursive: true }).catch(() => {});
+    if (isTauri) {
+      const { appDataDir, join } = await import('@tauri-apps/api/path');
+      const { exists, mkdir } = await import('@tauri-apps/plugin-fs');
+      const root = await appDataDir();
+      const appDir = await join(root, 'MamaStock');
+      setBaseDir(appDir);
+      const dbDir = await join(appDir, 'databases');
+      const file = await join(dbDir, 'mamastock.db');
+      setDbPath(file);
+      setDbExists(await exists(file));
+      // ensure directories exist when checking
+      await mkdir(appDir, { recursive: true }).catch(() => {});
+    }
   };
 
   useEffect(() => {
@@ -37,19 +28,21 @@ export default function DossierDonnees() {
   }, []);
 
   const openDir = async () => {
-    if (!isTauri) return;
-    const { open } = await import('@tauri-apps/plugin-shell');
-    await open(baseDir);
+    if (isTauri) {
+      const { open } = await import('@tauri-apps/plugin-shell');
+      await open(baseDir);
+    }
   };
 
   const ensureDir = async () => {
-    if (!isTauri) return;
-    const { mkdir, exists } = await import('@tauri-apps/plugin-fs');
-    const { join } = await import('@tauri-apps/api/path');
-    await mkdir(baseDir, { recursive: true });
-    const dbDir = await join(baseDir, 'databases');
-    await mkdir(dbDir, { recursive: true });
-    setDbExists(await exists(dbPath));
+    if (isTauri) {
+      const { mkdir, exists } = await import('@tauri-apps/plugin-fs');
+      const { join } = await import('@tauri-apps/api/path');
+      await mkdir(baseDir, { recursive: true });
+      const dbDir = await join(baseDir, 'databases');
+      await mkdir(dbDir, { recursive: true });
+      setDbExists(await exists(dbPath));
+    }
   };
 
   return (
@@ -64,8 +57,8 @@ export default function DossierDonnees() {
         )}
       </div>
       <div className="flex gap-2">
-        <Button onClick={openDir} disabled={!isTauri}>Ouvrir le dossier</Button>
-        <Button onClick={ensureDir} disabled={!isTauri}>Créer si manquant</Button>
+        <Button onClick={openDir}>Ouvrir le dossier</Button>
+        <Button onClick={ensureDir}>Créer si manquant</Button>
       </div>
     </div>
   );

--- a/src/pages/Parametrage/Familles.tsx
+++ b/src/pages/Parametrage/Familles.tsx
@@ -13,13 +13,13 @@ export default function Familles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isTauri) {
+    if (isTauri) {
+      getDb()
+        .then(setDb)
+        .catch(() => setError('Base de données indisponible'));
+    } else {
       setError('Base de données indisponible');
-      return;
     }
-    getDb()
-      .then(setDb)
-      .catch(() => setError('Base de données indisponible'));
   }, []);
 
   useEffect(() => {

--- a/src/pages/Parametrage/SousFamilles.tsx
+++ b/src/pages/Parametrage/SousFamilles.tsx
@@ -13,13 +13,13 @@ export default function SousFamilles() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isTauri) {
+    if (isTauri) {
+      getDb()
+        .then(setDb)
+        .catch(() => setError('Base de données indisponible'));
+    } else {
       setError('Base de données indisponible');
-      return;
     }
-    getDb()
-      .then(setDb)
-      .catch(() => setError('Base de données indisponible'));
   }, []);
 
   useEffect(() => {

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import TableHeader from '@/components/ui/TableHeader';
 import GlassCard from '@/components/ui/GlassCard';

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -17,7 +17,7 @@ import FournisseurRow from '@/components/fournisseurs/FournisseurRow';
 import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
 import { toast } from 'sonner';
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 import {
   ResponsiveContainer,
   LineChart,

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import TableContainer from '@/components/ui/TableContainer';
 import useExportCompta from '@/hooks/useExportCompta';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 export default function ExportComptaPage() {
   const { generateJournalCsv, exportToERP, loading } = useExportCompta();

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -8,19 +8,9 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 export default function Familles() {
-  if (!isTauri) {
-    return (
-      <div className="p-6 text-sm">
-        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
-        <p>
-          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
-        </p>
-      </div>
-    );
-  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [familles, setFamilles] = useState([]);
@@ -30,7 +20,7 @@ export default function Familles() {
   const refresh = async () => {
     try {
       setLoading(true);
-      const data = await listFamilles();
+      const data = isTauri ? await listFamilles() : [];
       setFamilles(data);
     } catch (err) {
       console.error(err);

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -9,19 +9,9 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 export default function SousFamilles() {
-  if (!isTauri) {
-    return (
-      <div className="p-6 text-sm">
-        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
-        <p>
-          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
-        </p>
-      </div>
-    );
-  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [sousFamilles, setSousFamilles] = useState([]);
@@ -32,7 +22,9 @@ export default function SousFamilles() {
   const refresh = async () => {
     try {
       setLoading(true);
-      const [sf, f] = await Promise.all([listSousFamilles(), listFamilles()]);
+      const [sf, f] = isTauri
+        ? await Promise.all([listSousFamilles(), listFamilles()])
+        : [[], []];
       setSousFamilles(sf);
       setFamilles(f);
     } catch (err) {

--- a/src/pages/parametrage/SystemTools.jsx
+++ b/src/pages/parametrage/SystemTools.jsx
@@ -1,6 +1,6 @@
 import { backupDb, restoreDb, maintenanceDb } from "@/lib/db";
 import { toast } from "sonner";
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 
 export default function SystemTools() {
   const backup = async () => {

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -8,19 +8,9 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 export default function Unites() {
-  if (!isTauri) {
-    return (
-      <div className="p-6 text-sm">
-        <h2 className="font-semibold mb-2">Fonction disponible uniquement dans l’application Tauri</h2>
-        <p>
-          Ferme l’onglet navigateur et utilise la fenêtre <b>MamaStock</b> (lancée via <code>npx tauri dev</code>).
-        </p>
-      </div>
-    );
-  }
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [unites, setUnites] = useState([]);
@@ -30,7 +20,7 @@ export default function Unites() {
   const refresh = async () => {
     setLoading(true);
     try {
-      const data = await listUnites();
+      const data = isTauri ? await listUnites() : [];
       setUnites(data);
     } catch (err) {
       console.error(err);

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -20,7 +20,7 @@ import { useAuth } from '@/hooks/useAuth';
 import ProduitRow from "@/components/produits/ProduitRow";
 import ModalImportProduits from "@/components/produits/ModalImportProduits";
 import useExport from '@/hooks/useExport';
-import { isTauri } from '@/lib/db/sql';
+import { isTauri, getDb } from '@/lib/db/sql';
 
 const PAGE_SIZE = 50;
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,7 +13,7 @@ import Unites from "@/pages/parametrage/Unites";
 import DossierDonnees from "@/pages/DossierDonnees";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import Sidebar from "@/components/Sidebar";
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 
 function AppLayout() {
   return (

--- a/src/tauri/fsStore.ts
+++ b/src/tauri/fsStore.ts
@@ -1,4 +1,4 @@
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 import { inAppDir } from "@/lib/paths";
 
 type Json = unknown;

--- a/src/tauriLog.ts
+++ b/src/tauriLog.ts
@@ -8,7 +8,7 @@ export type LogApi = {
 
 let api: Partial<LogApi> | null = null;
 
-import { isTauri } from "@/lib/db/sql";
+import { isTauri, getDb } from "@/lib/db/sql";
 
 export async function initLog() {
   if (isTauri && import.meta.env.PROD) {


### PR DESCRIPTION
## Summary
- unify Tauri environment imports across app
- drop isTauri UI guards and pointer-event disables in settings pages and navbar
- simplify hooks and utilities for non-Tauri usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5356a8ec0832d89f614ee5c4c363e