### PR TITLE
chore: add script to fix SQL plugin capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "check:native": "node scripts/check-node-native.js",
     "check:tauri-imports": "node scripts/check-tauri-imports.js",
     "check:tauri-plugins": "node scripts/check-tauri-plugins.js",
-    "scan:src": "node scripts/scan-src.js"
+    "scan:src": "node scripts/scan-src.js",
+    "fix:sql-perms": "node scripts/fix-sql-capabilities.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/fix-sql-capabilities.js
+++ b/scripts/fix-sql-capabilities.js
@@ -1,0 +1,38 @@
+import fs from "fs/promises";
+import path from "path";
+
+const ROOT = process.cwd();
+const capDir = path.join(ROOT, "src-tauri", "capabilities");
+const sqlPath = path.join(capDir, "sql.json");
+
+const obj = {
+  "$schema": "../gen/schemas/plugin-sql.json",
+  "identifier": "sql",
+  "description": "Permissions for SQL plugin",
+  "windows": ["main"],
+  "permissions": [
+    "sql:default",
+    "sql:allow-load",
+    "sql:allow-select",
+    "sql:allow-execute",
+    "sql:allow-close"
+  ]
+};
+
+async function main() {
+  await fs.mkdir(capDir, { recursive: true });
+  const json = JSON.stringify(obj, null, 2);
+  await fs.writeFile(sqlPath, json, "utf8");
+
+  // relecture + parse pour valider
+  const raw = await fs.readFile(sqlPath, "utf8");
+  const parsed = JSON.parse(raw);
+
+  console.log("✅ Wrote", path.relative(ROOT, sqlPath));
+  console.log("----");
+  console.log(JSON.stringify(parsed, null, 2));
+  console.log("----");
+  console.log("TIP: redémarre Tauri (npx tauri dev) pour recharger les capabilities.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src-tauri/capabilities/sql.json
+++ b/src-tauri/capabilities/sql.json
@@ -2,11 +2,14 @@
   "$schema": "../gen/schemas/plugin-sql.json",
   "identifier": "sql",
   "description": "Permissions for SQL plugin",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "sql:default",
     "sql:allow-load",
     "sql:allow-select",
-    "sql:allow-execute"
+    "sql:allow-execute",
+    "sql:allow-close"
   ]
 }


### PR DESCRIPTION
## Summary
- add fix-sql-capabilities script to regenerate SQL capability file
- expose new npm script `fix:sql-perms`
- regenerate `src-tauri/capabilities/sql.json`

## Testing
- `npm run fix:sql-perms`
- `npx tauri dev` *(fails: Waiting for your frontend dev server to start on http://localhost:5173/)*

------
https://chatgpt.com/codex/tasks/task_e_68c53d585670832d996aebd34b062727