### PR TITLE
feat: add source scanner

### DIFF
--- a/sidebar.plan.json
+++ b/sidebar.plan.json
@@ -1,0 +1,1007 @@
+{
+  "Dashboard": [
+    {
+      "label": "Dashboard",
+      "path": "dashboard",
+      "file": "src/pages/Dashboard.jsx"
+    }
+  ],
+  "Parametrage": [
+    {
+      "label": "Familles",
+      "path": "parametrage/familles",
+      "file": "src/pages/parametrage/Familles.jsx"
+    },
+    {
+      "label": "SousFamilles",
+      "path": "parametrage/sousfamilles",
+      "file": "src/pages/parametrage/SousFamilles.jsx"
+    },
+    {
+      "label": "Unites",
+      "path": "parametrage/unites",
+      "file": "src/pages/parametrage/Unites.jsx"
+    }
+  ],
+  "DossierDonnees": [
+    {
+      "label": "DossierDonnees",
+      "path": "dossierdonnees",
+      "file": "src/pages/DossierDonnees.jsx"
+    }
+  ],
+  "Debug": [
+    {
+      "label": "AuthDebug",
+      "path": "debug/authdebug",
+      "file": "src/pages/debug/AuthDebug.jsx"
+    }
+  ],
+  "__orphans__": [
+    {
+      "label": "Accueil",
+      "file": "src/pages/Accueil.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AideContextuelle",
+      "file": "src/pages/AideContextuelle.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Alertes",
+      "file": "src/pages/Alertes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "BarManager",
+      "file": "src/pages/BarManager.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CartePlats",
+      "file": "src/pages/CartePlats.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Consentements",
+      "file": "src/pages/Consentements.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Auth",
+      "file": "src/pages/Debug/Auth.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "EngineeringMenu",
+      "file": "src/pages/EngineeringMenu.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Feedback",
+      "file": "src/pages/Feedback.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "HelpCenter",
+      "file": "src/pages/HelpCenter.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Journal",
+      "file": "src/pages/Journal.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Login",
+      "file": "src/pages/Login.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "NotFound",
+      "file": "src/pages/NotFound.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Onboarding",
+      "file": "src/pages/Onboarding.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DossierDonnees",
+      "file": "src/pages/Parametrage/DossierDonnees.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Familles",
+      "file": "src/pages/Parametrage/Familles.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SousFamilles",
+      "file": "src/pages/Parametrage/SousFamilles.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Unites",
+      "file": "src/pages/Parametrage/Unites.tsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Familles",
+      "file": "src/pages/Parametres/Familles.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Pertes",
+      "file": "src/pages/Pertes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Planning",
+      "file": "src/pages/Planning.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PlanningDetail",
+      "file": "src/pages/PlanningDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PlanningForm",
+      "file": "src/pages/PlanningForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PlanningModule",
+      "file": "src/pages/PlanningModule.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Rgpd",
+      "file": "src/pages/Rgpd.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Stock",
+      "file": "src/pages/Stock.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Utilisateurs",
+      "file": "src/pages/Utilisateurs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Validations",
+      "file": "src/pages/Validations.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AchatDetail",
+      "file": "src/pages/achats/AchatDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AchatForm",
+      "file": "src/pages/achats/AchatForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Achats",
+      "file": "src/pages/achats/Achats.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Aide",
+      "file": "src/pages/aide/Aide.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AideForm",
+      "file": "src/pages/aide/AideForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Analyse",
+      "file": "src/pages/analyse/Analyse.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AnalyseCostCenter",
+      "file": "src/pages/analyse/AnalyseCostCenter.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuEngineering",
+      "file": "src/pages/analyse/MenuEngineering.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TableauxDeBord",
+      "file": "src/pages/analyse/TableauxDeBord.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AnalytiqueDashboard",
+      "file": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Blocked",
+      "file": "src/pages/auth/Blocked.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CreateMama",
+      "file": "src/pages/auth/CreateMama.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Logout",
+      "file": "src/pages/auth/Logout.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Pending",
+      "file": "src/pages/auth/Pending.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ResetPassword",
+      "file": "src/pages/auth/ResetPassword.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "RoleError",
+      "file": "src/pages/auth/RoleError.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Unauthorized",
+      "file": "src/pages/auth/Unauthorized.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "UpdatePassword",
+      "file": "src/pages/auth/UpdatePassword.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "BLCreate",
+      "file": "src/pages/bons_livraison/BLCreate.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "BLDetail",
+      "file": "src/pages/bons_livraison/BLDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "BLForm",
+      "file": "src/pages/bons_livraison/BLForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "BonsLivraison",
+      "file": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Carte",
+      "file": "src/pages/carte/Carte.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CatalogueSyncViewer",
+      "file": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CommandeDetail",
+      "file": "src/pages/commandes/CommandeDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CommandeForm",
+      "file": "src/pages/commandes/CommandeForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Commandes",
+      "file": "src/pages/commandes/Commandes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CommandesEnvoyees",
+      "file": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AccessMultiSites",
+      "file": "src/pages/consolidation/AccessMultiSites.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Consolidation",
+      "file": "src/pages/consolidation/Consolidation.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CostBoisson",
+      "file": "src/pages/costboisson/CostBoisson.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CostingCarte",
+      "file": "src/pages/costing/CostingCarte.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJour",
+      "file": "src/pages/cuisine/MenuDuJour.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DashboardBuilder",
+      "file": "src/pages/dashboard/DashboardBuilder.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AccessExample",
+      "file": "src/pages/debug/AccessExample.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Debug",
+      "file": "src/pages/debug/Debug.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DebugAuth",
+      "file": "src/pages/debug/DebugAuth.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DebugRights",
+      "file": "src/pages/debug/DebugRights.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DebugUser",
+      "file": "src/pages/debug/DebugUser.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "DocumentForm",
+      "file": "src/pages/documents/DocumentForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Documents",
+      "file": "src/pages/documents/Documents.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Ecarts",
+      "file": "src/pages/ecarts/Ecarts.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "EmailsEnvoyes",
+      "file": "src/pages/emails/EmailsEnvoyes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuEngineering",
+      "file": "src/pages/engineering/MenuEngineering.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FactureCreate",
+      "file": "src/pages/factures/FactureCreate.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FactureDetail",
+      "file": "src/pages/factures/FactureDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FactureForm",
+      "file": "src/pages/factures/FactureForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Factures",
+      "file": "src/pages/factures/Factures.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ImportFactures",
+      "file": "src/pages/factures/ImportFactures.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FicheDetail",
+      "file": "src/pages/fiches/FicheDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FicheForm",
+      "file": "src/pages/fiches/FicheForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Fiches",
+      "file": "src/pages/fiches/Fiches.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ApiFournisseurForm",
+      "file": "src/pages/fournisseurs/ApiFournisseurForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ApiFournisseurs",
+      "file": "src/pages/fournisseurs/ApiFournisseurs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FournisseurApiSettingsForm",
+      "file": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FournisseurCreate",
+      "file": "src/pages/fournisseurs/FournisseurCreate.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FournisseurDetail",
+      "file": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FournisseurDetailPage",
+      "file": "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "FournisseurForm",
+      "file": "src/pages/fournisseurs/FournisseurForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Fournisseurs",
+      "file": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ComparatifPrix",
+      "file": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PrixFournisseurs",
+      "file": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "EcartInventaire",
+      "file": "src/pages/inventaire/EcartInventaire.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Inventaire",
+      "file": "src/pages/inventaire/Inventaire.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InventaireDetail",
+      "file": "src/pages/inventaire/InventaireDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InventaireForm",
+      "file": "src/pages/inventaire/InventaireForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InventaireZones",
+      "file": "src/pages/inventaire/InventaireZones.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Cgu",
+      "file": "src/pages/legal/Cgu.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Cgv",
+      "file": "src/pages/legal/Cgv.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Confidentialite",
+      "file": "src/pages/legal/Confidentialite.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Contact",
+      "file": "src/pages/legal/Contact.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Licence",
+      "file": "src/pages/legal/Licence.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MentionsLegales",
+      "file": "src/pages/legal/MentionsLegales.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJour",
+      "file": "src/pages/menu/MenuDuJour.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJourJour",
+      "file": "src/pages/menu/MenuDuJourJour.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDetail",
+      "file": "src/pages/menus/MenuDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJour",
+      "file": "src/pages/menus/MenuDuJour.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJourDetail",
+      "file": "src/pages/menus/MenuDuJourDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuDuJourForm",
+      "file": "src/pages/menus/MenuDuJourForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuForm",
+      "file": "src/pages/menus/MenuForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuGroupeDetail",
+      "file": "src/pages/menus/MenuGroupeDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuGroupeForm",
+      "file": "src/pages/menus/MenuGroupeForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuGroupes",
+      "file": "src/pages/menus/MenuGroupes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MenuPDF",
+      "file": "src/pages/menus/MenuPDF.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Menus",
+      "file": "src/pages/menus/Menus.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MobileAccueil",
+      "file": "src/pages/mobile/MobileAccueil.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MobileInventaire",
+      "file": "src/pages/mobile/MobileInventaire.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MobileRequisition",
+      "file": "src/pages/mobile/MobileRequisition.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "NotificationSettingsForm",
+      "file": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "NotificationsInbox",
+      "file": "src/pages/notifications/NotificationsInbox.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "OnboardingUtilisateur",
+      "file": "src/pages/onboarding/OnboardingUtilisateur.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "APIKeys",
+      "file": "src/pages/parametrage/APIKeys.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AccessRights",
+      "file": "src/pages/parametrage/AccessRights.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "CentreCoutForm",
+      "file": "src/pages/parametrage/CentreCoutForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ExportComptaPage",
+      "file": "src/pages/parametrage/ExportComptaPage.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ExportUserData",
+      "file": "src/pages/parametrage/ExportUserData.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InvitationsEnAttente",
+      "file": "src/pages/parametrage/InvitationsEnAttente.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InviteUser",
+      "file": "src/pages/parametrage/InviteUser.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MamaForm",
+      "file": "src/pages/parametrage/MamaForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "MamaSettingsForm",
+      "file": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Mamas",
+      "file": "src/pages/parametrage/Mamas.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Parametrage",
+      "file": "src/pages/parametrage/Parametrage.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ParametresCommandes",
+      "file": "src/pages/parametrage/ParametresCommandes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Periodes",
+      "file": "src/pages/parametrage/Periodes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Permissions",
+      "file": "src/pages/parametrage/Permissions.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PermissionsAdmin",
+      "file": "src/pages/parametrage/PermissionsAdmin.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PermissionsForm",
+      "file": "src/pages/parametrage/PermissionsForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "RGPDConsentForm",
+      "file": "src/pages/parametrage/RGPDConsentForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "RoleForm",
+      "file": "src/pages/parametrage/RoleForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Roles",
+      "file": "src/pages/parametrage/Roles.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SystemTools",
+      "file": "src/pages/parametrage/SystemTools.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TemplateCommandeForm",
+      "file": "src/pages/parametrage/TemplateCommandeForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TemplatesCommandes",
+      "file": "src/pages/parametrage/TemplatesCommandes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Utilisateurs",
+      "file": "src/pages/parametrage/Utilisateurs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ZoneAccess",
+      "file": "src/pages/parametrage/ZoneAccess.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ZoneForm",
+      "file": "src/pages/parametrage/ZoneForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Zones",
+      "file": "src/pages/parametrage/Zones.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SimulationPlanner",
+      "file": "src/pages/planning/SimulationPlanner.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ProduitDetail",
+      "file": "src/pages/produits/ProduitDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ProduitForm",
+      "file": "src/pages/produits/ProduitForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Produits",
+      "file": "src/pages/produits/Produits.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "PromotionForm",
+      "file": "src/pages/promotions/PromotionForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Promotions",
+      "file": "src/pages/promotions/Promotions.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "LandingPage",
+      "file": "src/pages/public/LandingPage.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Onboarding",
+      "file": "src/pages/public/Onboarding.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Signup",
+      "file": "src/pages/public/Signup.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Receptions",
+      "file": "src/pages/receptions/Receptions.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Recettes",
+      "file": "src/pages/recettes/Recettes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "GraphCost",
+      "file": "src/pages/reporting/GraphCost.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Reporting",
+      "file": "src/pages/reporting/Reporting.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ReportingPDF",
+      "file": "src/pages/reporting/ReportingPDF.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "RequisitionDetail",
+      "file": "src/pages/requisitions/RequisitionDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "RequisitionForm",
+      "file": "src/pages/requisitions/RequisitionForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Requisitions",
+      "file": "src/pages/requisitions/Requisitions.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SignalementDetail",
+      "file": "src/pages/signalements/SignalementDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SignalementForm",
+      "file": "src/pages/signalements/SignalementForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Signalements",
+      "file": "src/pages/signalements/Signalements.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Simulation",
+      "file": "src/pages/simulation/Simulation.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SimulationForm",
+      "file": "src/pages/simulation/SimulationForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SimulationMenu",
+      "file": "src/pages/simulation/SimulationMenu.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SimulationResult",
+      "file": "src/pages/simulation/SimulationResult.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Stats",
+      "file": "src/pages/stats/Stats.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsAdvanced",
+      "file": "src/pages/stats/StatsAdvanced.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsConsolidation",
+      "file": "src/pages/stats/StatsConsolidation.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsCostCenters",
+      "file": "src/pages/stats/StatsCostCenters.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsCostCentersPivot",
+      "file": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsFiches",
+      "file": "src/pages/stats/StatsFiches.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "StatsStock",
+      "file": "src/pages/stats/StatsStock.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "AlertesRupture",
+      "file": "src/pages/stock/AlertesRupture.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Inventaire",
+      "file": "src/pages/stock/Inventaire.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "InventaireForm",
+      "file": "src/pages/stock/InventaireForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Requisitions",
+      "file": "src/pages/stock/Requisitions.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TransfertForm",
+      "file": "src/pages/stock/TransfertForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Transferts",
+      "file": "src/pages/stock/Transferts.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "ComparateurFiches",
+      "file": "src/pages/supervision/ComparateurFiches.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "GroupeParamForm",
+      "file": "src/pages/supervision/GroupeParamForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Logs",
+      "file": "src/pages/supervision/Logs.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Rapports",
+      "file": "src/pages/supervision/Rapports.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "SupervisionGroupe",
+      "file": "src/pages/supervision/SupervisionGroupe.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Surcouts",
+      "file": "src/pages/surcouts/Surcouts.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Alertes",
+      "file": "src/pages/taches/Alertes.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TacheDetail",
+      "file": "src/pages/taches/TacheDetail.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TacheForm",
+      "file": "src/pages/taches/TacheForm.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "TacheNew",
+      "file": "src/pages/taches/TacheNew.jsx",
+      "why": "non trouvé dans le routeur"
+    },
+    {
+      "label": "Taches",
+      "file": "src/pages/taches/Taches.jsx",
+      "why": "non trouvé dans le routeur"
+    }
+  ]
+}

--- a/src-inventory.json
+++ b/src-inventory.json
@@ -1,0 +1,12334 @@
+{
+  "generatedAt": "2025-09-13T10:11:12.959Z",
+  "root": "/workspace/MAMASTOCK-LOCAL",
+  "srcDir": "/workspace/MAMASTOCK-LOCAL/src",
+  "entrypoints": [
+    "src/main.jsx",
+    "src/router.tsx"
+  ],
+  "routerFile": "src/router.tsx",
+  "routes": [
+    {
+      "path": "/",
+      "component": "AppLayout",
+      "file": null
+    },
+    {
+      "path": "dashboard",
+      "component": "Dashboard",
+      "file": "src/pages/Dashboard.jsx"
+    },
+    {
+      "path": "parametrage/familles",
+      "component": "Familles",
+      "file": "src/pages/parametrage/Familles.jsx"
+    },
+    {
+      "path": "parametrage/sous-familles",
+      "component": "SousFamilles",
+      "file": "src/pages/parametrage/SousFamilles.jsx"
+    },
+    {
+      "path": "parametrage/unites",
+      "component": "Unites",
+      "file": "src/pages/parametrage/Unites.jsx"
+    },
+    {
+      "path": "parametrage/dossier-donnees",
+      "component": "DossierDonnees",
+      "file": "src/pages/DossierDonnees.jsx"
+    },
+    {
+      "path": "debug/auth",
+      "component": "AuthDebug",
+      "file": "src/pages/debug/AuthDebug.jsx"
+    },
+    {
+      "path": "*",
+      "component": "Navigate",
+      "file": null
+    }
+  ],
+  "pages": [
+    "src/pages/Accueil.jsx",
+    "src/pages/AideContextuelle.jsx",
+    "src/pages/Alertes.jsx",
+    "src/pages/BarManager.jsx",
+    "src/pages/CartePlats.jsx",
+    "src/pages/Consentements.jsx",
+    "src/pages/Dashboard.jsx",
+    "src/pages/Debug/Auth.tsx",
+    "src/pages/DossierDonnees.jsx",
+    "src/pages/EngineeringMenu.jsx",
+    "src/pages/Feedback.jsx",
+    "src/pages/HelpCenter.jsx",
+    "src/pages/Journal.jsx",
+    "src/pages/Login.jsx",
+    "src/pages/NotFound.jsx",
+    "src/pages/Onboarding.tsx",
+    "src/pages/Parametrage/DossierDonnees.tsx",
+    "src/pages/Parametrage/Familles.tsx",
+    "src/pages/Parametrage/SousFamilles.tsx",
+    "src/pages/Parametrage/Unites.tsx",
+    "src/pages/Parametres/Familles.jsx",
+    "src/pages/Pertes.jsx",
+    "src/pages/Planning.jsx",
+    "src/pages/PlanningDetail.jsx",
+    "src/pages/PlanningForm.jsx",
+    "src/pages/PlanningModule.jsx",
+    "src/pages/Rgpd.jsx",
+    "src/pages/Stock.jsx",
+    "src/pages/Utilisateurs.jsx",
+    "src/pages/Validations.jsx",
+    "src/pages/achats/AchatDetail.jsx",
+    "src/pages/achats/AchatForm.jsx",
+    "src/pages/achats/Achats.jsx",
+    "src/pages/aide/Aide.jsx",
+    "src/pages/aide/AideForm.jsx",
+    "src/pages/analyse/Analyse.jsx",
+    "src/pages/analyse/AnalyseCostCenter.jsx",
+    "src/pages/analyse/MenuEngineering.jsx",
+    "src/pages/analyse/TableauxDeBord.jsx",
+    "src/pages/analytique/AnalytiqueDashboard.jsx",
+    "src/pages/auth/Blocked.jsx",
+    "src/pages/auth/CreateMama.jsx",
+    "src/pages/auth/Logout.jsx",
+    "src/pages/auth/Pending.jsx",
+    "src/pages/auth/ResetPassword.jsx",
+    "src/pages/auth/RoleError.jsx",
+    "src/pages/auth/Unauthorized.jsx",
+    "src/pages/auth/UpdatePassword.jsx",
+    "src/pages/bons_livraison/BLCreate.jsx",
+    "src/pages/bons_livraison/BLDetail.jsx",
+    "src/pages/bons_livraison/BLForm.jsx",
+    "src/pages/bons_livraison/BonsLivraison.jsx",
+    "src/pages/carte/Carte.jsx",
+    "src/pages/catalogue/CatalogueSyncViewer.jsx",
+    "src/pages/commandes/CommandeDetail.jsx",
+    "src/pages/commandes/CommandeForm.jsx",
+    "src/pages/commandes/Commandes.jsx",
+    "src/pages/commandes/CommandesEnvoyees.jsx",
+    "src/pages/consolidation/AccessMultiSites.jsx",
+    "src/pages/consolidation/Consolidation.jsx",
+    "src/pages/costboisson/CostBoisson.jsx",
+    "src/pages/costing/CostingCarte.jsx",
+    "src/pages/cuisine/MenuDuJour.jsx",
+    "src/pages/dashboard/DashboardBuilder.jsx",
+    "src/pages/debug/AccessExample.jsx",
+    "src/pages/debug/AuthDebug.jsx",
+    "src/pages/debug/Debug.jsx",
+    "src/pages/debug/DebugAuth.jsx",
+    "src/pages/debug/DebugRights.jsx",
+    "src/pages/debug/DebugUser.jsx",
+    "src/pages/documents/DocumentForm.jsx",
+    "src/pages/documents/Documents.jsx",
+    "src/pages/ecarts/Ecarts.jsx",
+    "src/pages/emails/EmailsEnvoyes.jsx",
+    "src/pages/engineering/MenuEngineering.jsx",
+    "src/pages/factures/FactureCreate.jsx",
+    "src/pages/factures/FactureDetail.jsx",
+    "src/pages/factures/FactureForm.jsx",
+    "src/pages/factures/Factures.jsx",
+    "src/pages/factures/ImportFactures.jsx",
+    "src/pages/fiches/FicheDetail.jsx",
+    "src/pages/fiches/FicheForm.jsx",
+    "src/pages/fiches/Fiches.jsx",
+    "src/pages/fournisseurs/ApiFournisseurForm.jsx",
+    "src/pages/fournisseurs/ApiFournisseurs.jsx",
+    "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+    "src/pages/fournisseurs/FournisseurCreate.jsx",
+    "src/pages/fournisseurs/FournisseurDetail.jsx",
+    "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+    "src/pages/fournisseurs/FournisseurForm.jsx",
+    "src/pages/fournisseurs/Fournisseurs.jsx",
+    "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+    "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+    "src/pages/inventaire/EcartInventaire.jsx",
+    "src/pages/inventaire/Inventaire.jsx",
+    "src/pages/inventaire/InventaireDetail.jsx",
+    "src/pages/inventaire/InventaireForm.jsx",
+    "src/pages/inventaire/InventaireZones.jsx",
+    "src/pages/legal/Cgu.jsx",
+    "src/pages/legal/Cgv.jsx",
+    "src/pages/legal/Confidentialite.jsx",
+    "src/pages/legal/Contact.jsx",
+    "src/pages/legal/Licence.jsx",
+    "src/pages/legal/MentionsLegales.jsx",
+    "src/pages/menu/MenuDuJour.jsx",
+    "src/pages/menu/MenuDuJourJour.jsx",
+    "src/pages/menus/MenuDetail.jsx",
+    "src/pages/menus/MenuDuJour.jsx",
+    "src/pages/menus/MenuDuJourDetail.jsx",
+    "src/pages/menus/MenuDuJourForm.jsx",
+    "src/pages/menus/MenuForm.jsx",
+    "src/pages/menus/MenuGroupeDetail.jsx",
+    "src/pages/menus/MenuGroupeForm.jsx",
+    "src/pages/menus/MenuGroupes.jsx",
+    "src/pages/menus/MenuPDF.jsx",
+    "src/pages/menus/Menus.jsx",
+    "src/pages/mobile/MobileAccueil.jsx",
+    "src/pages/mobile/MobileInventaire.jsx",
+    "src/pages/mobile/MobileRequisition.jsx",
+    "src/pages/notifications/NotificationSettingsForm.jsx",
+    "src/pages/notifications/NotificationsInbox.jsx",
+    "src/pages/onboarding/OnboardingUtilisateur.jsx",
+    "src/pages/parametrage/APIKeys.jsx",
+    "src/pages/parametrage/AccessRights.jsx",
+    "src/pages/parametrage/CentreCoutForm.jsx",
+    "src/pages/parametrage/ExportComptaPage.jsx",
+    "src/pages/parametrage/ExportUserData.jsx",
+    "src/pages/parametrage/Familles.jsx",
+    "src/pages/parametrage/InvitationsEnAttente.jsx",
+    "src/pages/parametrage/InviteUser.jsx",
+    "src/pages/parametrage/MamaForm.jsx",
+    "src/pages/parametrage/MamaSettingsForm.jsx",
+    "src/pages/parametrage/Mamas.jsx",
+    "src/pages/parametrage/Parametrage.jsx",
+    "src/pages/parametrage/ParametresCommandes.jsx",
+    "src/pages/parametrage/Periodes.jsx",
+    "src/pages/parametrage/Permissions.jsx",
+    "src/pages/parametrage/PermissionsAdmin.jsx",
+    "src/pages/parametrage/PermissionsForm.jsx",
+    "src/pages/parametrage/RGPDConsentForm.jsx",
+    "src/pages/parametrage/RoleForm.jsx",
+    "src/pages/parametrage/Roles.jsx",
+    "src/pages/parametrage/SousFamilles.jsx",
+    "src/pages/parametrage/SystemTools.jsx",
+    "src/pages/parametrage/TemplateCommandeForm.jsx",
+    "src/pages/parametrage/TemplatesCommandes.jsx",
+    "src/pages/parametrage/Unites.jsx",
+    "src/pages/parametrage/Utilisateurs.jsx",
+    "src/pages/parametrage/ZoneAccess.jsx",
+    "src/pages/parametrage/ZoneForm.jsx",
+    "src/pages/parametrage/Zones.jsx",
+    "src/pages/planning/SimulationPlanner.jsx",
+    "src/pages/produits/ProduitDetail.jsx",
+    "src/pages/produits/ProduitForm.jsx",
+    "src/pages/produits/Produits.jsx",
+    "src/pages/promotions/PromotionForm.jsx",
+    "src/pages/promotions/Promotions.jsx",
+    "src/pages/public/LandingPage.jsx",
+    "src/pages/public/Onboarding.jsx",
+    "src/pages/public/Signup.jsx",
+    "src/pages/receptions/Receptions.jsx",
+    "src/pages/recettes/Recettes.jsx",
+    "src/pages/reporting/GraphCost.jsx",
+    "src/pages/reporting/Reporting.jsx",
+    "src/pages/reporting/ReportingPDF.jsx",
+    "src/pages/requisitions/RequisitionDetail.jsx",
+    "src/pages/requisitions/RequisitionForm.jsx",
+    "src/pages/requisitions/Requisitions.jsx",
+    "src/pages/signalements/SignalementDetail.jsx",
+    "src/pages/signalements/SignalementForm.jsx",
+    "src/pages/signalements/Signalements.jsx",
+    "src/pages/simulation/Simulation.jsx",
+    "src/pages/simulation/SimulationForm.jsx",
+    "src/pages/simulation/SimulationMenu.jsx",
+    "src/pages/simulation/SimulationResult.jsx",
+    "src/pages/stats/Stats.jsx",
+    "src/pages/stats/StatsAdvanced.jsx",
+    "src/pages/stats/StatsConsolidation.jsx",
+    "src/pages/stats/StatsCostCenters.jsx",
+    "src/pages/stats/StatsCostCentersPivot.jsx",
+    "src/pages/stats/StatsFiches.jsx",
+    "src/pages/stats/StatsStock.jsx",
+    "src/pages/stock/AlertesRupture.jsx",
+    "src/pages/stock/Inventaire.jsx",
+    "src/pages/stock/InventaireForm.jsx",
+    "src/pages/stock/Requisitions.jsx",
+    "src/pages/stock/TransfertForm.jsx",
+    "src/pages/stock/Transferts.jsx",
+    "src/pages/supervision/ComparateurFiches.jsx",
+    "src/pages/supervision/GroupeParamForm.jsx",
+    "src/pages/supervision/Logs.jsx",
+    "src/pages/supervision/Rapports.jsx",
+    "src/pages/supervision/SupervisionGroupe.jsx",
+    "src/pages/surcouts/Surcouts.jsx",
+    "src/pages/taches/Alertes.jsx",
+    "src/pages/taches/TacheDetail.jsx",
+    "src/pages/taches/TacheForm.jsx",
+    "src/pages/taches/TacheNew.jsx",
+    "src/pages/taches/Taches.jsx"
+  ],
+  "imports": {
+    "src/App.jsx": {
+      "internal": [
+        "src/router.tsx",
+        "src/context/HelpProvider.jsx",
+        "src/context/MultiMamaContext.jsx",
+        "src/context/ThemeProvider.jsx",
+        "src/components/CookieConsent.jsx",
+        "src/components/ToastRoot.jsx",
+        "src/components/DebugRibbon.jsx"
+      ],
+      "external": [
+        "@tanstack/react-query",
+        "nprogress",
+        "react",
+        "/src/shims/selftest"
+      ],
+      "missing": []
+    },
+    "src/appFs.ts": {
+      "internal": [
+        "src/lib/paths.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/auth/authAdapter.ts": {
+      "internal": [
+        "src/auth/localAccount.ts",
+        "src/context/AuthContext.tsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/auth/localAccount.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/auth/sqlAccount.ts": {
+      "internal": [
+        "src/db/index.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/auth/sqlAuth.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/auth/sqliteAuth.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "bcryptjs"
+      ],
+      "missing": []
+    },
+    "src/components/CookieConsent.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/DebugRibbon.jsx": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "@tauri-apps/api/webviewWindow",
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-shell"
+      ],
+      "missing": []
+    },
+    "src/components/DeleteAccountButton.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useRGPD.js",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/ErrorBoundary.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/FactureImportModal.jsx": {
+      "internal": [
+        "src/components/ui/SmartDialog.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/input.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/components/FactureLigne.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/factures/ProduitSearchModal.jsx",
+        "src/components/factures/PriceDelta.jsx",
+        "src/components/forms/NumericInputFR.jsx",
+        "src/components/forms/MoneyInputFR.jsx"
+      ],
+      "external": [
+        "react",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/FactureTable.jsx": {
+      "internal": [
+        "src/components/factures/FactureRow.jsx",
+        "src/components/ui/ListingContainer.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/Footer.jsx": {
+      "internal": [],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/LiquidBackground/BubblesParticles.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/LiquidBackground/LiquidBackground.jsx": {
+      "internal": [
+        "src/components/LiquidBackground/BubblesParticles.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/LiquidBackground/MouseLight.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/LiquidBackground/TouchLight.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/LiquidBackground/WavesBackground.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/LiquidBackground/index.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ProtectedRoute.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/Reporting/GraphMultiZone.jsx": {
+      "internal": [
+        "src/utils/formIds.js"
+      ],
+      "external": [
+        "recharts",
+        "react",
+        "html2canvas"
+      ],
+      "missing": []
+    },
+    "src/components/ResetAuthButton.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/Sidebar.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useMamaSettings.js",
+        "src/assets/logo-mamastock.png",
+        "src/lib/access.js"
+      ],
+      "external": [
+        "react-router-dom",
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ToastRoot.jsx": {
+      "internal": [],
+      "external": [
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/achats/AchatRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/analytics/CostCenterAllocationModal.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/ui/button.jsx",
+        "src/hooks/useCostCenters.js",
+        "src/hooks/useMouvementCostCenters.js",
+        "src/hooks/useCostCenterSuggestions.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/bons_livraison/BonLivraisonRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/costing/CostingCartePDF.jsx": {
+      "internal": [],
+      "external": [
+        "@react-pdf/renderer"
+      ],
+      "missing": []
+    },
+    "src/components/dashboard/DashboardCard.jsx": {
+      "internal": [],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/dashboard/GadgetConfigForm.jsx": {
+      "internal": [
+        "src/hooks/useGadgets.js",
+        "src/components/ui/InputField.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/dashboard/PeriodFilter.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/dashboard/WidgetRenderer.jsx": {
+      "internal": [
+        "src/components/dashboard/DashboardCard.jsx"
+      ],
+      "external": [
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/components/dev/ApiDiagnostic.jsx": {
+      "internal": [
+        "src/local/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/documents/DocumentPreview.jsx": {
+      "internal": [
+        "src/components/ui/SmartDialog.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/documents/DocumentUpload.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/engineering/EngineeringChart.jsx": {
+      "internal": [],
+      "external": [
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/components/engineering/EngineeringFilters.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/engineering/ImportVentesExcel.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/components/export/ExportManager.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/export/FicheExportView.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/factures/FactureRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/constants/factures.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/factures/PriceDelta.jsx": {
+      "internal": [],
+      "external": [
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/factures/ProduitSearchModal.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useProduitsSearch.js"
+      ],
+      "external": [
+        "react",
+        "@radix-ui/react-dialog",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/factures/SupplierBrowserModal.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useFournisseursBrowse.js"
+      ],
+      "external": [
+        "react",
+        "@radix-ui/react-dialog",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/factures/SupplierPicker.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/hooks/useDebounce.js",
+        "src/hooks/useFournisseursAutocomplete.js",
+        "src/components/factures/SupplierBrowserModal.jsx",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/fiches/FicheLigne.jsx": {
+      "internal": [
+        "src/components/ui/select.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/fiches/FicheRentabiliteCard.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": [
+        "@/components/ui/Card"
+      ]
+    },
+    "src/components/fiches/FicheRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/filters/SupplierFilter.jsx": {
+      "internal": [
+        "src/hooks/useFournisseursAutocomplete.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/forms/AutocompleteProduit.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useProduitsSearch.js",
+        "src/hooks/useDebounce.js",
+        "src/components/forms/ProductPickerModal.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/forms/MoneyInputFR.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/utils/numberFormat.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/forms/NumericInput.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/forms/NumericInputFR.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/forms/ProductPickerModal.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useProduitsSearch.js"
+      ],
+      "external": [
+        "react",
+        "@radix-ui/react-dialog",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/fournisseurs/FournisseurFormModal.jsx": {
+      "internal": [
+        "src/hooks/useFournisseurs.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/fournisseurs/FournisseurRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetAlerteStockFaible.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useAlerteStockFaible.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetBudgetMensuel.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useBudgetMensuel.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetConsoMoyenne.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useConsoMoyenne.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetDerniersAcces.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useDerniersAcces.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetEvolutionAchats.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useEvolutionAchats.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetProduitsUtilises.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useProduitsUtilises.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetTachesUrgentes.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useTachesUrgentes.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/gadgets/GadgetTopFournisseurs.jsx": {
+      "internal": [
+        "src/hooks/gadgets/useTopFournisseurs.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/components/ui/LoadingSkeleton.jsx"
+      ],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/help/DocumentationPanel.jsx": {
+      "internal": [
+        "src/components/ui/SmartDialog.jsx",
+        "src/context/HelpProvider.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/help/FeedbackForm.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/hooks/useFeedback.js",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/help/GuidedTour.jsx": {
+      "internal": [
+        "src/context/HelpProvider.jsx"
+      ],
+      "external": [
+        "react",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/help/TooltipHelper.jsx": {
+      "internal": [
+        "src/context/HelpProvider.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ia/RecommandationsBox.jsx": {
+      "internal": [
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useRecommendations.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/inventaire/InventaireLigneRow.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/inventaires/InventaireDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "file-saver",
+        "xlsx",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/inventaires/InventaireForm.jsx": {
+      "internal": [
+        "src/hooks/useInventaires.js",
+        "src/hooks/useProducts.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useStorage.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/layout/Sidebar.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/assets/logo-mamastock.png"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/mouvements/MouvementFormModal.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/SmartDialog.jsx"
+      ],
+      "external": [
+        "react",
+        "framer-motion",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/FamilleRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/parametrage/SousFamilleRow.jsx",
+        "src/forms/SousFamilleForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ParamAccess.jsx": {
+      "internal": [
+        "src/hooks/usePermissions.js",
+        "src/hooks/useRoles.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/hooks/useAuth.ts",
+        "src/config/modules.js",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ParamCostCenters.jsx": {
+      "internal": [
+        "src/hooks/useCostCenters.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ParamFamilles.jsx": {
+      "internal": [
+        "src/hooks/useFamilles.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "file-saver",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ParamMama.jsx": {
+      "internal": [
+        "src/hooks/useMama.js",
+        "src/components/ui/button.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ParamRoles.jsx": {
+      "internal": [
+        "src/pages/parametrage/Roles.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/parametrage/ParamSecurity.jsx": {
+      "internal": [
+        "src/components/security/TwoFactorSetup.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/parametrage/ParamUnites.jsx": {
+      "internal": [
+        "src/hooks/useUnites.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "file-saver",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/SousFamilleList.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/SousFamilleModal.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/parametrage/SousFamilleList.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/parametrage/SousFamilleRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/forms/SousFamilleForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/UniteRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/parametrage/UtilisateurRow.jsx": {
+      "internal": [
+        "src/auth/localAccount.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ZoneFormProducts.jsx": {
+      "internal": [
+        "src/hooks/useZoneProducts.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/parametrage/ZoneRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/pdf/CommandePDF.jsx": {
+      "internal": [],
+      "external": [
+        "@react-pdf/renderer"
+      ],
+      "missing": []
+    },
+    "src/components/produits/ModalImportProduits.jsx": {
+      "internal": [
+        "src/components/ui/SmartDialog.jsx",
+        "src/components/ui/ImportPreviewTable.jsx",
+        "src/utils/excelUtils.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/produits/ProduitDetail.jsx": {
+      "internal": [
+        "src/hooks/useProducts.js",
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/produits/priceHelpers.js"
+      ],
+      "external": [
+        "react",
+        "recharts",
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/components/produits/ProduitForm.jsx": {
+      "internal": [
+        "src/hooks/useProducts.js",
+        "src/hooks/useFamilles.js",
+        "src/hooks/useSousFamilles.js",
+        "src/hooks/useUnites.js",
+        "src/hooks/useZonesStock.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/checkbox.jsx",
+        "src/components/ui/AutoCompleteField.jsx",
+        "src/components/ui/badge.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/produits/ProduitFormModal.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/produits/ProduitForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/produits/ProduitRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/produits/priceHelpers.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/promotions/PromotionRow.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/requisitions/RequisitionRow.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/security/TwoFactorSetup.jsx": {
+      "internal": [
+        "src/hooks/useTwoFactorAuth.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "qrcode.react"
+      ],
+      "missing": []
+    },
+    "src/components/simulation/SimulationDetailsModal.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/components/stock/AlertBadge.jsx": {
+      "internal": [
+        "src/hooks/useRuptureAlerts.js"
+      ],
+      "external": [
+        "react",
+        "lucide-react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/stock/StockDetail.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/taches/TacheForm.jsx": {
+      "internal": [
+        "src/hooks/useTasks.js",
+        "src/hooks/useUtilisateurs.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/taches/TachesKanban.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/AutoCompleteField.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/AutoCompleteZoneField.jsx": {
+      "internal": [
+        "src/components/ui/AutoCompleteField.jsx",
+        "src/hooks/useZones.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/Breadcrumbs.jsx": {
+      "internal": [],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/ui/Form.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/FormActions.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/FormField.jsx": {
+      "internal": [
+        "src/utils/formIds.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/GlassCard.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/ImportPreviewTable.jsx": {
+      "internal": [
+        "src/utils/excelUtils.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/InputField.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/LanguageSelector.jsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "react-i18next"
+      ],
+      "missing": []
+    },
+    "src/components/ui/ListingContainer.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/LoadingScreen.jsx": {
+      "internal": [
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/LoadingSkeleton.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/LoadingSpinner.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/MamaLogo.jsx": {
+      "internal": [
+        "src/assets/logo-mamastock.png",
+        "src/context/ThemeProvider.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/ModalGlass.jsx": {
+      "internal": [],
+      "external": [
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/components/ui/PageIntro.jsx": {
+      "internal": [
+        "src/components/ui/MamaLogo.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/PageSkeleton.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/PageWrapper.jsx": {
+      "internal": [
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/ui/PaginationFooter.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/PreviewBanner.jsx": {
+      "internal": [],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/components/ui/PrimaryButton.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/SecondaryButton.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/SmartDialog.jsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "@radix-ui/react-dialog"
+      ],
+      "missing": []
+    },
+    "src/components/ui/StatCard.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/TableContainer.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/TableHeader.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/badge.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/button.jsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "@radix-ui/react-slot"
+      ],
+      "missing": []
+    },
+    "src/components/ui/card.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/checkbox.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/controls/index.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/dialog.jsx": {
+      "internal": [],
+      "external": [
+        "@radix-ui/react-dialog"
+      ],
+      "missing": []
+    },
+    "src/components/ui/dropdown-menu.jsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "@radix-ui/react-dropdown-menu"
+      ],
+      "missing": []
+    },
+    "src/components/ui/input.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/label.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/ui/select.jsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "@radix-ui/react-select",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/components/ui/tabs.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/components/utilisateurs/UtilisateurDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/components/utilisateurs/UtilisateurForm.jsx": {
+      "internal": [
+        "src/hooks/useUtilisateurs.js",
+        "src/hooks/useRoles.js",
+        "src/hooks/useMamas.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/label.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/config/modules.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/components/utilisateurs/UtilisateurRow.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/config/modules.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/constants/accessKeys.js": {
+      "internal": [
+        "src/config/modules.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/constants/factures.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/constants/roles.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/constants/tables.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/context/AuthContext.tsx": {
+      "internal": [
+        "src/appFs.ts",
+        "src/lib/access.js",
+        "src/utils/permissions.js",
+        "src/constants/roles.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/context/HelpProvider.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/context/MultiMamaContext.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/context/ThemeProvider.jsx": {
+      "internal": [
+        "src/hooks/useMamaSettings.js",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/crypto/random.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/db/client.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/db/connection.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/db/index.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/db/migrate.ts": {
+      "internal": [
+        "src/db/client.ts",
+        "src/db/migrationsList.ts",
+        "src/lib/paths.ts"
+      ],
+      "external": [
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/db/migrationsList.ts": {
+      "internal": [
+        "src/migrations/001_schema.sql",
+        "src/migrations/002_seed.sql"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/debug/ErrorBoundary.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/debug/dbSmoke.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/debug/devAuth.ts": {
+      "internal": [
+        "src/auth/localAccount.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/debug/ensureLocalAdmin.ts": {
+      "internal": [
+        "src/auth/localAccount.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/features/factures/invoiceMappers.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/forms/FamilleForm.jsx": {
+      "internal": [
+        "src/components/ui/Form.jsx",
+        "src/components/ui/FormField.jsx",
+        "src/components/ui/FormActions.jsx",
+        "src/components/ui/controls/index.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/forms/PeriodeForm.jsx": {
+      "internal": [
+        "src/components/ui/Form.jsx",
+        "src/components/ui/FormField.jsx",
+        "src/components/ui/FormActions.jsx",
+        "src/components/ui/controls/index.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/forms/SousFamilleForm.jsx": {
+      "internal": [
+        "src/components/ui/Form.jsx",
+        "src/components/ui/FormField.jsx",
+        "src/components/ui/FormActions.jsx",
+        "src/components/ui/controls/index.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/forms/UniteForm.jsx": {
+      "internal": [
+        "src/components/ui/Form.jsx",
+        "src/components/ui/FormField.jsx",
+        "src/components/ui/FormActions.jsx",
+        "src/components/ui/controls/index.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/forms/ZoneForm.jsx": {
+      "internal": [
+        "src/components/ui/Form.jsx",
+        "src/components/ui/FormField.jsx",
+        "src/components/ui/FormActions.jsx",
+        "src/components/ui/controls/index.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/_shared/createAsyncState.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/data/useFactures.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/data/useFournisseurs.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useAchatsMensuels.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useAlerteStockFaible.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useBudgetMensuel.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/budget.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useConsoMoyenne.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useDerniersAcces.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useEvolutionAchats.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/_shared/createAsyncState.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useProduitsUtilises.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useTachesUrgentes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/gadgets/useTopFournisseurs.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAccess.js": {
+      "internal": [
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useAchats.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/achats.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAdvancedStats.js": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAide.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useAlerteStockFaible.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAlerts.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAnalyse.js": {
+      "internal": [
+        "src/local/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useAnalytique.js": {
+      "internal": [
+        "src/local/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useApiFournisseurs.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useApiKeys.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/apiKeys.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useAuditLog.js": {
+      "internal": [
+        "src/local/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useAuth.ts": {
+      "internal": [
+        "src/context/AuthContext.tsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useBonsLivraison.js": {
+      "internal": [
+        "src/local/bonsLivraison.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useCarte.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useCommandes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/commandes.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useComparatif.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useConsentements.js": {
+      "internal": [
+        "src/local/files.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useConsolidatedStats.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useConsolidation.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "jspdf",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/hooks/useCostCenterMonthlyStats.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useCostCenterStats.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useCostCenterSuggestions.js": {
+      "internal": [
+        "src/local/costCenters.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useCostCenters.js": {
+      "internal": [
+        "src/hooks/useAuditLog.js",
+        "src/local/costCenters.ts"
+      ],
+      "external": [
+        "react",
+        "file-saver",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/hooks/useCostingCarte.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "jspdf",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/hooks/useDashboardStats.js": {
+      "internal": [
+        "src/local/files.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useDashboards.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useDebounce.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useDocuments.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useStorage.js",
+        "src/local/documents.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useEcartsInventaire.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useEmailsEnvoyes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/_shared/createAsyncState.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useEnrichedProducts.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useExport.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/lib/export/exportHelpers.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useExportCompta.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/export/exportHelpers.js",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFactureForm.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFactures.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFacturesAutocomplete.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFamilles.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFamillesWithSousFamilles.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFeedback.js": {
+      "internal": [
+        "src/local/files.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFicheCoutHistory.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFiches.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "file-saver",
+        "jspdf",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFichesAutocomplete.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFichesTechniques.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFormErrors.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFormatters.js": {
+      "internal": [],
+      "external": [
+        "react-i18next"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseurAPI.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseurApiConfig.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseurNotes.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseurStats.js": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useFournisseurs.js": {
+      "internal": [
+        "src/lib/dal/fournisseurs.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseursAutocomplete.js": {
+      "internal": [
+        "src/hooks/useDebounce.js",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseursBrowse.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseursInactifs.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useFournisseursList.js": {
+      "internal": [
+        "src/hooks/data/useFournisseurs.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useFournisseursRecents.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useGadgets.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useGlobalSearch.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useGraphiquesMultiZone.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useHelpArticles.js": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInventaireLignes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInventaireZones.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInventaires.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInvoice.ts": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInvoiceImport.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInvoiceItems.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInvoiceOcr.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useInvoices.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/lib/xlsx/safeImportXLSX.js"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/hooks/useLogs.js": {
+      "internal": [
+        "src/context/AuthContext.tsx",
+        "src/local/logs.ts"
+      ],
+      "external": [
+        "react",
+        "file-saver",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMama.js": {
+      "internal": [
+        "src/appFs.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMamaSettings.js": {
+      "internal": [
+        "src/context/AuthContext.tsx",
+        "src/lib/access.js",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "react",
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMamaSwitcher.js": {
+      "internal": [
+        "src/context/MultiMamaContext.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMamas.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts",
+        "src/lib/xlsx/safeImportXLSX.js"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMenuDuJour.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMenuEngineering.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMenuGroupe.js": {
+      "internal": [
+        "src/local/menuGroupes.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useMenus.js": {
+      "internal": [],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/hooks/useMouvementCostCenters.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useAuditLog.js",
+        "src/local/files.ts",
+        "src/local/costCenters.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useNotifications.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/notifications.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useOnboarding.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/usePerformanceFiches.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/usePeriodes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/usePermissions.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts",
+        "src/lib/xlsx/safeImportXLSX.js"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/hooks/usePertes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useAuditLog.js",
+        "src/local/pertes.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/usePlanning.js": {
+      "internal": [
+        "src/local/files.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/usePriceTrends.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useProducts.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useProduitLineDefaults.js": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useProduitsAutocomplete.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useProduitsFournisseur.js": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useProduitsInventaire.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useProduitsSearch.js": {
+      "internal": [
+        "src/hooks/useDebounce.js",
+        "src/lib/react-query.js",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/usePromotions.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/promotions.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useRGPD.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/auth/localAccount.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useRecommendations.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/recommendations.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useReportingFinancier.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/local/files.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useRequisitions.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/requisitions.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useRoles.js": {
+      "internal": [
+        "src/appFs.ts",
+        "src/constants/roles.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useRuptureAlerts.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useSignalements.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/signalements.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useSimulation.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useSousFamilles.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useStats.js": {
+      "internal": [
+        "src/local/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useStock.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useStockRequisitionne.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/stockRequisitionne.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useStorage.js": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useSwipe.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useTacheAssignation.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useTasks.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useTemplatesCommandes.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/templatesCommandes.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useTopProducts.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useTransferts.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/usePeriodes.js",
+        "src/local/transferts.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useTwoFactorAuth.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/twoFactor.ts"
+      ],
+      "external": [
+        "react",
+        "otplib"
+      ],
+      "missing": []
+    },
+    "src/hooks/useUnites.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/hooks/useUsageStats.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useUtilisateurs.js": {
+      "internal": [
+        "src/auth/localAccount.ts",
+        "src/lib/export/exportHelpers.js",
+        "src/constants/roles.js",
+        "src/lib/xlsx/safeImportXLSX.js"
+      ],
+      "external": [
+        "react",
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/hooks/useValidations.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/local/validations.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useZoneProducts.js": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/hooks/useZoneRights.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/hooks/useZones.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "sonner",
+        "react"
+      ],
+      "missing": []
+    },
+    "src/hooks/useZonesStock.js": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/i18n/i18n.js": {
+      "internal": [
+        "src/i18n/locales/fr.json",
+        "src/i18n/locales/en.json",
+        "src/i18n/locales/es.json"
+      ],
+      "external": [
+        "i18next",
+        "react-i18next"
+      ],
+      "missing": []
+    },
+    "src/layout/AdminLayout.jsx": {
+      "internal": [
+        "src/components/layout/Sidebar.jsx",
+        "src/layout/Navbar.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/layout/Layout.jsx": {
+      "internal": [
+        "src/components/Sidebar.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useNotifications.js",
+        "src/components/ui/badge.jsx",
+        "src/components/Footer.jsx",
+        "src/components/stock/AlertBadge.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom",
+        "react",
+        "lucide-react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/layout/LegalLayout.jsx": {
+      "internal": [
+        "src/components/Footer.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/layout/Navbar.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useGlobalSearch.js",
+        "src/components/ui/LanguageSelector.jsx",
+        "src/lib/shutdown.ts",
+        "src/lib/lock.ts",
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "react-i18next",
+        "@tauri-apps/api/window"
+      ],
+      "missing": []
+    },
+    "src/layout/Sidebar.jsx": {
+      "internal": [
+        "src/router.tsx",
+        "src/hooks/useAuth.ts",
+        "src/assets/logo-mamastock.png"
+      ],
+      "external": [
+        "react-router-dom",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/layout/ViewerLayout.jsx": {
+      "internal": [
+        "src/layout/Navbar.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/access.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/access.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/dal/fournisseurs.ts": {
+      "internal": [
+        "src/lib/db/sql.ts",
+        "src/lib/types.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/dal/produits.ts": {
+      "internal": [
+        "src/lib/db/sql.ts",
+        "src/lib/types.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/db.ts": {
+      "internal": [
+        "src/lib/db/sql.ts",
+        "src/lib/paths.ts",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "@tauri-apps/plugin-dialog",
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/lib/db/sql.ts": {
+      "internal": [],
+      "external": [
+        "@tauri-apps/plugin-sql",
+        "@tauri-apps/api/path"
+      ],
+      "missing": []
+    },
+    "src/lib/export/exportHelpers.js": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "jspdf",
+        "xlsx",
+        "file-saver",
+        "js-yaml",
+        "jspdf-autotable",
+        "@tauri-apps/plugin-fs",
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-dialog"
+      ],
+      "missing": []
+    },
+    "src/lib/familles.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/lazyWithPreload.js": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/lib/lock.ts": {
+      "internal": [
+        "src/lib/shutdown.ts",
+        "src/lib/db/sql.ts",
+        "src/lib/paths.ts"
+      ],
+      "external": [
+        "uuid",
+        "@tauri-apps/plugin-fs",
+        "@tauri-apps/api/webviewWindow"
+      ],
+      "missing": []
+    },
+    "src/lib/paths.ts": {
+      "internal": [],
+      "external": [
+        "@tauri-apps/api/path"
+      ],
+      "missing": []
+    },
+    "src/lib/react-query.js": {
+      "internal": [],
+      "external": [
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/lib/roleUtils.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/runtime.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/shutdown.ts": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/sousFamilles.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/sql.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/types.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/unites.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/utils.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/lib/xlsx/safeImportXLSX.js": {
+      "internal": [],
+      "external": [
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/license.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/local/achats.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/apiKeys.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/bonsLivraison.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/budget.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/commandes.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/costCenters.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/dao.ts": {
+      "internal": [
+        "src/local/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/db.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/documents.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/files.ts": {
+      "internal": [],
+      "external": [
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/local/logs.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/menuGroupes.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/notifications.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/pertes.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/promotions.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/recommendations.ts": {
+      "internal": [
+        "src/lib/db.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/requisitions.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/signalements.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/stockRequisitionne.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/templatesCommandes.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/transferts.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/twoFactor.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/local/validations.ts": {
+      "internal": [
+        "src/local/files.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/main.jsx": {
+      "internal": [
+        "src/context/AuthContext.tsx",
+        "src/context/HelpProvider.jsx",
+        "src/context/MultiMamaContext.jsx",
+        "src/context/ThemeProvider.jsx",
+        "src/components/CookieConsent.jsx",
+        "src/components/ToastRoot.jsx",
+        "src/components/DebugRibbon.jsx",
+        "src/router.tsx",
+        "src/globals.css"
+      ],
+      "external": [
+        "react",
+        "react-dom/client",
+        "@tanstack/react-query",
+        "nprogress",
+        "/src/shims/selftest",
+        "nprogress/nprogress.css"
+      ],
+      "missing": []
+    },
+    "src/onboarding/steps.ts": {
+      "internal": [
+        "src/db/connection.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/Accueil.jsx": {
+      "internal": [
+        "src/assets/logo-mamastock.png",
+        "src/hooks/useAuth.ts",
+        "src/components/Footer.jsx",
+        "src/components/ui/PreviewBanner.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "framer-motion",
+        "react-router-dom",
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/AideContextuelle.jsx": {
+      "internal": [
+        "src/pages/aide/Aide.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/Alertes.jsx": {
+      "internal": [
+        "src/hooks/useAlerts.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "lucide-react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/BarManager.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/CartePlats.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Consentements.jsx": {
+      "internal": [
+        "src/hooks/useConsentements.js",
+        "src/pages/parametrage/RGPDConsentForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Dashboard.jsx": {
+      "internal": [
+        "src/components/gadgets/GadgetTopFournisseurs.jsx",
+        "src/components/gadgets/GadgetProduitsUtilises.jsx",
+        "src/components/gadgets/GadgetBudgetMensuel.jsx",
+        "src/components/gadgets/GadgetAlerteStockFaible.jsx",
+        "src/components/gadgets/GadgetEvolutionAchats.jsx",
+        "src/components/gadgets/GadgetTachesUrgentes.jsx",
+        "src/components/gadgets/GadgetConsoMoyenne.jsx",
+        "src/components/gadgets/GadgetDerniersAcces.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Debug/Auth.tsx": {
+      "internal": [
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/DossierDonnees.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-fs",
+        "@tauri-apps/plugin-shell"
+      ],
+      "missing": []
+    },
+    "src/pages/EngineeringMenu.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/usePerformanceFiches.js",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/Feedback.jsx": {
+      "internal": [
+        "src/hooks/useFeedback.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/HelpCenter.jsx": {
+      "internal": [
+        "src/hooks/useHelpArticles.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Journal.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useLogs.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Login.jsx": {
+      "internal": [
+        "src/context/AuthContext.tsx",
+        "src/auth/localAccount.ts",
+        "src/pages/login.css"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/NotFound.jsx": {
+      "internal": [
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/Onboarding.tsx": {
+      "internal": [
+        "src/lib/db/sql.ts",
+        "src/auth/localAccount.ts"
+      ],
+      "external": [
+        "react",
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-fs",
+        "@tauri-apps/plugin-shell"
+      ],
+      "missing": []
+    },
+    "src/pages/Parametrage/DossierDonnees.tsx": {
+      "internal": [],
+      "external": [
+        "react",
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-shell"
+      ],
+      "missing": []
+    },
+    "src/pages/Parametrage/Familles.tsx": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Parametrage/SousFamilles.tsx": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Parametrage/Unites.tsx": {
+      "internal": [
+        "src/lib/unites.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/Parametres/Familles.jsx": {
+      "internal": [
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/parametrage/FamilleRow.jsx",
+        "src/forms/FamilleForm.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/hooks/useFamillesWithSousFamilles.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/Pertes.jsx": {
+      "internal": [
+        "src/hooks/usePertes.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/Planning.jsx": {
+      "internal": [
+        "src/hooks/usePlanning.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/PlanningDetail.jsx": {
+      "internal": [
+        "src/hooks/usePlanning.js",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/PlanningForm.jsx": {
+      "internal": [
+        "src/hooks/usePlanning.js",
+        "src/hooks/useProducts.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/PlanningModule.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/Rgpd.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/pages/parametrage/ExportUserData.jsx",
+        "src/components/DeleteAccountButton.jsx",
+        "src/layout/LegalLayout.jsx"
+      ],
+      "external": [
+        "react-router-dom",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/Stock.jsx": {
+      "internal": [
+        "src/hooks/useStock.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "file-saver",
+        "xlsx",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/Utilisateurs.jsx": {
+      "internal": [
+        "src/hooks/useUtilisateurs.js",
+        "src/hooks/useAuth.ts",
+        "src/components/utilisateurs/UtilisateurForm.jsx",
+        "src/components/utilisateurs/UtilisateurDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "file-saver",
+        "xlsx",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/Validations.jsx": {
+      "internal": [
+        "src/hooks/useValidations.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/achats/AchatDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAchats.js",
+        "src/hooks/useAuth.ts",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/achats/AchatForm.jsx": {
+      "internal": [
+        "src/hooks/useAchats.js",
+        "src/hooks/useProduitsAutocomplete.js",
+        "src/components/ui/AutoCompleteField.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/achats/Achats.jsx": {
+      "internal": [
+        "src/hooks/useAchats.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/hooks/useProduitsAutocomplete.js",
+        "src/pages/achats/AchatForm.jsx",
+        "src/pages/achats/AchatDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/achats/AchatRow.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/aide/Aide.jsx": {
+      "internal": [
+        "src/hooks/useAide.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/button.jsx",
+        "src/pages/aide/AideForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/aide/AideForm.jsx": {
+      "internal": [
+        "src/components/ui/ModalGlass.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useAide.js",
+        "src/components/ui/input.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/analyse/Analyse.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useAnalyse.js",
+        "src/hooks/useProduitsAutocomplete.js",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/pages/analyse/AnalyseCostCenter.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/analyse/MenuEngineering.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useMenuEngineering.js",
+        "src/components/fiches/FicheRentabiliteCard.jsx"
+      ],
+      "external": [
+        "react",
+        "recharts",
+        "html2canvas",
+        "jspdf"
+      ],
+      "missing": []
+    },
+    "src/pages/analyse/TableauxDeBord.jsx": {
+      "internal": [
+        "src/pages/dashboard/DashboardBuilder.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/analytique/AnalytiqueDashboard.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useCostCenters.js",
+        "src/hooks/useFamilles.js",
+        "src/hooks/useAnalytique.js"
+      ],
+      "external": [
+        "react",
+        "recharts",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/Blocked.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/CreateMama.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useMamas.js",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/MamaLogo.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/Logout.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/Pending.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/auth/ResetPassword.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/auth/RoleError.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/Unauthorized.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/auth/UpdatePassword.jsx": {
+      "internal": [
+        "src/assets/logo-mamastock.png",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/auth/localAccount.ts",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/bons_livraison/BLCreate.jsx": {
+      "internal": [
+        "src/hooks/data/useFournisseurs.js",
+        "src/pages/bons_livraison/BLForm.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/bons_livraison/BLDetail.jsx": {
+      "internal": [
+        "src/hooks/useBonsLivraison.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/bons_livraison/BLForm.jsx": {
+      "internal": [
+        "src/hooks/useBonsLivraison.js",
+        "src/hooks/useProduitsAutocomplete.js",
+        "src/hooks/useFournisseursAutocomplete.js",
+        "src/components/ui/AutoCompleteField.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/bons_livraison/BonsLivraison.jsx": {
+      "internal": [
+        "src/hooks/useBonsLivraison.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/pages/bons_livraison/BLForm.jsx",
+        "src/pages/bons_livraison/BLDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/bons_livraison/BonLivraisonRow.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/carte/Carte.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useCarte.js",
+        "src/hooks/useFamilles.js",
+        "src/components/ui/tabs.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/catalogue/CatalogueSyncViewer.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/commandes/CommandeDetail.jsx": {
+      "internal": [
+        "src/hooks/useCommandes.js",
+        "src/hooks/useTemplatesCommandes.js",
+        "src/components/pdf/CommandePDF.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "@react-pdf/renderer",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/commandes/CommandeForm.jsx": {
+      "internal": [
+        "src/hooks/useCommandes.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/hooks/useProduitsFournisseur.js",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useTemplatesCommandes.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/commandes/Commandes.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useCommandes.js",
+        "src/hooks/data/useFournisseurs.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/commandes/CommandesEnvoyees.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/appFs.ts",
+        "src/components/ui/button.jsx",
+        "src/hooks/useFournisseurAPI.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/consolidation/AccessMultiSites.jsx": {
+      "internal": [
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/appFs.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/consolidation/Consolidation.jsx": {
+      "internal": [
+        "src/hooks/useConsolidation.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/costboisson/CostBoisson.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/costing/CostingCarte.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useCostingCarte.js",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/cuisine/MenuDuJour.jsx": {
+      "internal": [
+        "src/hooks/useMenuDuJour.js",
+        "src/hooks/useFiches.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/dashboard/DashboardBuilder.jsx": {
+      "internal": [
+        "src/hooks/useDashboards.js",
+        "src/components/dashboard/WidgetRenderer.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/debug/AccessExample.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/debug/AuthDebug.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ResetAuthButton.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/debug/Debug.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/dev/ApiDiagnostic.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/debug/DebugAuth.jsx": {
+      "internal": [
+        "src/context/AuthContext.tsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/debug/DebugRights.jsx": {
+      "internal": [
+        "src/context/AuthContext.tsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/debug/DebugUser.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/documents/DocumentForm.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/select.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/documents/Documents.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useDocuments.js",
+        "src/pages/documents/DocumentForm.jsx",
+        "src/components/documents/DocumentPreview.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/ecarts/Ecarts.jsx": {
+      "internal": [
+        "src/hooks/useEcartsInventaire.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/pages/emails/EmailsEnvoyes.jsx": {
+      "internal": [
+        "src/hooks/useEmailsEnvoyes.js",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useCommandes.js",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/badge.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/pdf/CommandePDF.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "xlsx",
+        "file-saver",
+        "@react-pdf/renderer",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/engineering/MenuEngineering.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useMenuEngineering.js",
+        "src/components/engineering/EngineeringFilters.jsx",
+        "src/components/engineering/EngineeringChart.jsx",
+        "src/components/engineering/ImportVentesExcel.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "html2canvas",
+        "jspdf",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/factures/FactureCreate.jsx": {
+      "internal": [
+        "src/pages/factures/FactureForm.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/factures/FactureDetail.jsx": {
+      "internal": [
+        "src/pages/factures/FactureForm.jsx",
+        "src/features/factures/invoiceMappers.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/factures/FactureForm.jsx": {
+      "internal": [
+        "src/components/FactureLigne.jsx",
+        "src/components/factures/SupplierPicker.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/forms/NumericInput.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/badge.jsx",
+        "src/hooks/useProduitLineDefaults.js",
+        "src/hooks/useZonesStock.js",
+        "src/utils/numberFormat.ts",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react",
+        "react-hook-form",
+        "sonner",
+        "date-fns",
+        "@tanstack/react-query"
+      ],
+      "missing": []
+    },
+    "src/pages/factures/Factures.jsx": {
+      "internal": [
+        "src/hooks/useFactures.js",
+        "src/hooks/data/useFactures.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useFacturesAutocomplete.js",
+        "src/pages/factures/FactureForm.jsx",
+        "src/pages/factures/FactureDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/dropdown-menu.jsx",
+        "src/hooks/useExport.js",
+        "src/lib/db/sql.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/FactureTable.jsx",
+        "src/components/FactureImportModal.jsx",
+        "src/constants/factures.js",
+        "src/components/filters/SupplierFilter.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "lucide-react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/factures/ImportFactures.jsx": {
+      "internal": [
+        "src/hooks/useInvoiceImport.js",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/fiches/FicheDetail.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/hooks/useFiches.js",
+        "src/hooks/useFicheCoutHistory.js",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "xlsx",
+        "jspdf",
+        "recharts",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/pages/fiches/FicheForm.jsx": {
+      "internal": [
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useFiches.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useFamilles.js",
+        "src/hooks/useFichesAutocomplete.js",
+        "src/components/ui/select.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/fiches/FicheLigne.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/fiches/Fiches.jsx": {
+      "internal": [
+        "src/hooks/useFiches.js",
+        "src/hooks/useAuth.ts",
+        "src/pages/fiches/FicheForm.jsx",
+        "src/pages/fiches/FicheDetail.jsx",
+        "src/components/fiches/FicheRow.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/hooks/useFamilles.js",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/ApiFournisseurForm.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/fournisseurs/ApiFournisseurs.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useFournisseurApiConfig.js",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useFournisseurApiConfig.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/FournisseurCreate.jsx": {
+      "internal": [
+        "src/components/fournisseurs/FournisseurFormModal.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/FournisseurDetail.jsx": {
+      "internal": [
+        "src/hooks/useFournisseurStats.js",
+        "src/hooks/useProduitsFournisseur.js",
+        "src/hooks/useFournisseurs.js",
+        "src/lib/db.ts",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/FournisseurDetailPage.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js",
+        "src/pages/fournisseurs/FournisseurDetail.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/FournisseurForm.jsx": {
+      "internal": [
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/Fournisseurs.jsx": {
+      "internal": [
+        "src/hooks/data/useFournisseurs.js",
+        "src/hooks/useFournisseurs.js",
+        "src/hooks/useFournisseurStats.js",
+        "src/hooks/useProduitsFournisseur.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useFournisseursInactifs.js",
+        "src/components/ui/card.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/fournisseurs/FournisseurRow.jsx",
+        "src/components/ui/SmartDialog.jsx",
+        "src/hooks/useExport.js",
+        "src/lib/db/sql.ts",
+        "src/pages/fournisseurs/FournisseurDetail.jsx",
+        "src/pages/fournisseurs/FournisseurForm.jsx",
+        "src/hooks/useAuth.ts",
+        "src/lib/dal/fournisseurs.ts"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "recharts",
+        "lucide-react"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx": {
+      "internal": [
+        "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/select.jsx",
+        "src/lib/db.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx": {
+      "internal": [
+        "src/hooks/useComparatif.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/inventaire/EcartInventaire.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/inventaire/Inventaire.jsx": {
+      "internal": [
+        "src/hooks/useInventaires.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/inventaire/InventaireDetail.jsx": {
+      "internal": [
+        "src/hooks/useInventaires.js",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "xlsx",
+        "jspdf",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/pages/inventaire/InventaireForm.jsx": {
+      "internal": [
+        "src/hooks/useInventaires.js",
+        "src/hooks/useProduitsInventaire.js",
+        "src/hooks/useInventaireZones.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/components/inventaire/InventaireLigneRow.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/inventaire/InventaireZones.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/SmartDialog.jsx",
+        "src/hooks/useInventaireZones.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/Cgu.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/Cgv.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/Confidentialite.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx",
+        "src/hooks/useMamaSettings.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/Contact.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/Licence.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/legal/MentionsLegales.jsx": {
+      "internal": [
+        "src/layout/LegalLayout.jsx",
+        "src/hooks/useMamaSettings.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/menu/MenuDuJour.jsx": {
+      "internal": [
+        "src/hooks/useMenuDuJour.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/menu/MenuDuJourJour.jsx": {
+      "internal": [
+        "src/hooks/useMenuDuJour.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "file-saver",
+        "xlsx",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuDuJour.jsx": {
+      "internal": [
+        "src/hooks/useMenuDuJour.js",
+        "src/hooks/useFiches.js",
+        "src/hooks/useAuth.ts",
+        "src/pages/menus/MenuDuJourForm.jsx",
+        "src/pages/menus/MenuDuJourDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuDuJourDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "file-saver",
+        "xlsx",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuDuJourForm.jsx": {
+      "internal": [
+        "src/hooks/useMenuDuJour.js",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useStorage.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuForm.jsx": {
+      "internal": [
+        "src/hooks/useMenus.js",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useStorage.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuGroupeDetail.jsx": {
+      "internal": [
+        "src/hooks/useMenuGroupe.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuGroupeForm.jsx": {
+      "internal": [
+        "src/hooks/useMenuGroupe.js",
+        "src/hooks/useFiches.js"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuGroupes.jsx": {
+      "internal": [
+        "src/hooks/useMenuGroupe.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/menus/MenuPDF.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/menus/Menus.jsx": {
+      "internal": [
+        "src/hooks/useMenus.js",
+        "src/hooks/useFiches.js",
+        "src/hooks/useAuth.ts",
+        "src/pages/menus/MenuForm.jsx",
+        "src/pages/menus/MenuDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "file-saver",
+        "xlsx",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/mobile/MobileAccueil.jsx": {
+      "internal": [
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/mobile/MobileInventaire.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useInventaires.js",
+        "src/lib/db.ts",
+        "src/components/LiquidBackground/index.js",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/mobile/MobileRequisition.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/db.ts",
+        "src/components/LiquidBackground/index.js",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "react-toastify"
+      ],
+      "missing": []
+    },
+    "src/pages/notifications/NotificationSettingsForm.jsx": {
+      "internal": [
+        "src/hooks/useNotifications.js",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/notifications/NotificationsInbox.jsx": {
+      "internal": [
+        "src/hooks/useNotifications.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/onboarding/OnboardingUtilisateur.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/APIKeys.jsx": {
+      "internal": [
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/hooks/useApiKeys.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/AccessRights.jsx": {
+      "internal": [
+        "src/hooks/useUtilisateurs.js",
+        "src/hooks/useAuth.ts",
+        "src/config/modules.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/CentreCoutForm.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/ExportComptaPage.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/hooks/useExportCompta.js",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/ExportUserData.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/useRGPD.js"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Familles.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/familles.ts",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/InvitationsEnAttente.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/InviteUser.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/MamaForm.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/MamaSettingsForm.jsx": {
+      "internal": [
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/hooks/useMamaSettings.js",
+        "src/hooks/useStorage.js",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Mamas.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useMamas.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/SmartDialog.jsx",
+        "src/pages/parametrage/MamaForm.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Parametrage.jsx": {
+      "internal": [
+        "src/components/ui/tabs.jsx",
+        "src/components/parametrage/ParamFamilles.jsx",
+        "src/components/parametrage/ParamUnites.jsx",
+        "src/components/parametrage/ParamRoles.jsx",
+        "src/components/parametrage/ParamAccess.jsx",
+        "src/components/parametrage/ParamMama.jsx",
+        "src/components/parametrage/ParamCostCenters.jsx",
+        "src/components/parametrage/ParamSecurity.jsx",
+        "src/hooks/useAuth.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/ParametresCommandes.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/Periodes.jsx": {
+      "internal": [
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/hooks/useAuth.ts",
+        "src/hooks/usePeriodes.js",
+        "src/forms/PeriodeForm.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Permissions.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/PermissionsAdmin.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/PermissionsForm.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/RGPDConsentForm.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/RoleForm.jsx": {
+      "internal": [
+        "src/hooks/useRoles.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Roles.jsx": {
+      "internal": [
+        "src/hooks/useRoles.js",
+        "src/components/ui/button.jsx",
+        "src/pages/parametrage/RoleForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/SousFamilles.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/sousFamilles.ts",
+        "src/lib/familles.ts",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/SystemTools.jsx": {
+      "internal": [
+        "src/lib/db.ts",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "sonner",
+        "@tauri-apps/plugin-dialog",
+        "@tauri-apps/plugin-process"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/TemplateCommandeForm.jsx": {
+      "internal": [
+        "src/hooks/useTemplatesCommandes.js",
+        "src/components/ui/button.jsx",
+        "src/local/files.ts"
+      ],
+      "external": [
+        "react",
+        "@tauri-apps/api/path",
+        "@tauri-apps/api/tauri"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/TemplatesCommandes.jsx": {
+      "internal": [
+        "src/hooks/useTemplatesCommandes.js",
+        "src/hooks/data/useFournisseurs.js",
+        "src/pages/parametrage/TemplateCommandeForm.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Unites.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/lib/unites.ts",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/auth/Unauthorized.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Utilisateurs.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/parametrage/ZoneAccess.jsx": {
+      "internal": [
+        "src/hooks/useZoneRights.js",
+        "src/hooks/useZones.js",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/ZoneForm.jsx": {
+      "internal": [
+        "src/hooks/useZones.js",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/tabs.jsx",
+        "src/components/parametrage/ZoneFormProducts.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/parametrage/Zones.jsx": {
+      "internal": [
+        "src/hooks/useZones.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useAuth.ts",
+        "src/pages/auth/Unauthorized.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/planning/SimulationPlanner.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useMenus.js",
+        "src/hooks/useSimulation.js",
+        "src/components/simulation/SimulationDetailsModal.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/produits/ProduitDetail.jsx": {
+      "internal": [
+        "src/hooks/useProducts.js",
+        "src/components/produits/ProduitFormModal.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/produits/priceHelpers.js"
+      ],
+      "external": [
+        "react-router-dom",
+        "react",
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/pages/produits/ProduitForm.jsx": {
+      "internal": [
+        "src/components/LiquidBackground/index.js",
+        "src/components/produits/ProduitForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/produits/Produits.jsx": {
+      "internal": [
+        "src/hooks/useProducts.js",
+        "src/hooks/useFamilles.js",
+        "src/hooks/useSousFamilles.js",
+        "src/hooks/useZonesStock.js",
+        "src/components/ui/LoadingSkeleton.jsx",
+        "src/components/produits/ProduitFormModal.jsx",
+        "src/components/produits/ProduitDetail.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/card.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/produits/ProduitRow.jsx",
+        "src/components/produits/ModalImportProduits.jsx",
+        "src/hooks/useExport.js",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "lucide-react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/promotions/PromotionForm.jsx": {
+      "internal": [
+        "src/components/ui/input.jsx",
+        "src/components/ui/label.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/SecondaryButton.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/promotions/Promotions.jsx": {
+      "internal": [
+        "src/hooks/usePromotions.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/promotions/PromotionRow.jsx",
+        "src/pages/promotions/PromotionForm.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/public/LandingPage.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PageIntro.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react-router-dom",
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/public/Onboarding.jsx": {
+      "internal": [
+        "src/hooks/useOnboarding.js",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/LiquidBackground/index.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "framer-motion"
+      ],
+      "missing": []
+    },
+    "src/pages/public/Signup.jsx": {
+      "internal": [
+        "src/components/ui/MamaLogo.jsx",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/PageWrapper.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/label.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/receptions/Receptions.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/recettes/Recettes.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/reporting/GraphCost.jsx": {
+      "internal": [],
+      "external": [
+        "recharts"
+      ],
+      "missing": []
+    },
+    "src/pages/reporting/Reporting.jsx": {
+      "internal": [
+        "src/hooks/useReportingFinancier.js",
+        "src/components/ui/StatCard.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/reporting/ReportingPDF.jsx": {
+      "internal": [
+        "src/pages/reporting/GraphCost.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/requisitions/RequisitionDetail.jsx": {
+      "internal": [
+        "src/hooks/useRequisitions.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react-router-dom",
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/requisitions/RequisitionForm.jsx": {
+      "internal": [
+        "src/hooks/useRequisitions.js",
+        "src/hooks/useZoneProducts.js",
+        "src/hooks/useZones.js",
+        "src/hooks/useUnites.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/label.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/requisitions/Requisitions.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useZones.js",
+        "src/hooks/useRequisitions.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useUtilisateurs.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner",
+        "xlsx",
+        "jspdf",
+        "react-router-dom",
+        "jspdf-autotable"
+      ],
+      "missing": []
+    },
+    "src/pages/signalements/SignalementDetail.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/signalements/SignalementForm.jsx": {
+      "internal": [
+        "src/hooks/useSignalements.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/PrimaryButton.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/signalements/Signalements.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/simulation/Simulation.jsx": {
+      "internal": [
+        "src/hooks/useSignalements.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/simulation/SimulationForm.jsx": {
+      "internal": [],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/simulation/SimulationMenu.jsx": {
+      "internal": [
+        "src/pages/simulation/SimulationForm.jsx",
+        "src/pages/simulation/SimulationResult.jsx",
+        "src/hooks/useSimulation.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/simulation/SimulationResult.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/stats/Stats.jsx": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/stats/StatsAdvanced.jsx": {
+      "internal": [
+        "src/hooks/useAdvancedStats.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react",
+        "recharts",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/stats/StatsConsolidation.jsx": {
+      "internal": [
+        "src/hooks/useConsolidatedStats.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/stats/StatsCostCenters.jsx": {
+      "internal": [
+        "src/hooks/useCostCenterStats.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/stats/StatsCostCentersPivot.jsx": {
+      "internal": [
+        "src/hooks/useCostCenterMonthlyStats.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/stats/StatsFiches.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/stats/StatsStock.jsx": {
+      "internal": [
+        "src/hooks/useDashboardStats.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx"
+      ],
+      "external": [
+        "react",
+        "xlsx"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/AlertesRupture.jsx": {
+      "internal": [
+        "src/hooks/useRuptureAlerts.js",
+        "src/components/ui/button.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/Inventaire.jsx": {
+      "internal": [
+        "src/hooks/useStock.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/InventaireForm.jsx": {
+      "internal": [
+        "src/components/inventaires/InventaireForm.jsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/Requisitions.jsx": {
+      "internal": [
+        "src/hooks/useRequisitions.js",
+        "src/hooks/useAuth.ts",
+        "src/components/ui/ListingContainer.jsx",
+        "src/components/ui/TableHeader.jsx",
+        "src/components/ui/PaginationFooter.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/requisitions/RequisitionRow.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/TransfertForm.jsx": {
+      "internal": [
+        "src/hooks/useTransferts.js",
+        "src/hooks/useProducts.js",
+        "src/hooks/useZones.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/stock/Transferts.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useTransferts.js",
+        "src/hooks/useZones.js",
+        "src/hooks/useProducts.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/pages/stock/TransfertForm.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/supervision/ComparateurFiches.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/supervision/GroupeParamForm.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/supervision/Logs.jsx": {
+      "internal": [
+        "src/hooks/useAuth.ts",
+        "src/hooks/useLogs.js",
+        "src/components/ui/GlassCard.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/ui/input.jsx",
+        "src/components/ui/button.jsx",
+        "src/components/ui/PrimaryButton.jsx",
+        "src/components/ui/select.jsx",
+        "src/components/ui/checkbox.jsx",
+        "src/components/ui/SmartDialog.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/badge.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/supervision/Rapports.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/supervision/SupervisionGroupe.jsx": {
+      "internal": [
+        "src/components/ui/PageWrapper.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/surcouts/Surcouts.jsx": {
+      "internal": [
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/taches/Alertes.jsx": {
+      "internal": [
+        "src/hooks/useAlerts.js",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx"
+      ],
+      "external": [
+        "react"
+      ],
+      "missing": []
+    },
+    "src/pages/taches/TacheDetail.jsx": {
+      "internal": [
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/hooks/useTasks.js"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/pages/taches/TacheForm.jsx": {
+      "internal": [
+        "src/hooks/useTasks.js",
+        "src/hooks/useUtilisateurs.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/pages/taches/TacheNew.jsx": {
+      "internal": [
+        "src/components/taches/TacheForm.jsx"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/pages/taches/Taches.jsx": {
+      "internal": [
+        "src/hooks/useTasks.js",
+        "src/hooks/useUtilisateurs.js",
+        "src/components/ui/button.jsx",
+        "src/components/ui/LoadingSpinner.jsx",
+        "src/components/ui/TableContainer.jsx",
+        "src/components/taches/TachesKanban.jsx",
+        "src/components/ui/GlassCard.jsx"
+      ],
+      "external": [
+        "react",
+        "react-router-dom",
+        "sonner"
+      ],
+      "missing": []
+    },
+    "src/registerSW.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/router.tsx": {
+      "internal": [
+        "src/pages/Dashboard.jsx",
+        "src/pages/parametrage/Familles.jsx",
+        "src/pages/parametrage/SousFamilles.jsx",
+        "src/pages/parametrage/Unites.jsx",
+        "src/pages/DossierDonnees.jsx",
+        "src/pages/debug/AuthDebug.jsx",
+        "src/components/Sidebar.jsx",
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "react",
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/router/PrivateOutlet.jsx": {
+      "internal": [
+        "src/context/AuthContext.tsx"
+      ],
+      "external": [
+        "react-router-dom"
+      ],
+      "missing": []
+    },
+    "src/services/inventory.ts": {
+      "internal": [
+        "src/db/index.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/shims/crypto.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/shims/selftest.ts": {
+      "internal": [],
+      "external": [
+        "/src/shims/crypto"
+      ],
+      "missing": []
+    },
+    "src/tauri/fsStore.ts": {
+      "internal": [
+        "src/lib/db/sql.ts",
+        "src/lib/paths.ts"
+      ],
+      "external": [
+        "@tauri-apps/api/path",
+        "@tauri-apps/plugin-fs"
+      ],
+      "missing": []
+    },
+    "src/tauri/hmrGuard.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/tauri/isTauri.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/tauriEnv.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/tauriLog.ts": {
+      "internal": [
+        "src/lib/db/sql.ts"
+      ],
+      "external": [
+        "@tauri-apps/plugin-log"
+      ],
+      "missing": []
+    },
+    "src/types/api.d.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/types/requisitions.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/__tests__/number.test.ts": {
+      "internal": [
+        "src/utils/number.ts"
+      ],
+      "external": [
+        "vitest"
+      ],
+      "missing": []
+    },
+    "src/utils/__tests__/numberFormat.test.ts": {
+      "internal": [
+        "src/utils/numberFormat.ts"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/excelUtils.js": {
+      "internal": [
+        "src/utils/importExcelProduits.js",
+        "src/utils/exportExcelProduits.js"
+      ],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/exportExcelProduits.js": {
+      "internal": [
+        "src/local/db.ts"
+      ],
+      "external": [
+        "xlsx",
+        "file-saver"
+      ],
+      "missing": []
+    },
+    "src/utils/factures/mappers.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/formIds.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/formatNumberLive.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/importExcelProduits.js": {
+      "internal": [
+        "src/local/db.ts",
+        "src/hooks/useFamilles.js",
+        "src/hooks/useUnites.js",
+        "src/hooks/useZonesStock.js"
+      ],
+      "external": [
+        "xlsx",
+        "uuid"
+      ],
+      "missing": []
+    },
+    "src/utils/number.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/numberFormat.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/permissions.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/selectSafe.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/utils/watermark.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/vite-env.d.ts": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    },
+    "src/workers/NotificationServiceWorker.js": {
+      "internal": [],
+      "external": [],
+      "missing": []
+    }
+  },
+  "graph": [
+    {
+      "from": "src/App.jsx",
+      "to": "src/router.tsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/context/HelpProvider.jsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/context/MultiMamaContext.jsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/context/ThemeProvider.jsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/components/CookieConsent.jsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/components/ToastRoot.jsx"
+    },
+    {
+      "from": "src/App.jsx",
+      "to": "src/components/DebugRibbon.jsx"
+    },
+    {
+      "from": "src/appFs.ts",
+      "to": "src/lib/paths.ts"
+    },
+    {
+      "from": "src/appFs.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/auth/authAdapter.ts",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/auth/authAdapter.ts",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/auth/localAccount.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/auth/sqlAccount.ts",
+      "to": "src/db/index.ts"
+    },
+    {
+      "from": "src/auth/sqlAuth.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/auth/sqliteAuth.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/components/CookieConsent.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/CookieConsent.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/components/DebugRibbon.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/components/DeleteAccountButton.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/DeleteAccountButton.jsx",
+      "to": "src/hooks/useRGPD.js"
+    },
+    {
+      "from": "src/components/DeleteAccountButton.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/FactureImportModal.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/components/FactureImportModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/FactureImportModal.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/factures/ProduitSearchModal.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/factures/PriceDelta.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/forms/NumericInputFR.jsx"
+    },
+    {
+      "from": "src/components/FactureLigne.jsx",
+      "to": "src/components/forms/MoneyInputFR.jsx"
+    },
+    {
+      "from": "src/components/FactureTable.jsx",
+      "to": "src/components/factures/FactureRow.jsx"
+    },
+    {
+      "from": "src/components/FactureTable.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/components/LiquidBackground/LiquidBackground.jsx",
+      "to": "src/components/LiquidBackground/BubblesParticles.jsx"
+    },
+    {
+      "from": "src/components/ProtectedRoute.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/Reporting/GraphMultiZone.jsx",
+      "to": "src/utils/formIds.js"
+    },
+    {
+      "from": "src/components/ResetAuthButton.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/Sidebar.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/Sidebar.jsx",
+      "to": "src/hooks/useMamaSettings.js"
+    },
+    {
+      "from": "src/components/Sidebar.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/components/Sidebar.jsx",
+      "to": "src/lib/access.js"
+    },
+    {
+      "from": "src/components/achats/AchatRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/analytics/CostCenterAllocationModal.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/analytics/CostCenterAllocationModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/analytics/CostCenterAllocationModal.jsx",
+      "to": "src/hooks/useCostCenters.js"
+    },
+    {
+      "from": "src/components/analytics/CostCenterAllocationModal.jsx",
+      "to": "src/hooks/useMouvementCostCenters.js"
+    },
+    {
+      "from": "src/components/analytics/CostCenterAllocationModal.jsx",
+      "to": "src/hooks/useCostCenterSuggestions.js"
+    },
+    {
+      "from": "src/components/bons_livraison/BonLivraisonRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/dashboard/GadgetConfigForm.jsx",
+      "to": "src/hooks/useGadgets.js"
+    },
+    {
+      "from": "src/components/dashboard/GadgetConfigForm.jsx",
+      "to": "src/components/ui/InputField.jsx"
+    },
+    {
+      "from": "src/components/dashboard/GadgetConfigForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/dashboard/GadgetConfigForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/dashboard/WidgetRenderer.jsx",
+      "to": "src/components/dashboard/DashboardCard.jsx"
+    },
+    {
+      "from": "src/components/dev/ApiDiagnostic.jsx",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/components/documents/DocumentPreview.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/components/documents/DocumentUpload.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/engineering/ImportVentesExcel.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/export/ExportManager.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/export/ExportManager.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/factures/FactureRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/factures/FactureRow.jsx",
+      "to": "src/constants/factures.js"
+    },
+    {
+      "from": "src/components/factures/ProduitSearchModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/factures/ProduitSearchModal.jsx",
+      "to": "src/hooks/useProduitsSearch.js"
+    },
+    {
+      "from": "src/components/factures/SupplierBrowserModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/factures/SupplierBrowserModal.jsx",
+      "to": "src/hooks/useFournisseursBrowse.js"
+    },
+    {
+      "from": "src/components/factures/SupplierPicker.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/factures/SupplierPicker.jsx",
+      "to": "src/hooks/useDebounce.js"
+    },
+    {
+      "from": "src/components/factures/SupplierPicker.jsx",
+      "to": "src/hooks/useFournisseursAutocomplete.js"
+    },
+    {
+      "from": "src/components/factures/SupplierPicker.jsx",
+      "to": "src/components/factures/SupplierBrowserModal.jsx"
+    },
+    {
+      "from": "src/components/factures/SupplierPicker.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/components/fiches/FicheLigne.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/components/fiches/FicheLigne.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/fiches/FicheLigne.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/fiches/FicheRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/filters/SupplierFilter.jsx",
+      "to": "src/hooks/useFournisseursAutocomplete.js"
+    },
+    {
+      "from": "src/components/forms/AutocompleteProduit.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/forms/AutocompleteProduit.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/forms/AutocompleteProduit.jsx",
+      "to": "src/hooks/useProduitsSearch.js"
+    },
+    {
+      "from": "src/components/forms/AutocompleteProduit.jsx",
+      "to": "src/hooks/useDebounce.js"
+    },
+    {
+      "from": "src/components/forms/AutocompleteProduit.jsx",
+      "to": "src/components/forms/ProductPickerModal.jsx"
+    },
+    {
+      "from": "src/components/forms/MoneyInputFR.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/forms/MoneyInputFR.jsx",
+      "to": "src/utils/numberFormat.ts"
+    },
+    {
+      "from": "src/components/forms/ProductPickerModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/forms/ProductPickerModal.jsx",
+      "to": "src/hooks/useProduitsSearch.js"
+    },
+    {
+      "from": "src/components/fournisseurs/FournisseurFormModal.jsx",
+      "to": "src/hooks/useFournisseurs.js"
+    },
+    {
+      "from": "src/components/fournisseurs/FournisseurFormModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/fournisseurs/FournisseurRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetAlerteStockFaible.jsx",
+      "to": "src/hooks/gadgets/useAlerteStockFaible.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetAlerteStockFaible.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetBudgetMensuel.jsx",
+      "to": "src/hooks/gadgets/useBudgetMensuel.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetBudgetMensuel.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetConsoMoyenne.jsx",
+      "to": "src/hooks/gadgets/useConsoMoyenne.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetConsoMoyenne.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetDerniersAcces.jsx",
+      "to": "src/hooks/gadgets/useDerniersAcces.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetDerniersAcces.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetEvolutionAchats.jsx",
+      "to": "src/hooks/gadgets/useEvolutionAchats.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetEvolutionAchats.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetProduitsUtilises.jsx",
+      "to": "src/hooks/gadgets/useProduitsUtilises.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetProduitsUtilises.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetTachesUrgentes.jsx",
+      "to": "src/hooks/gadgets/useTachesUrgentes.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetTachesUrgentes.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/gadgets/GadgetTopFournisseurs.jsx",
+      "to": "src/hooks/gadgets/useTopFournisseurs.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetTopFournisseurs.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/components/gadgets/GadgetTopFournisseurs.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/components/help/DocumentationPanel.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/components/help/DocumentationPanel.jsx",
+      "to": "src/context/HelpProvider.jsx"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/hooks/useFeedback.js"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/components/help/FeedbackForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/components/help/GuidedTour.jsx",
+      "to": "src/context/HelpProvider.jsx"
+    },
+    {
+      "from": "src/components/help/TooltipHelper.jsx",
+      "to": "src/context/HelpProvider.jsx"
+    },
+    {
+      "from": "src/components/ia/RecommandationsBox.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/ia/RecommandationsBox.jsx",
+      "to": "src/hooks/useRecommendations.js"
+    },
+    {
+      "from": "src/components/inventaire/InventaireLigneRow.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/inventaires/InventaireDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/inventaires/InventaireForm.jsx",
+      "to": "src/hooks/useInventaires.js"
+    },
+    {
+      "from": "src/components/inventaires/InventaireForm.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/components/inventaires/InventaireForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/inventaires/InventaireForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/inventaires/InventaireForm.jsx",
+      "to": "src/hooks/useStorage.js"
+    },
+    {
+      "from": "src/components/layout/Sidebar.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/layout/Sidebar.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/components/mouvements/MouvementFormModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/mouvements/MouvementFormModal.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/components/parametrage/FamilleRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/FamilleRow.jsx",
+      "to": "src/components/parametrage/SousFamilleRow.jsx"
+    },
+    {
+      "from": "src/components/parametrage/FamilleRow.jsx",
+      "to": "src/forms/SousFamilleForm.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/hooks/usePermissions.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/hooks/useRoles.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/config/modules.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamAccess.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamCostCenters.jsx",
+      "to": "src/hooks/useCostCenters.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamCostCenters.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/parametrage/ParamCostCenters.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamCostCenters.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamCostCenters.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamFamilles.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamFamilles.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamFamilles.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamFamilles.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/parametrage/ParamFamilles.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamMama.jsx",
+      "to": "src/hooks/useMama.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamMama.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamMama.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/parametrage/ParamMama.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamRoles.jsx",
+      "to": "src/pages/parametrage/Roles.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamSecurity.jsx",
+      "to": "src/components/security/TwoFactorSetup.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamUnites.jsx",
+      "to": "src/hooks/useUnites.js"
+    },
+    {
+      "from": "src/components/parametrage/ParamUnites.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamUnites.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ParamUnites.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/parametrage/ParamUnites.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/parametrage/SousFamilleModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/SousFamilleModal.jsx",
+      "to": "src/components/parametrage/SousFamilleList.jsx"
+    },
+    {
+      "from": "src/components/parametrage/SousFamilleRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/SousFamilleRow.jsx",
+      "to": "src/forms/SousFamilleForm.jsx"
+    },
+    {
+      "from": "src/components/parametrage/UniteRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/UtilisateurRow.jsx",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/components/parametrage/ZoneFormProducts.jsx",
+      "to": "src/hooks/useZoneProducts.js"
+    },
+    {
+      "from": "src/components/parametrage/ZoneFormProducts.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/parametrage/ZoneRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/produits/ModalImportProduits.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/components/produits/ModalImportProduits.jsx",
+      "to": "src/components/ui/ImportPreviewTable.jsx"
+    },
+    {
+      "from": "src/components/produits/ModalImportProduits.jsx",
+      "to": "src/utils/excelUtils.js"
+    },
+    {
+      "from": "src/components/produits/ModalImportProduits.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/produits/ModalImportProduits.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitDetail.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/components/produits/ProduitDetail.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitDetail.jsx",
+      "to": "src/components/produits/priceHelpers.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useSousFamilles.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useUnites.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useZonesStock.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/components/ui/checkbox.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/components/ui/AutoCompleteField.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitForm.jsx",
+      "to": "src/components/ui/badge.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitFormModal.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitFormModal.jsx",
+      "to": "src/components/produits/ProduitForm.jsx"
+    },
+    {
+      "from": "src/components/produits/ProduitRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/promotions/PromotionRow.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/security/TwoFactorSetup.jsx",
+      "to": "src/hooks/useTwoFactorAuth.js"
+    },
+    {
+      "from": "src/components/security/TwoFactorSetup.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/simulation/SimulationDetailsModal.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/components/simulation/SimulationDetailsModal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/simulation/SimulationDetailsModal.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/stock/AlertBadge.jsx",
+      "to": "src/hooks/useRuptureAlerts.js"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/hooks/useTasks.js"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/components/taches/TacheForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/ui/AutoCompleteField.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/ui/AutoCompleteField.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/ui/AutoCompleteZoneField.jsx",
+      "to": "src/components/ui/AutoCompleteField.jsx"
+    },
+    {
+      "from": "src/components/ui/AutoCompleteZoneField.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/components/ui/FormField.jsx",
+      "to": "src/utils/formIds.js"
+    },
+    {
+      "from": "src/components/ui/ImportPreviewTable.jsx",
+      "to": "src/utils/excelUtils.js"
+    },
+    {
+      "from": "src/components/ui/ListingContainer.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/ui/ListingContainer.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/components/ui/LoadingScreen.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/ui/MamaLogo.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/components/ui/MamaLogo.jsx",
+      "to": "src/context/ThemeProvider.jsx"
+    },
+    {
+      "from": "src/components/ui/PageIntro.jsx",
+      "to": "src/components/ui/MamaLogo.jsx"
+    },
+    {
+      "from": "src/components/ui/PageWrapper.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/components/ui/PaginationFooter.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/hooks/useRoles.js"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/hooks/useMamas.js"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/label.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/components/utilisateurs/UtilisateurForm.jsx",
+      "to": "src/config/modules.js"
+    },
+    {
+      "from": "src/constants/accessKeys.js",
+      "to": "src/config/modules.js"
+    },
+    {
+      "from": "src/context/AuthContext.tsx",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/context/AuthContext.tsx",
+      "to": "src/lib/access.js"
+    },
+    {
+      "from": "src/context/AuthContext.tsx",
+      "to": "src/utils/permissions.js"
+    },
+    {
+      "from": "src/context/AuthContext.tsx",
+      "to": "src/constants/roles.js"
+    },
+    {
+      "from": "src/context/HelpProvider.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/context/HelpProvider.jsx",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/context/MultiMamaContext.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/context/MultiMamaContext.jsx",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/context/MultiMamaContext.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/context/ThemeProvider.jsx",
+      "to": "src/hooks/useMamaSettings.js"
+    },
+    {
+      "from": "src/context/ThemeProvider.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/db/client.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/db/connection.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/db/index.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/db/migrate.ts",
+      "to": "src/db/client.ts"
+    },
+    {
+      "from": "src/db/migrate.ts",
+      "to": "src/db/migrationsList.ts"
+    },
+    {
+      "from": "src/db/migrate.ts",
+      "to": "src/lib/paths.ts"
+    },
+    {
+      "from": "src/db/migrationsList.ts",
+      "to": "src/migrations/001_schema.sql"
+    },
+    {
+      "from": "src/db/migrationsList.ts",
+      "to": "src/migrations/002_seed.sql"
+    },
+    {
+      "from": "src/debug/dbSmoke.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/debug/devAuth.ts",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/debug/ensureLocalAdmin.ts",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/forms/FamilleForm.jsx",
+      "to": "src/components/ui/Form.jsx"
+    },
+    {
+      "from": "src/forms/FamilleForm.jsx",
+      "to": "src/components/ui/FormField.jsx"
+    },
+    {
+      "from": "src/forms/FamilleForm.jsx",
+      "to": "src/components/ui/FormActions.jsx"
+    },
+    {
+      "from": "src/forms/FamilleForm.jsx",
+      "to": "src/components/ui/controls/index.jsx"
+    },
+    {
+      "from": "src/forms/PeriodeForm.jsx",
+      "to": "src/components/ui/Form.jsx"
+    },
+    {
+      "from": "src/forms/PeriodeForm.jsx",
+      "to": "src/components/ui/FormField.jsx"
+    },
+    {
+      "from": "src/forms/PeriodeForm.jsx",
+      "to": "src/components/ui/FormActions.jsx"
+    },
+    {
+      "from": "src/forms/PeriodeForm.jsx",
+      "to": "src/components/ui/controls/index.jsx"
+    },
+    {
+      "from": "src/forms/SousFamilleForm.jsx",
+      "to": "src/components/ui/Form.jsx"
+    },
+    {
+      "from": "src/forms/SousFamilleForm.jsx",
+      "to": "src/components/ui/FormField.jsx"
+    },
+    {
+      "from": "src/forms/SousFamilleForm.jsx",
+      "to": "src/components/ui/FormActions.jsx"
+    },
+    {
+      "from": "src/forms/SousFamilleForm.jsx",
+      "to": "src/components/ui/controls/index.jsx"
+    },
+    {
+      "from": "src/forms/UniteForm.jsx",
+      "to": "src/components/ui/Form.jsx"
+    },
+    {
+      "from": "src/forms/UniteForm.jsx",
+      "to": "src/components/ui/FormField.jsx"
+    },
+    {
+      "from": "src/forms/UniteForm.jsx",
+      "to": "src/components/ui/FormActions.jsx"
+    },
+    {
+      "from": "src/forms/UniteForm.jsx",
+      "to": "src/components/ui/controls/index.jsx"
+    },
+    {
+      "from": "src/forms/ZoneForm.jsx",
+      "to": "src/components/ui/Form.jsx"
+    },
+    {
+      "from": "src/forms/ZoneForm.jsx",
+      "to": "src/components/ui/FormField.jsx"
+    },
+    {
+      "from": "src/forms/ZoneForm.jsx",
+      "to": "src/components/ui/FormActions.jsx"
+    },
+    {
+      "from": "src/forms/ZoneForm.jsx",
+      "to": "src/components/ui/controls/index.jsx"
+    },
+    {
+      "from": "src/hooks/data/useFactures.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/data/useFournisseurs.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useAchatsMensuels.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useAchatsMensuels.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useAlerteStockFaible.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useAlerteStockFaible.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useBudgetMensuel.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useBudgetMensuel.js",
+      "to": "src/local/budget.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useConsoMoyenne.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useConsoMoyenne.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useDerniersAcces.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useDerniersAcces.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useEvolutionAchats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useEvolutionAchats.js",
+      "to": "src/hooks/_shared/createAsyncState.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useEvolutionAchats.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useProduitsUtilises.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useProduitsUtilises.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useTachesUrgentes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useTachesUrgentes.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useTopFournisseurs.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/gadgets/useTopFournisseurs.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useAccess.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAchats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAchats.js",
+      "to": "src/local/achats.ts"
+    },
+    {
+      "from": "src/hooks/useAdvancedStats.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useAlerteStockFaible.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAlerteStockFaible.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useAlerts.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useAlerts.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAnalyse.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useAnalyse.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAnalytique.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useAnalytique.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useApiKeys.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useApiKeys.js",
+      "to": "src/local/apiKeys.ts"
+    },
+    {
+      "from": "src/hooks/useAuditLog.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useAuditLog.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useAuth.ts",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/hooks/useBonsLivraison.js",
+      "to": "src/local/bonsLivraison.ts"
+    },
+    {
+      "from": "src/hooks/useBonsLivraison.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useCarte.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useCarte.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useCommandes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useCommandes.js",
+      "to": "src/local/commandes.ts"
+    },
+    {
+      "from": "src/hooks/useComparatif.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useComparatif.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useConsentements.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useConsentements.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useConsolidatedStats.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useConsolidation.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useConsolidation.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenterMonthlyStats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenterMonthlyStats.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenterStats.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenterStats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenterSuggestions.js",
+      "to": "src/local/costCenters.ts"
+    },
+    {
+      "from": "src/hooks/useCostCenters.js",
+      "to": "src/hooks/useAuditLog.js"
+    },
+    {
+      "from": "src/hooks/useCostCenters.js",
+      "to": "src/local/costCenters.ts"
+    },
+    {
+      "from": "src/hooks/useCostingCarte.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useCostingCarte.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useDashboardStats.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useDashboardStats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useDashboards.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useDashboards.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useDocuments.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useDocuments.js",
+      "to": "src/hooks/useStorage.js"
+    },
+    {
+      "from": "src/hooks/useDocuments.js",
+      "to": "src/local/documents.ts"
+    },
+    {
+      "from": "src/hooks/useEcartsInventaire.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useEcartsInventaire.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useEmailsEnvoyes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useEmailsEnvoyes.js",
+      "to": "src/hooks/_shared/createAsyncState.ts"
+    },
+    {
+      "from": "src/hooks/useEmailsEnvoyes.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useEnrichedProducts.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useEnrichedProducts.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useExport.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useExport.js",
+      "to": "src/lib/export/exportHelpers.js"
+    },
+    {
+      "from": "src/hooks/useExportCompta.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useExportCompta.js",
+      "to": "src/lib/export/exportHelpers.js"
+    },
+    {
+      "from": "src/hooks/useExportCompta.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFactures.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFacturesAutocomplete.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFamilles.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFamilles.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFamillesWithSousFamilles.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFamillesWithSousFamilles.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFeedback.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useFeedback.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFicheCoutHistory.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFicheCoutHistory.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFiches.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFiches.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFichesAutocomplete.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFichesAutocomplete.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFichesTechniques.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFichesTechniques.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurAPI.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurAPI.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurAPI.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurApiConfig.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurApiConfig.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurNotes.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurStats.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseurs.js",
+      "to": "src/lib/dal/fournisseurs.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseursAutocomplete.js",
+      "to": "src/hooks/useDebounce.js"
+    },
+    {
+      "from": "src/hooks/useFournisseursAutocomplete.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseursBrowse.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseursInactifs.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseursList.js",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/hooks/useFournisseursRecents.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useFournisseursRecents.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useGadgets.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useGadgets.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useGlobalSearch.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useGlobalSearch.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useGraphiquesMultiZone.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useGraphiquesMultiZone.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useHelpArticles.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useInventaireLignes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useInventaireLignes.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInventaireZones.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useInventaireZones.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInventaireZones.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useInventaires.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useInventaires.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInventaires.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useInvoice.ts",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInvoiceImport.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInvoiceItems.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInvoices.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useInvoices.js",
+      "to": "src/lib/xlsx/safeImportXLSX.js"
+    },
+    {
+      "from": "src/hooks/useLogs.js",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/hooks/useLogs.js",
+      "to": "src/local/logs.ts"
+    },
+    {
+      "from": "src/hooks/useMama.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useMama.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useMamaSettings.js",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/hooks/useMamaSettings.js",
+      "to": "src/lib/access.js"
+    },
+    {
+      "from": "src/hooks/useMamaSettings.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useMamaSwitcher.js",
+      "to": "src/context/MultiMamaContext.jsx"
+    },
+    {
+      "from": "src/hooks/useMamas.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useMamas.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useMamas.js",
+      "to": "src/lib/xlsx/safeImportXLSX.js"
+    },
+    {
+      "from": "src/hooks/useMenuEngineering.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useMenuEngineering.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useMenuGroupe.js",
+      "to": "src/local/menuGroupes.ts"
+    },
+    {
+      "from": "src/hooks/useMouvementCostCenters.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useMouvementCostCenters.js",
+      "to": "src/hooks/useAuditLog.js"
+    },
+    {
+      "from": "src/hooks/useMouvementCostCenters.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useMouvementCostCenters.js",
+      "to": "src/local/costCenters.ts"
+    },
+    {
+      "from": "src/hooks/useNotifications.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useNotifications.js",
+      "to": "src/local/notifications.ts"
+    },
+    {
+      "from": "src/hooks/useOnboarding.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useOnboarding.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/usePerformanceFiches.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/usePerformanceFiches.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePeriodes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePeriodes.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/usePermissions.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/usePermissions.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePermissions.js",
+      "to": "src/lib/xlsx/safeImportXLSX.js"
+    },
+    {
+      "from": "src/hooks/usePertes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePertes.js",
+      "to": "src/hooks/useAuditLog.js"
+    },
+    {
+      "from": "src/hooks/usePertes.js",
+      "to": "src/local/pertes.ts"
+    },
+    {
+      "from": "src/hooks/usePlanning.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/usePlanning.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePriceTrends.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePriceTrends.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useProducts.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useProduitLineDefaults.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useProduitsAutocomplete.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useProduitsAutocomplete.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useProduitsFournisseur.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useProduitsInventaire.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useProduitsSearch.js",
+      "to": "src/hooks/useDebounce.js"
+    },
+    {
+      "from": "src/hooks/useProduitsSearch.js",
+      "to": "src/lib/react-query.js"
+    },
+    {
+      "from": "src/hooks/useProduitsSearch.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/usePromotions.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/usePromotions.js",
+      "to": "src/local/promotions.ts"
+    },
+    {
+      "from": "src/hooks/useRGPD.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useRGPD.js",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/hooks/useRecommendations.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useRecommendations.js",
+      "to": "src/local/recommendations.ts"
+    },
+    {
+      "from": "src/hooks/useReportingFinancier.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useReportingFinancier.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useReportingFinancier.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useRequisitions.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useRequisitions.js",
+      "to": "src/local/requisitions.ts"
+    },
+    {
+      "from": "src/hooks/useRoles.js",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/hooks/useRoles.js",
+      "to": "src/constants/roles.js"
+    },
+    {
+      "from": "src/hooks/useRuptureAlerts.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useRuptureAlerts.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useSignalements.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useSignalements.js",
+      "to": "src/local/signalements.ts"
+    },
+    {
+      "from": "src/hooks/useSousFamilles.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useSousFamilles.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useStats.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/hooks/useStats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useStock.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useStock.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useStock.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/hooks/useStockRequisitionne.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useStockRequisitionne.js",
+      "to": "src/local/stockRequisitionne.ts"
+    },
+    {
+      "from": "src/hooks/useStorage.js",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/hooks/useTacheAssignation.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useTasks.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useTasks.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useTemplatesCommandes.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useTemplatesCommandes.js",
+      "to": "src/local/templatesCommandes.ts"
+    },
+    {
+      "from": "src/hooks/useTransferts.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useTransferts.js",
+      "to": "src/hooks/usePeriodes.js"
+    },
+    {
+      "from": "src/hooks/useTransferts.js",
+      "to": "src/local/transferts.ts"
+    },
+    {
+      "from": "src/hooks/useTwoFactorAuth.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useTwoFactorAuth.js",
+      "to": "src/local/twoFactor.ts"
+    },
+    {
+      "from": "src/hooks/useUnites.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useUsageStats.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useUsageStats.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useUtilisateurs.js",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/hooks/useUtilisateurs.js",
+      "to": "src/lib/export/exportHelpers.js"
+    },
+    {
+      "from": "src/hooks/useUtilisateurs.js",
+      "to": "src/constants/roles.js"
+    },
+    {
+      "from": "src/hooks/useUtilisateurs.js",
+      "to": "src/lib/xlsx/safeImportXLSX.js"
+    },
+    {
+      "from": "src/hooks/useValidations.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useValidations.js",
+      "to": "src/local/validations.ts"
+    },
+    {
+      "from": "src/hooks/useZoneProducts.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useZoneProducts.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useZoneRights.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useZoneRights.js",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/hooks/useZones.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/hooks/useZonesStock.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/i18n/i18n.js",
+      "to": "src/i18n/locales/fr.json"
+    },
+    {
+      "from": "src/i18n/i18n.js",
+      "to": "src/i18n/locales/en.json"
+    },
+    {
+      "from": "src/i18n/i18n.js",
+      "to": "src/i18n/locales/es.json"
+    },
+    {
+      "from": "src/layout/AdminLayout.jsx",
+      "to": "src/components/layout/Sidebar.jsx"
+    },
+    {
+      "from": "src/layout/AdminLayout.jsx",
+      "to": "src/layout/Navbar.jsx"
+    },
+    {
+      "from": "src/layout/AdminLayout.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/components/Sidebar.jsx"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/hooks/useNotifications.js"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/components/ui/badge.jsx"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/components/Footer.jsx"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/components/stock/AlertBadge.jsx"
+    },
+    {
+      "from": "src/layout/Layout.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/layout/LegalLayout.jsx",
+      "to": "src/components/Footer.jsx"
+    },
+    {
+      "from": "src/layout/LegalLayout.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/hooks/useGlobalSearch.js"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/components/ui/LanguageSelector.jsx"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/lib/shutdown.ts"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/lib/lock.ts"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/layout/Navbar.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/layout/Sidebar.jsx",
+      "to": "src/router.tsx"
+    },
+    {
+      "from": "src/layout/Sidebar.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/layout/Sidebar.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/layout/ViewerLayout.jsx",
+      "to": "src/layout/Navbar.jsx"
+    },
+    {
+      "from": "src/layout/ViewerLayout.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/lib/dal/fournisseurs.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/dal/fournisseurs.ts",
+      "to": "src/lib/types.ts"
+    },
+    {
+      "from": "src/lib/dal/produits.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/dal/produits.ts",
+      "to": "src/lib/types.ts"
+    },
+    {
+      "from": "src/lib/db.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/db.ts",
+      "to": "src/lib/paths.ts"
+    },
+    {
+      "from": "src/lib/db.ts",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/lib/export/exportHelpers.js",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/lib/export/exportHelpers.js",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/familles.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/lock.ts",
+      "to": "src/lib/shutdown.ts"
+    },
+    {
+      "from": "src/lib/lock.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/lock.ts",
+      "to": "src/lib/paths.ts"
+    },
+    {
+      "from": "src/lib/shutdown.ts",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/lib/sousFamilles.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/lib/unites.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/local/achats.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/apiKeys.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/bonsLivraison.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/budget.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/commandes.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/costCenters.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/dao.ts",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/local/db.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/local/documents.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/logs.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/menuGroupes.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/notifications.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/pertes.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/promotions.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/recommendations.ts",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/local/requisitions.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/signalements.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/stockRequisitionne.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/templatesCommandes.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/transferts.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/twoFactor.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/local/validations.ts",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/context/HelpProvider.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/context/MultiMamaContext.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/context/ThemeProvider.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/components/CookieConsent.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/components/ToastRoot.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/components/DebugRibbon.jsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/router.tsx"
+    },
+    {
+      "from": "src/main.jsx",
+      "to": "src/globals.css"
+    },
+    {
+      "from": "src/onboarding/steps.ts",
+      "to": "src/db/connection.ts"
+    },
+    {
+      "from": "src/pages/Accueil.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/pages/Accueil.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Accueil.jsx",
+      "to": "src/components/Footer.jsx"
+    },
+    {
+      "from": "src/pages/Accueil.jsx",
+      "to": "src/components/ui/PreviewBanner.jsx"
+    },
+    {
+      "from": "src/pages/Accueil.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/AideContextuelle.jsx",
+      "to": "src/pages/aide/Aide.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/hooks/useAlerts.js"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Alertes.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/BarManager.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/BarManager.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/CartePlats.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/CartePlats.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/CartePlats.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/CartePlats.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Consentements.jsx",
+      "to": "src/hooks/useConsentements.js"
+    },
+    {
+      "from": "src/pages/Consentements.jsx",
+      "to": "src/pages/parametrage/RGPDConsentForm.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetTopFournisseurs.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetProduitsUtilises.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetBudgetMensuel.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetAlerteStockFaible.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetEvolutionAchats.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetTachesUrgentes.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetConsoMoyenne.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/components/gadgets/GadgetDerniersAcces.jsx"
+    },
+    {
+      "from": "src/pages/Dashboard.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/Debug/Auth.tsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/DossierDonnees.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/DossierDonnees.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/EngineeringMenu.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/EngineeringMenu.jsx",
+      "to": "src/hooks/usePerformanceFiches.js"
+    },
+    {
+      "from": "src/pages/EngineeringMenu.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/hooks/useFeedback.js"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Feedback.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/HelpCenter.jsx",
+      "to": "src/hooks/useHelpArticles.js"
+    },
+    {
+      "from": "src/pages/HelpCenter.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/HelpCenter.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/hooks/useLogs.js"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Journal.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/Login.jsx",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/pages/Login.jsx",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/pages/Login.jsx",
+      "to": "src/pages/login.css"
+    },
+    {
+      "from": "src/pages/NotFound.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/Onboarding.tsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/Onboarding.tsx",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/pages/Parametrage/Familles.tsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/Parametrage/SousFamilles.tsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/Parametrage/Unites.tsx",
+      "to": "src/lib/unites.ts"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/components/parametrage/FamilleRow.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/forms/FamilleForm.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/Parametres/Familles.jsx",
+      "to": "src/hooks/useFamillesWithSousFamilles.js"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/hooks/usePertes.js"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Pertes.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Planning.jsx",
+      "to": "src/hooks/usePlanning.js"
+    },
+    {
+      "from": "src/pages/Planning.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Planning.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Planning.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/Planning.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/PlanningDetail.jsx",
+      "to": "src/hooks/usePlanning.js"
+    },
+    {
+      "from": "src/pages/PlanningDetail.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/PlanningDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/PlanningDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/PlanningDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/hooks/usePlanning.js"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/PlanningForm.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/Rgpd.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Rgpd.jsx",
+      "to": "src/pages/parametrage/ExportUserData.jsx"
+    },
+    {
+      "from": "src/pages/Rgpd.jsx",
+      "to": "src/components/DeleteAccountButton.jsx"
+    },
+    {
+      "from": "src/pages/Rgpd.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/Stock.jsx",
+      "to": "src/hooks/useStock.js"
+    },
+    {
+      "from": "src/pages/Stock.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Stock.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Stock.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/utilisateurs/UtilisateurForm.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/utilisateurs/UtilisateurDetail.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/Utilisateurs.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/hooks/useValidations.js"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/Validations.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/hooks/useAchats.js"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/achats/AchatDetail.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/hooks/useAchats.js"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/hooks/useProduitsAutocomplete.js"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/components/ui/AutoCompleteField.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/achats/AchatForm.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/hooks/useAchats.js"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/hooks/useProduitsAutocomplete.js"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/pages/achats/AchatForm.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/pages/achats/AchatDetail.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/components/achats/AchatRow.jsx"
+    },
+    {
+      "from": "src/pages/achats/Achats.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/hooks/useAide.js"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/aide/Aide.jsx",
+      "to": "src/pages/aide/AideForm.jsx"
+    },
+    {
+      "from": "src/pages/aide/AideForm.jsx",
+      "to": "src/components/ui/ModalGlass.jsx"
+    },
+    {
+      "from": "src/pages/aide/AideForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/aide/AideForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/aide/AideForm.jsx",
+      "to": "src/hooks/useAide.js"
+    },
+    {
+      "from": "src/pages/aide/AideForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/analyse/Analyse.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/analyse/Analyse.jsx",
+      "to": "src/hooks/useAnalyse.js"
+    },
+    {
+      "from": "src/pages/analyse/Analyse.jsx",
+      "to": "src/hooks/useProduitsAutocomplete.js"
+    },
+    {
+      "from": "src/pages/analyse/Analyse.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/analyse/Analyse.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/analyse/MenuEngineering.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/analyse/MenuEngineering.jsx",
+      "to": "src/hooks/useMenuEngineering.js"
+    },
+    {
+      "from": "src/pages/analyse/MenuEngineering.jsx",
+      "to": "src/components/fiches/FicheRentabiliteCard.jsx"
+    },
+    {
+      "from": "src/pages/analyse/TableauxDeBord.jsx",
+      "to": "src/pages/dashboard/DashboardBuilder.jsx"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/hooks/useCostCenters.js"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/pages/analytique/AnalytiqueDashboard.jsx",
+      "to": "src/hooks/useAnalytique.js"
+    },
+    {
+      "from": "src/pages/auth/Blocked.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/Blocked.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/Blocked.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/hooks/useMamas.js"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/components/ui/MamaLogo.jsx"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/auth/CreateMama.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/auth/Logout.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/auth/Logout.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/Logout.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/Pending.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/Pending.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/ResetPassword.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/ResetPassword.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/RoleError.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/RoleError.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/RoleError.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/auth/Unauthorized.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/Unauthorized.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/Unauthorized.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/assets/logo-mamastock.png"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/auth/localAccount.ts"
+    },
+    {
+      "from": "src/pages/auth/UpdatePassword.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/pages/bons_livraison/BLForm.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLCreate.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLDetail.jsx",
+      "to": "src/hooks/useBonsLivraison.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLDetail.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/hooks/useBonsLivraison.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/hooks/useProduitsAutocomplete.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/hooks/useFournisseursAutocomplete.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/AutoCompleteField.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BLForm.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/hooks/useBonsLivraison.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/pages/bons_livraison/BLForm.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/pages/bons_livraison/BLDetail.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/components/bons_livraison/BonLivraisonRow.jsx"
+    },
+    {
+      "from": "src/pages/bons_livraison/BonsLivraison.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/hooks/useCarte.js"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/components/ui/tabs.jsx"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/carte/Carte.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandeDetail.jsx",
+      "to": "src/hooks/useCommandes.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandeDetail.jsx",
+      "to": "src/hooks/useTemplatesCommandes.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandeDetail.jsx",
+      "to": "src/components/pdf/CommandePDF.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandeDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandeForm.jsx",
+      "to": "src/hooks/useCommandes.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandeForm.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandeForm.jsx",
+      "to": "src/hooks/useProduitsFournisseur.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandeForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/commandes/CommandeForm.jsx",
+      "to": "src/hooks/useTemplatesCommandes.js"
+    },
+    {
+      "from": "src/pages/commandes/Commandes.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/commandes/Commandes.jsx",
+      "to": "src/hooks/useCommandes.js"
+    },
+    {
+      "from": "src/pages/commandes/Commandes.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/hooks/useFournisseurAPI.js"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/commandes/CommandesEnvoyees.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/consolidation/AccessMultiSites.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/consolidation/AccessMultiSites.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/consolidation/AccessMultiSites.jsx",
+      "to": "src/appFs.ts"
+    },
+    {
+      "from": "src/pages/consolidation/Consolidation.jsx",
+      "to": "src/hooks/useConsolidation.js"
+    },
+    {
+      "from": "src/pages/consolidation/Consolidation.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/consolidation/Consolidation.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/consolidation/Consolidation.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/costboisson/CostBoisson.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/costboisson/CostBoisson.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/costing/CostingCarte.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/costing/CostingCarte.jsx",
+      "to": "src/hooks/useCostingCarte.js"
+    },
+    {
+      "from": "src/pages/costing/CostingCarte.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/costing/CostingCarte.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/costing/CostingCarte.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/cuisine/MenuDuJour.jsx",
+      "to": "src/hooks/useMenuDuJour.js"
+    },
+    {
+      "from": "src/pages/cuisine/MenuDuJour.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/cuisine/MenuDuJour.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/dashboard/DashboardBuilder.jsx",
+      "to": "src/hooks/useDashboards.js"
+    },
+    {
+      "from": "src/pages/dashboard/DashboardBuilder.jsx",
+      "to": "src/components/dashboard/WidgetRenderer.jsx"
+    },
+    {
+      "from": "src/pages/dashboard/DashboardBuilder.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/dashboard/DashboardBuilder.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/debug/AccessExample.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/debug/AccessExample.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/debug/AccessExample.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/debug/AuthDebug.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/debug/AuthDebug.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/debug/AuthDebug.jsx",
+      "to": "src/components/ResetAuthButton.jsx"
+    },
+    {
+      "from": "src/pages/debug/Debug.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/debug/Debug.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/debug/Debug.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/debug/Debug.jsx",
+      "to": "src/components/dev/ApiDiagnostic.jsx"
+    },
+    {
+      "from": "src/pages/debug/DebugAuth.jsx",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/pages/debug/DebugRights.jsx",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/pages/debug/DebugUser.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/debug/DebugUser.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/debug/DebugUser.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/documents/DocumentForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/documents/DocumentForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/documents/DocumentForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/documents/DocumentForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/documents/DocumentForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/hooks/useDocuments.js"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/pages/documents/DocumentForm.jsx"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/components/documents/DocumentPreview.jsx"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/documents/Documents.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/hooks/useEcartsInventaire.js"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/ecarts/Ecarts.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/hooks/useEmailsEnvoyes.js"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/hooks/useCommandes.js"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/badge.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/emails/EmailsEnvoyes.jsx",
+      "to": "src/components/pdf/CommandePDF.jsx"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/hooks/useMenuEngineering.js"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/components/engineering/EngineeringFilters.jsx"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/components/engineering/EngineeringChart.jsx"
+    },
+    {
+      "from": "src/pages/engineering/MenuEngineering.jsx",
+      "to": "src/components/engineering/ImportVentesExcel.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureCreate.jsx",
+      "to": "src/pages/factures/FactureForm.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureCreate.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureCreate.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/factures/FactureDetail.jsx",
+      "to": "src/pages/factures/FactureForm.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureDetail.jsx",
+      "to": "src/features/factures/invoiceMappers.ts"
+    },
+    {
+      "from": "src/pages/factures/FactureDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureDetail.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/FactureLigne.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/factures/SupplierPicker.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/forms/NumericInput.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/components/ui/badge.jsx"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/hooks/useProduitLineDefaults.js"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/hooks/useZonesStock.js"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/utils/numberFormat.ts"
+    },
+    {
+      "from": "src/pages/factures/FactureForm.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/useFactures.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/data/useFactures.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/useFacturesAutocomplete.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/pages/factures/FactureForm.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/pages/factures/FactureDetail.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/dropdown-menu.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/hooks/useExport.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/FactureTable.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/FactureImportModal.jsx"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/constants/factures.js"
+    },
+    {
+      "from": "src/pages/factures/Factures.jsx",
+      "to": "src/components/filters/SupplierFilter.jsx"
+    },
+    {
+      "from": "src/pages/factures/ImportFactures.jsx",
+      "to": "src/hooks/useInvoiceImport.js"
+    },
+    {
+      "from": "src/pages/factures/ImportFactures.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/factures/ImportFactures.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/factures/ImportFactures.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fiches/FicheDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheDetail.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheDetail.jsx",
+      "to": "src/hooks/useFicheCoutHistory.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/hooks/useFichesAutocomplete.js"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fiches/FicheForm.jsx",
+      "to": "src/components/fiches/FicheLigne.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/pages/fiches/FicheForm.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/pages/fiches/FicheDetail.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/fiches/FicheRow.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/pages/fiches/Fiches.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/ApiFournisseurs.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/ApiFournisseurs.jsx",
+      "to": "src/hooks/useFournisseurApiConfig.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/ApiFournisseurs.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/ApiFournisseurs.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "to": "src/hooks/useFournisseurApiConfig.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurCreate.jsx",
+      "to": "src/components/fournisseurs/FournisseurFormModal.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurCreate.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurCreate.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/hooks/useFournisseurStats.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/hooks/useProduitsFournisseur.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/hooks/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetail.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+      "to": "src/pages/fournisseurs/FournisseurDetail.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/FournisseurForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useFournisseurStats.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useProduitsFournisseur.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useFournisseursInactifs.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/card.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/fournisseurs/FournisseurRow.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useExport.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/pages/fournisseurs/FournisseurDetail.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/pages/fournisseurs/FournisseurForm.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/Fournisseurs.jsx",
+      "to": "src/lib/dal/fournisseurs.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "to": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "to": "src/hooks/useComparatif.js"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/EcartInventaire.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/Inventaire.jsx",
+      "to": "src/hooks/useInventaires.js"
+    },
+    {
+      "from": "src/pages/inventaire/Inventaire.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/Inventaire.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/Inventaire.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/Inventaire.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireDetail.jsx",
+      "to": "src/hooks/useInventaires.js"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireDetail.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/hooks/useInventaires.js"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/hooks/useProduitsInventaire.js"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/hooks/useInventaireZones.js"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireForm.jsx",
+      "to": "src/components/inventaire/InventaireLigneRow.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/hooks/useInventaireZones.js"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/inventaire/InventaireZones.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/legal/Cgu.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/Cgv.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/Confidentialite.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/Confidentialite.jsx",
+      "to": "src/hooks/useMamaSettings.js"
+    },
+    {
+      "from": "src/pages/legal/Contact.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/Licence.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/MentionsLegales.jsx",
+      "to": "src/layout/LegalLayout.jsx"
+    },
+    {
+      "from": "src/pages/legal/MentionsLegales.jsx",
+      "to": "src/hooks/useMamaSettings.js"
+    },
+    {
+      "from": "src/pages/menu/MenuDuJour.jsx",
+      "to": "src/hooks/useMenuDuJour.js"
+    },
+    {
+      "from": "src/pages/menu/MenuDuJourJour.jsx",
+      "to": "src/hooks/useMenuDuJour.js"
+    },
+    {
+      "from": "src/pages/menus/MenuDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDetail.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/hooks/useMenuDuJour.js"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/pages/menus/MenuDuJourForm.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/pages/menus/MenuDuJourDetail.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJour.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/hooks/useMenuDuJour.js"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuDuJourForm.jsx",
+      "to": "src/hooks/useStorage.js"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/hooks/useMenus.js"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/menus/MenuForm.jsx",
+      "to": "src/hooks/useStorage.js"
+    },
+    {
+      "from": "src/pages/menus/MenuGroupeDetail.jsx",
+      "to": "src/hooks/useMenuGroupe.js"
+    },
+    {
+      "from": "src/pages/menus/MenuGroupeForm.jsx",
+      "to": "src/hooks/useMenuGroupe.js"
+    },
+    {
+      "from": "src/pages/menus/MenuGroupeForm.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/menus/MenuGroupes.jsx",
+      "to": "src/hooks/useMenuGroupe.js"
+    },
+    {
+      "from": "src/pages/menus/MenuPDF.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/hooks/useMenus.js"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/hooks/useFiches.js"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/pages/menus/MenuForm.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/pages/menus/MenuDetail.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/menus/Menus.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/mobile/MobileAccueil.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/mobile/MobileInventaire.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/mobile/MobileInventaire.jsx",
+      "to": "src/hooks/useInventaires.js"
+    },
+    {
+      "from": "src/pages/mobile/MobileInventaire.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/mobile/MobileInventaire.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/mobile/MobileInventaire.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/mobile/MobileRequisition.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/mobile/MobileRequisition.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/mobile/MobileRequisition.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/mobile/MobileRequisition.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "to": "src/hooks/useNotifications.js"
+    },
+    {
+      "from": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationSettingsForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationsInbox.jsx",
+      "to": "src/hooks/useNotifications.js"
+    },
+    {
+      "from": "src/pages/notifications/NotificationsInbox.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationsInbox.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/notifications/NotificationsInbox.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/onboarding/OnboardingUtilisateur.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/onboarding/OnboardingUtilisateur.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/onboarding/OnboardingUtilisateur.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/hooks/useApiKeys.js"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/APIKeys.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/AccessRights.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/pages/parametrage/AccessRights.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/AccessRights.jsx",
+      "to": "src/config/modules.js"
+    },
+    {
+      "from": "src/pages/parametrage/AccessRights.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/AccessRights.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/CentreCoutForm.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ExportComptaPage.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ExportComptaPage.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ExportComptaPage.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ExportComptaPage.jsx",
+      "to": "src/hooks/useExportCompta.js"
+    },
+    {
+      "from": "src/pages/parametrage/ExportComptaPage.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/parametrage/ExportUserData.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ExportUserData.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/ExportUserData.jsx",
+      "to": "src/hooks/useRGPD.js"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/lib/familles.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Familles.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/parametrage/InvitationsEnAttente.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/InviteUser.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/hooks/useMamaSettings.js"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/hooks/useStorage.js"
+    },
+    {
+      "from": "src/pages/parametrage/MamaSettingsForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/hooks/useMamas.js"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/pages/parametrage/MamaForm.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Mamas.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/ui/tabs.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamFamilles.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamUnites.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamRoles.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamAccess.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamMama.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamCostCenters.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/components/parametrage/ParamSecurity.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Parametrage.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/ParametresCommandes.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/hooks/usePeriodes.js"
+    },
+    {
+      "from": "src/pages/parametrage/Periodes.jsx",
+      "to": "src/forms/PeriodeForm.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Permissions.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/PermissionsAdmin.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/PermissionsForm.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/RGPDConsentForm.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/RoleForm.jsx",
+      "to": "src/hooks/useRoles.js"
+    },
+    {
+      "from": "src/pages/parametrage/RoleForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Roles.jsx",
+      "to": "src/hooks/useRoles.js"
+    },
+    {
+      "from": "src/pages/parametrage/Roles.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Roles.jsx",
+      "to": "src/pages/parametrage/RoleForm.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/lib/sousFamilles.ts"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/lib/familles.ts"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/SousFamilles.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/parametrage/SystemTools.jsx",
+      "to": "src/lib/db.ts"
+    },
+    {
+      "from": "src/pages/parametrage/SystemTools.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/parametrage/TemplateCommandeForm.jsx",
+      "to": "src/hooks/useTemplatesCommandes.js"
+    },
+    {
+      "from": "src/pages/parametrage/TemplateCommandeForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/TemplateCommandeForm.jsx",
+      "to": "src/local/files.ts"
+    },
+    {
+      "from": "src/pages/parametrage/TemplatesCommandes.jsx",
+      "to": "src/hooks/useTemplatesCommandes.js"
+    },
+    {
+      "from": "src/pages/parametrage/TemplatesCommandes.jsx",
+      "to": "src/hooks/data/useFournisseurs.js"
+    },
+    {
+      "from": "src/pages/parametrage/TemplatesCommandes.jsx",
+      "to": "src/pages/parametrage/TemplateCommandeForm.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/TemplatesCommandes.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/lib/unites.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Unites.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Utilisateurs.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/hooks/useZoneRights.js"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneAccess.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/ui/tabs.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/ZoneForm.jsx",
+      "to": "src/components/parametrage/ZoneFormProducts.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Zones.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/parametrage/Zones.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Zones.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/parametrage/Zones.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/parametrage/Zones.jsx",
+      "to": "src/pages/auth/Unauthorized.jsx"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/hooks/useMenus.js"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/hooks/useSimulation.js"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/components/simulation/SimulationDetailsModal.jsx"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/planning/SimulationPlanner.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/components/produits/ProduitFormModal.jsx"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/produits/ProduitDetail.jsx",
+      "to": "src/components/produits/priceHelpers.js"
+    },
+    {
+      "from": "src/pages/produits/ProduitForm.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/produits/ProduitForm.jsx",
+      "to": "src/components/produits/ProduitForm.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useSousFamilles.js"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useZonesStock.js"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/LoadingSkeleton.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/produits/ProduitFormModal.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/produits/ProduitDetail.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/ui/card.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/produits/ProduitRow.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/components/produits/ModalImportProduits.jsx"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/hooks/useExport.js"
+    },
+    {
+      "from": "src/pages/produits/Produits.jsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/pages/promotions/PromotionForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/promotions/PromotionForm.jsx",
+      "to": "src/components/ui/label.jsx"
+    },
+    {
+      "from": "src/pages/promotions/PromotionForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/promotions/PromotionForm.jsx",
+      "to": "src/components/ui/SecondaryButton.jsx"
+    },
+    {
+      "from": "src/pages/promotions/PromotionForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/hooks/usePromotions.js"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/components/promotions/PromotionRow.jsx"
+    },
+    {
+      "from": "src/pages/promotions/Promotions.jsx",
+      "to": "src/pages/promotions/PromotionForm.jsx"
+    },
+    {
+      "from": "src/pages/public/LandingPage.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/public/LandingPage.jsx",
+      "to": "src/components/ui/PageIntro.jsx"
+    },
+    {
+      "from": "src/pages/public/LandingPage.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/public/LandingPage.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/public/Onboarding.jsx",
+      "to": "src/hooks/useOnboarding.js"
+    },
+    {
+      "from": "src/pages/public/Onboarding.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/public/Onboarding.jsx",
+      "to": "src/components/LiquidBackground/index.js"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/MamaLogo.jsx"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/label.jsx"
+    },
+    {
+      "from": "src/pages/public/Signup.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/recettes/Recettes.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/reporting/Reporting.jsx",
+      "to": "src/hooks/useReportingFinancier.js"
+    },
+    {
+      "from": "src/pages/reporting/Reporting.jsx",
+      "to": "src/components/ui/StatCard.jsx"
+    },
+    {
+      "from": "src/pages/reporting/Reporting.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/reporting/ReportingPDF.jsx",
+      "to": "src/pages/reporting/GraphCost.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionDetail.jsx",
+      "to": "src/hooks/useRequisitions.js"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionDetail.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionDetail.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/hooks/useRequisitions.js"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/hooks/useZoneProducts.js"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/hooks/useUnites.js"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/label.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/RequisitionForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/hooks/useRequisitions.js"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/requisitions/Requisitions.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/signalements/SignalementForm.jsx",
+      "to": "src/hooks/useSignalements.js"
+    },
+    {
+      "from": "src/pages/signalements/SignalementForm.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/signalements/SignalementForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/signalements/SignalementForm.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/simulation/Simulation.jsx",
+      "to": "src/hooks/useSignalements.js"
+    },
+    {
+      "from": "src/pages/simulation/Simulation.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/simulation/Simulation.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/simulation/Simulation.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/simulation/SimulationMenu.jsx",
+      "to": "src/pages/simulation/SimulationForm.jsx"
+    },
+    {
+      "from": "src/pages/simulation/SimulationMenu.jsx",
+      "to": "src/pages/simulation/SimulationResult.jsx"
+    },
+    {
+      "from": "src/pages/simulation/SimulationMenu.jsx",
+      "to": "src/hooks/useSimulation.js"
+    },
+    {
+      "from": "src/pages/stats/StatsAdvanced.jsx",
+      "to": "src/hooks/useAdvancedStats.js"
+    },
+    {
+      "from": "src/pages/stats/StatsAdvanced.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stats/StatsAdvanced.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsAdvanced.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsConsolidation.jsx",
+      "to": "src/hooks/useConsolidatedStats.js"
+    },
+    {
+      "from": "src/pages/stats/StatsConsolidation.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stats/StatsConsolidation.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsConsolidation.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsConsolidation.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCenters.jsx",
+      "to": "src/hooks/useCostCenterStats.js"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCenters.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCenters.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCenters.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCenters.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "to": "src/hooks/useCostCenterMonthlyStats.js"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsCostCentersPivot.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsFiches.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsStock.jsx",
+      "to": "src/hooks/useDashboardStats.js"
+    },
+    {
+      "from": "src/pages/stats/StatsStock.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stats/StatsStock.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsStock.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/stats/StatsStock.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stock/AlertesRupture.jsx",
+      "to": "src/hooks/useRuptureAlerts.js"
+    },
+    {
+      "from": "src/pages/stock/AlertesRupture.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stock/Inventaire.jsx",
+      "to": "src/hooks/useStock.js"
+    },
+    {
+      "from": "src/pages/stock/Inventaire.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stock/Inventaire.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/stock/Inventaire.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/stock/InventaireForm.jsx",
+      "to": "src/components/inventaires/InventaireForm.jsx"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/hooks/useRequisitions.js"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/components/ui/ListingContainer.jsx"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/components/ui/TableHeader.jsx"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/components/ui/PaginationFooter.jsx"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stock/Requisitions.jsx",
+      "to": "src/components/requisitions/RequisitionRow.jsx"
+    },
+    {
+      "from": "src/pages/stock/TransfertForm.jsx",
+      "to": "src/hooks/useTransferts.js"
+    },
+    {
+      "from": "src/pages/stock/TransfertForm.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/stock/TransfertForm.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/stock/TransfertForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stock/TransfertForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/hooks/useTransferts.js"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/hooks/useZones.js"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/hooks/useProducts.js"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/stock/Transferts.jsx",
+      "to": "src/pages/stock/TransfertForm.jsx"
+    },
+    {
+      "from": "src/pages/supervision/ComparateurFiches.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/supervision/GroupeParamForm.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/hooks/useAuth.ts"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/hooks/useLogs.js"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/input.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/PrimaryButton.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/select.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/checkbox.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/SmartDialog.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Logs.jsx",
+      "to": "src/components/ui/badge.jsx"
+    },
+    {
+      "from": "src/pages/supervision/Rapports.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/supervision/SupervisionGroupe.jsx",
+      "to": "src/components/ui/PageWrapper.jsx"
+    },
+    {
+      "from": "src/pages/surcouts/Surcouts.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/taches/Alertes.jsx",
+      "to": "src/hooks/useAlerts.js"
+    },
+    {
+      "from": "src/pages/taches/Alertes.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/taches/Alertes.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/taches/TacheDetail.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/taches/TacheDetail.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/taches/TacheDetail.jsx",
+      "to": "src/hooks/useTasks.js"
+    },
+    {
+      "from": "src/pages/taches/TacheForm.jsx",
+      "to": "src/hooks/useTasks.js"
+    },
+    {
+      "from": "src/pages/taches/TacheForm.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/pages/taches/TacheForm.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/taches/TacheForm.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/pages/taches/TacheNew.jsx",
+      "to": "src/components/taches/TacheForm.jsx"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/hooks/useTasks.js"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/hooks/useUtilisateurs.js"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/components/ui/button.jsx"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/components/ui/LoadingSpinner.jsx"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/components/ui/TableContainer.jsx"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/components/taches/TachesKanban.jsx"
+    },
+    {
+      "from": "src/pages/taches/Taches.jsx",
+      "to": "src/components/ui/GlassCard.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/Dashboard.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/parametrage/Familles.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/parametrage/SousFamilles.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/parametrage/Unites.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/DossierDonnees.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/pages/debug/AuthDebug.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/components/Sidebar.jsx"
+    },
+    {
+      "from": "src/router.tsx",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/router/PrivateOutlet.jsx",
+      "to": "src/context/AuthContext.tsx"
+    },
+    {
+      "from": "src/services/inventory.ts",
+      "to": "src/db/index.ts"
+    },
+    {
+      "from": "src/tauri/fsStore.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/tauri/fsStore.ts",
+      "to": "src/lib/paths.ts"
+    },
+    {
+      "from": "src/tauriLog.ts",
+      "to": "src/lib/db/sql.ts"
+    },
+    {
+      "from": "src/utils/__tests__/number.test.ts",
+      "to": "src/utils/number.ts"
+    },
+    {
+      "from": "src/utils/__tests__/numberFormat.test.ts",
+      "to": "src/utils/numberFormat.ts"
+    },
+    {
+      "from": "src/utils/excelUtils.js",
+      "to": "src/utils/importExcelProduits.js"
+    },
+    {
+      "from": "src/utils/excelUtils.js",
+      "to": "src/utils/exportExcelProduits.js"
+    },
+    {
+      "from": "src/utils/exportExcelProduits.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/utils/importExcelProduits.js",
+      "to": "src/local/db.ts"
+    },
+    {
+      "from": "src/utils/importExcelProduits.js",
+      "to": "src/hooks/useFamilles.js"
+    },
+    {
+      "from": "src/utils/importExcelProduits.js",
+      "to": "src/hooks/useUnites.js"
+    },
+    {
+      "from": "src/utils/importExcelProduits.js",
+      "to": "src/hooks/useZonesStock.js"
+    }
+  ],
+  "pageSidebar": [
+    {
+      "label": "Dashboard",
+      "path": "dashboard",
+      "file": "src/pages/Dashboard.jsx",
+      "group": "Dashboard"
+    },
+    {
+      "label": "Familles",
+      "path": "parametrage/familles",
+      "file": "src/pages/parametrage/Familles.jsx",
+      "group": "Parametrage"
+    },
+    {
+      "label": "SousFamilles",
+      "path": "parametrage/sousfamilles",
+      "file": "src/pages/parametrage/SousFamilles.jsx",
+      "group": "Parametrage"
+    },
+    {
+      "label": "Unites",
+      "path": "parametrage/unites",
+      "file": "src/pages/parametrage/Unites.jsx",
+      "group": "Parametrage"
+    },
+    {
+      "label": "DossierDonnees",
+      "path": "dossierdonnees",
+      "file": "src/pages/DossierDonnees.jsx",
+      "group": "DossierDonnees"
+    },
+    {
+      "label": "AuthDebug",
+      "path": "debug/authdebug",
+      "file": "src/pages/debug/AuthDebug.jsx",
+      "group": "Debug"
+    }
+  ],
+  "orphans": [
+    "src/pages/Accueil.jsx",
+    "src/pages/AideContextuelle.jsx",
+    "src/pages/Alertes.jsx",
+    "src/pages/BarManager.jsx",
+    "src/pages/CartePlats.jsx",
+    "src/pages/Consentements.jsx",
+    "src/pages/Debug/Auth.tsx",
+    "src/pages/EngineeringMenu.jsx",
+    "src/pages/Feedback.jsx",
+    "src/pages/HelpCenter.jsx",
+    "src/pages/Journal.jsx",
+    "src/pages/Login.jsx",
+    "src/pages/NotFound.jsx",
+    "src/pages/Onboarding.tsx",
+    "src/pages/Parametrage/DossierDonnees.tsx",
+    "src/pages/Parametrage/Familles.tsx",
+    "src/pages/Parametrage/SousFamilles.tsx",
+    "src/pages/Parametrage/Unites.tsx",
+    "src/pages/Parametres/Familles.jsx",
+    "src/pages/Pertes.jsx",
+    "src/pages/Planning.jsx",
+    "src/pages/PlanningDetail.jsx",
+    "src/pages/PlanningForm.jsx",
+    "src/pages/PlanningModule.jsx",
+    "src/pages/Rgpd.jsx",
+    "src/pages/Stock.jsx",
+    "src/pages/Utilisateurs.jsx",
+    "src/pages/Validations.jsx",
+    "src/pages/achats/AchatDetail.jsx",
+    "src/pages/achats/AchatForm.jsx",
+    "src/pages/achats/Achats.jsx",
+    "src/pages/aide/Aide.jsx",
+    "src/pages/aide/AideForm.jsx",
+    "src/pages/analyse/Analyse.jsx",
+    "src/pages/analyse/AnalyseCostCenter.jsx",
+    "src/pages/analyse/MenuEngineering.jsx",
+    "src/pages/analyse/TableauxDeBord.jsx",
+    "src/pages/analytique/AnalytiqueDashboard.jsx",
+    "src/pages/auth/Blocked.jsx",
+    "src/pages/auth/CreateMama.jsx",
+    "src/pages/auth/Logout.jsx",
+    "src/pages/auth/Pending.jsx",
+    "src/pages/auth/ResetPassword.jsx",
+    "src/pages/auth/RoleError.jsx",
+    "src/pages/auth/Unauthorized.jsx",
+    "src/pages/auth/UpdatePassword.jsx",
+    "src/pages/bons_livraison/BLCreate.jsx",
+    "src/pages/bons_livraison/BLDetail.jsx",
+    "src/pages/bons_livraison/BLForm.jsx",
+    "src/pages/bons_livraison/BonsLivraison.jsx",
+    "src/pages/carte/Carte.jsx",
+    "src/pages/catalogue/CatalogueSyncViewer.jsx",
+    "src/pages/commandes/CommandeDetail.jsx",
+    "src/pages/commandes/CommandeForm.jsx",
+    "src/pages/commandes/Commandes.jsx",
+    "src/pages/commandes/CommandesEnvoyees.jsx",
+    "src/pages/consolidation/AccessMultiSites.jsx",
+    "src/pages/consolidation/Consolidation.jsx",
+    "src/pages/costboisson/CostBoisson.jsx",
+    "src/pages/costing/CostingCarte.jsx",
+    "src/pages/cuisine/MenuDuJour.jsx",
+    "src/pages/dashboard/DashboardBuilder.jsx",
+    "src/pages/debug/AccessExample.jsx",
+    "src/pages/debug/Debug.jsx",
+    "src/pages/debug/DebugAuth.jsx",
+    "src/pages/debug/DebugRights.jsx",
+    "src/pages/debug/DebugUser.jsx",
+    "src/pages/documents/DocumentForm.jsx",
+    "src/pages/documents/Documents.jsx",
+    "src/pages/ecarts/Ecarts.jsx",
+    "src/pages/emails/EmailsEnvoyes.jsx",
+    "src/pages/engineering/MenuEngineering.jsx",
+    "src/pages/factures/FactureCreate.jsx",
+    "src/pages/factures/FactureDetail.jsx",
+    "src/pages/factures/FactureForm.jsx",
+    "src/pages/factures/Factures.jsx",
+    "src/pages/factures/ImportFactures.jsx",
+    "src/pages/fiches/FicheDetail.jsx",
+    "src/pages/fiches/FicheForm.jsx",
+    "src/pages/fiches/Fiches.jsx",
+    "src/pages/fournisseurs/ApiFournisseurForm.jsx",
+    "src/pages/fournisseurs/ApiFournisseurs.jsx",
+    "src/pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+    "src/pages/fournisseurs/FournisseurCreate.jsx",
+    "src/pages/fournisseurs/FournisseurDetail.jsx",
+    "src/pages/fournisseurs/FournisseurDetailPage.jsx",
+    "src/pages/fournisseurs/FournisseurForm.jsx",
+    "src/pages/fournisseurs/Fournisseurs.jsx",
+    "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+    "src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+    "src/pages/inventaire/EcartInventaire.jsx",
+    "src/pages/inventaire/Inventaire.jsx",
+    "src/pages/inventaire/InventaireDetail.jsx",
+    "src/pages/inventaire/InventaireForm.jsx",
+    "src/pages/inventaire/InventaireZones.jsx",
+    "src/pages/legal/Cgu.jsx",
+    "src/pages/legal/Cgv.jsx",
+    "src/pages/legal/Confidentialite.jsx",
+    "src/pages/legal/Contact.jsx",
+    "src/pages/legal/Licence.jsx",
+    "src/pages/legal/MentionsLegales.jsx",
+    "src/pages/menu/MenuDuJour.jsx",
+    "src/pages/menu/MenuDuJourJour.jsx",
+    "src/pages/menus/MenuDetail.jsx",
+    "src/pages/menus/MenuDuJour.jsx",
+    "src/pages/menus/MenuDuJourDetail.jsx",
+    "src/pages/menus/MenuDuJourForm.jsx",
+    "src/pages/menus/MenuForm.jsx",
+    "src/pages/menus/MenuGroupeDetail.jsx",
+    "src/pages/menus/MenuGroupeForm.jsx",
+    "src/pages/menus/MenuGroupes.jsx",
+    "src/pages/menus/MenuPDF.jsx",
+    "src/pages/menus/Menus.jsx",
+    "src/pages/mobile/MobileAccueil.jsx",
+    "src/pages/mobile/MobileInventaire.jsx",
+    "src/pages/mobile/MobileRequisition.jsx",
+    "src/pages/notifications/NotificationSettingsForm.jsx",
+    "src/pages/notifications/NotificationsInbox.jsx",
+    "src/pages/onboarding/OnboardingUtilisateur.jsx",
+    "src/pages/parametrage/APIKeys.jsx",
+    "src/pages/parametrage/AccessRights.jsx",
+    "src/pages/parametrage/CentreCoutForm.jsx",
+    "src/pages/parametrage/ExportComptaPage.jsx",
+    "src/pages/parametrage/ExportUserData.jsx",
+    "src/pages/parametrage/InvitationsEnAttente.jsx",
+    "src/pages/parametrage/InviteUser.jsx",
+    "src/pages/parametrage/MamaForm.jsx",
+    "src/pages/parametrage/MamaSettingsForm.jsx",
+    "src/pages/parametrage/Mamas.jsx",
+    "src/pages/parametrage/Parametrage.jsx",
+    "src/pages/parametrage/ParametresCommandes.jsx",
+    "src/pages/parametrage/Periodes.jsx",
+    "src/pages/parametrage/Permissions.jsx",
+    "src/pages/parametrage/PermissionsAdmin.jsx",
+    "src/pages/parametrage/PermissionsForm.jsx",
+    "src/pages/parametrage/RGPDConsentForm.jsx",
+    "src/pages/parametrage/RoleForm.jsx",
+    "src/pages/parametrage/Roles.jsx",
+    "src/pages/parametrage/SystemTools.jsx",
+    "src/pages/parametrage/TemplateCommandeForm.jsx",
+    "src/pages/parametrage/TemplatesCommandes.jsx",
+    "src/pages/parametrage/Utilisateurs.jsx",
+    "src/pages/parametrage/ZoneAccess.jsx",
+    "src/pages/parametrage/ZoneForm.jsx",
+    "src/pages/parametrage/Zones.jsx",
+    "src/pages/planning/SimulationPlanner.jsx",
+    "src/pages/produits/ProduitDetail.jsx",
+    "src/pages/produits/ProduitForm.jsx",
+    "src/pages/produits/Produits.jsx",
+    "src/pages/promotions/PromotionForm.jsx",
+    "src/pages/promotions/Promotions.jsx",
+    "src/pages/public/LandingPage.jsx",
+    "src/pages/public/Onboarding.jsx",
+    "src/pages/public/Signup.jsx",
+    "src/pages/receptions/Receptions.jsx",
+    "src/pages/recettes/Recettes.jsx",
+    "src/pages/reporting/GraphCost.jsx",
+    "src/pages/reporting/Reporting.jsx",
+    "src/pages/reporting/ReportingPDF.jsx",
+    "src/pages/requisitions/RequisitionDetail.jsx",
+    "src/pages/requisitions/RequisitionForm.jsx",
+    "src/pages/requisitions/Requisitions.jsx",
+    "src/pages/signalements/SignalementDetail.jsx",
+    "src/pages/signalements/SignalementForm.jsx",
+    "src/pages/signalements/Signalements.jsx",
+    "src/pages/simulation/Simulation.jsx",
+    "src/pages/simulation/SimulationForm.jsx",
+    "src/pages/simulation/SimulationMenu.jsx",
+    "src/pages/simulation/SimulationResult.jsx",
+    "src/pages/stats/Stats.jsx",
+    "src/pages/stats/StatsAdvanced.jsx",
+    "src/pages/stats/StatsConsolidation.jsx",
+    "src/pages/stats/StatsCostCenters.jsx",
+    "src/pages/stats/StatsCostCentersPivot.jsx",
+    "src/pages/stats/StatsFiches.jsx",
+    "src/pages/stats/StatsStock.jsx",
+    "src/pages/stock/AlertesRupture.jsx",
+    "src/pages/stock/Inventaire.jsx",
+    "src/pages/stock/InventaireForm.jsx",
+    "src/pages/stock/Requisitions.jsx",
+    "src/pages/stock/TransfertForm.jsx",
+    "src/pages/stock/Transferts.jsx",
+    "src/pages/supervision/ComparateurFiches.jsx",
+    "src/pages/supervision/GroupeParamForm.jsx",
+    "src/pages/supervision/Logs.jsx",
+    "src/pages/supervision/Rapports.jsx",
+    "src/pages/supervision/SupervisionGroupe.jsx",
+    "src/pages/surcouts/Surcouts.jsx",
+    "src/pages/taches/Alertes.jsx",
+    "src/pages/taches/TacheDetail.jsx",
+    "src/pages/taches/TacheForm.jsx",
+    "src/pages/taches/TacheNew.jsx",
+    "src/pages/taches/Taches.jsx"
+  ],
+  "stats": {
+    "pages": 199,
+    "routes": 8,
+    "routedPages": 6,
+    "orphans": 193
+  }
+}

--- a/src-inventory.md
+++ b/src-inventory.md
@@ -1,0 +1,230 @@
+# Inventaire src/
+_Généré: 2025-09-13T10:11:12.959Z_
+
+## Entrypoints
+- `src/main.jsx`
+- `src/router.tsx`
+
+## Router
+- `src/router.tsx`
+
+## Routes
+| path | file |
+| --- | --- |
+| `/` |  |
+| `dashboard` | `src/pages/Dashboard.jsx` |
+| `parametrage/familles` | `src/pages/parametrage/Familles.jsx` |
+| `parametrage/sous-familles` | `src/pages/parametrage/SousFamilles.jsx` |
+| `parametrage/unites` | `src/pages/parametrage/Unites.jsx` |
+| `parametrage/dossier-donnees` | `src/pages/DossierDonnees.jsx` |
+| `debug/auth` | `src/pages/debug/AuthDebug.jsx` |
+| `*` |  |
+
+## Pages routées
+- `src/pages/Dashboard.jsx`
+- `src/pages/parametrage/Familles.jsx`
+- `src/pages/parametrage/SousFamilles.jsx`
+- `src/pages/parametrage/Unites.jsx`
+- `src/pages/DossierDonnees.jsx`
+- `src/pages/debug/AuthDebug.jsx`
+
+## Pages orphelines
+- `src/pages/Accueil.jsx`
+- `src/pages/AideContextuelle.jsx`
+- `src/pages/Alertes.jsx`
+- `src/pages/BarManager.jsx`
+- `src/pages/CartePlats.jsx`
+- `src/pages/Consentements.jsx`
+- `src/pages/Debug/Auth.tsx`
+- `src/pages/EngineeringMenu.jsx`
+- `src/pages/Feedback.jsx`
+- `src/pages/HelpCenter.jsx`
+- `src/pages/Journal.jsx`
+- `src/pages/Login.jsx`
+- `src/pages/NotFound.jsx`
+- `src/pages/Onboarding.tsx`
+- `src/pages/Parametrage/DossierDonnees.tsx`
+- `src/pages/Parametrage/Familles.tsx`
+- `src/pages/Parametrage/SousFamilles.tsx`
+- `src/pages/Parametrage/Unites.tsx`
+- `src/pages/Parametres/Familles.jsx`
+- `src/pages/Pertes.jsx`
+- `src/pages/Planning.jsx`
+- `src/pages/PlanningDetail.jsx`
+- `src/pages/PlanningForm.jsx`
+- `src/pages/PlanningModule.jsx`
+- `src/pages/Rgpd.jsx`
+- `src/pages/Stock.jsx`
+- `src/pages/Utilisateurs.jsx`
+- `src/pages/Validations.jsx`
+- `src/pages/achats/AchatDetail.jsx`
+- `src/pages/achats/AchatForm.jsx`
+- `src/pages/achats/Achats.jsx`
+- `src/pages/aide/Aide.jsx`
+- `src/pages/aide/AideForm.jsx`
+- `src/pages/analyse/Analyse.jsx`
+- `src/pages/analyse/AnalyseCostCenter.jsx`
+- `src/pages/analyse/MenuEngineering.jsx`
+- `src/pages/analyse/TableauxDeBord.jsx`
+- `src/pages/analytique/AnalytiqueDashboard.jsx`
+- `src/pages/auth/Blocked.jsx`
+- `src/pages/auth/CreateMama.jsx`
+- `src/pages/auth/Logout.jsx`
+- `src/pages/auth/Pending.jsx`
+- `src/pages/auth/ResetPassword.jsx`
+- `src/pages/auth/RoleError.jsx`
+- `src/pages/auth/Unauthorized.jsx`
+- `src/pages/auth/UpdatePassword.jsx`
+- `src/pages/bons_livraison/BLCreate.jsx`
+- `src/pages/bons_livraison/BLDetail.jsx`
+- `src/pages/bons_livraison/BLForm.jsx`
+- `src/pages/bons_livraison/BonsLivraison.jsx`
+- `src/pages/carte/Carte.jsx`
+- `src/pages/catalogue/CatalogueSyncViewer.jsx`
+- `src/pages/commandes/CommandeDetail.jsx`
+- `src/pages/commandes/CommandeForm.jsx`
+- `src/pages/commandes/Commandes.jsx`
+- `src/pages/commandes/CommandesEnvoyees.jsx`
+- `src/pages/consolidation/AccessMultiSites.jsx`
+- `src/pages/consolidation/Consolidation.jsx`
+- `src/pages/costboisson/CostBoisson.jsx`
+- `src/pages/costing/CostingCarte.jsx`
+- `src/pages/cuisine/MenuDuJour.jsx`
+- `src/pages/dashboard/DashboardBuilder.jsx`
+- `src/pages/debug/AccessExample.jsx`
+- `src/pages/debug/Debug.jsx`
+- `src/pages/debug/DebugAuth.jsx`
+- `src/pages/debug/DebugRights.jsx`
+- `src/pages/debug/DebugUser.jsx`
+- `src/pages/documents/DocumentForm.jsx`
+- `src/pages/documents/Documents.jsx`
+- `src/pages/ecarts/Ecarts.jsx`
+- `src/pages/emails/EmailsEnvoyes.jsx`
+- `src/pages/engineering/MenuEngineering.jsx`
+- `src/pages/factures/FactureCreate.jsx`
+- `src/pages/factures/FactureDetail.jsx`
+- `src/pages/factures/FactureForm.jsx`
+- `src/pages/factures/Factures.jsx`
+- `src/pages/factures/ImportFactures.jsx`
+- `src/pages/fiches/FicheDetail.jsx`
+- `src/pages/fiches/FicheForm.jsx`
+- `src/pages/fiches/Fiches.jsx`
+- `src/pages/fournisseurs/ApiFournisseurForm.jsx`
+- `src/pages/fournisseurs/ApiFournisseurs.jsx`
+- `src/pages/fournisseurs/FournisseurApiSettingsForm.jsx`
+- `src/pages/fournisseurs/FournisseurCreate.jsx`
+- `src/pages/fournisseurs/FournisseurDetail.jsx`
+- `src/pages/fournisseurs/FournisseurDetailPage.jsx`
+- `src/pages/fournisseurs/FournisseurForm.jsx`
+- `src/pages/fournisseurs/Fournisseurs.jsx`
+- `src/pages/fournisseurs/comparatif/ComparatifPrix.jsx`
+- `src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx`
+- `src/pages/inventaire/EcartInventaire.jsx`
+- `src/pages/inventaire/Inventaire.jsx`
+- `src/pages/inventaire/InventaireDetail.jsx`
+- `src/pages/inventaire/InventaireForm.jsx`
+- `src/pages/inventaire/InventaireZones.jsx`
+- `src/pages/legal/Cgu.jsx`
+- `src/pages/legal/Cgv.jsx`
+- `src/pages/legal/Confidentialite.jsx`
+- `src/pages/legal/Contact.jsx`
+- `src/pages/legal/Licence.jsx`
+- `src/pages/legal/MentionsLegales.jsx`
+- `src/pages/menu/MenuDuJour.jsx`
+- `src/pages/menu/MenuDuJourJour.jsx`
+- `src/pages/menus/MenuDetail.jsx`
+- `src/pages/menus/MenuDuJour.jsx`
+- `src/pages/menus/MenuDuJourDetail.jsx`
+- `src/pages/menus/MenuDuJourForm.jsx`
+- `src/pages/menus/MenuForm.jsx`
+- `src/pages/menus/MenuGroupeDetail.jsx`
+- `src/pages/menus/MenuGroupeForm.jsx`
+- `src/pages/menus/MenuGroupes.jsx`
+- `src/pages/menus/MenuPDF.jsx`
+- `src/pages/menus/Menus.jsx`
+- `src/pages/mobile/MobileAccueil.jsx`
+- `src/pages/mobile/MobileInventaire.jsx`
+- `src/pages/mobile/MobileRequisition.jsx`
+- `src/pages/notifications/NotificationSettingsForm.jsx`
+- `src/pages/notifications/NotificationsInbox.jsx`
+- `src/pages/onboarding/OnboardingUtilisateur.jsx`
+- `src/pages/parametrage/APIKeys.jsx`
+- `src/pages/parametrage/AccessRights.jsx`
+- `src/pages/parametrage/CentreCoutForm.jsx`
+- `src/pages/parametrage/ExportComptaPage.jsx`
+- `src/pages/parametrage/ExportUserData.jsx`
+- `src/pages/parametrage/InvitationsEnAttente.jsx`
+- `src/pages/parametrage/InviteUser.jsx`
+- `src/pages/parametrage/MamaForm.jsx`
+- `src/pages/parametrage/MamaSettingsForm.jsx`
+- `src/pages/parametrage/Mamas.jsx`
+- `src/pages/parametrage/Parametrage.jsx`
+- `src/pages/parametrage/ParametresCommandes.jsx`
+- `src/pages/parametrage/Periodes.jsx`
+- `src/pages/parametrage/Permissions.jsx`
+- `src/pages/parametrage/PermissionsAdmin.jsx`
+- `src/pages/parametrage/PermissionsForm.jsx`
+- `src/pages/parametrage/RGPDConsentForm.jsx`
+- `src/pages/parametrage/RoleForm.jsx`
+- `src/pages/parametrage/Roles.jsx`
+- `src/pages/parametrage/SystemTools.jsx`
+- `src/pages/parametrage/TemplateCommandeForm.jsx`
+- `src/pages/parametrage/TemplatesCommandes.jsx`
+- `src/pages/parametrage/Utilisateurs.jsx`
+- `src/pages/parametrage/ZoneAccess.jsx`
+- `src/pages/parametrage/ZoneForm.jsx`
+- `src/pages/parametrage/Zones.jsx`
+- `src/pages/planning/SimulationPlanner.jsx`
+- `src/pages/produits/ProduitDetail.jsx`
+- `src/pages/produits/ProduitForm.jsx`
+- `src/pages/produits/Produits.jsx`
+- `src/pages/promotions/PromotionForm.jsx`
+- `src/pages/promotions/Promotions.jsx`
+- `src/pages/public/LandingPage.jsx`
+- `src/pages/public/Onboarding.jsx`
+- `src/pages/public/Signup.jsx`
+- `src/pages/receptions/Receptions.jsx`
+- `src/pages/recettes/Recettes.jsx`
+- `src/pages/reporting/GraphCost.jsx`
+- `src/pages/reporting/Reporting.jsx`
+- `src/pages/reporting/ReportingPDF.jsx`
+- `src/pages/requisitions/RequisitionDetail.jsx`
+- `src/pages/requisitions/RequisitionForm.jsx`
+- `src/pages/requisitions/Requisitions.jsx`
+- `src/pages/signalements/SignalementDetail.jsx`
+- `src/pages/signalements/SignalementForm.jsx`
+- `src/pages/signalements/Signalements.jsx`
+- `src/pages/simulation/Simulation.jsx`
+- `src/pages/simulation/SimulationForm.jsx`
+- `src/pages/simulation/SimulationMenu.jsx`
+- `src/pages/simulation/SimulationResult.jsx`
+- `src/pages/stats/Stats.jsx`
+- `src/pages/stats/StatsAdvanced.jsx`
+- `src/pages/stats/StatsConsolidation.jsx`
+- `src/pages/stats/StatsCostCenters.jsx`
+- `src/pages/stats/StatsCostCentersPivot.jsx`
+- `src/pages/stats/StatsFiches.jsx`
+- `src/pages/stats/StatsStock.jsx`
+- `src/pages/stock/AlertesRupture.jsx`
+- `src/pages/stock/Inventaire.jsx`
+- `src/pages/stock/InventaireForm.jsx`
+- `src/pages/stock/Requisitions.jsx`
+- `src/pages/stock/TransfertForm.jsx`
+- `src/pages/stock/Transferts.jsx`
+- `src/pages/supervision/ComparateurFiches.jsx`
+- `src/pages/supervision/GroupeParamForm.jsx`
+- `src/pages/supervision/Logs.jsx`
+- `src/pages/supervision/Rapports.jsx`
+- `src/pages/supervision/SupervisionGroupe.jsx`
+- `src/pages/surcouts/Surcouts.jsx`
+- `src/pages/taches/Alertes.jsx`
+- `src/pages/taches/TacheDetail.jsx`
+- `src/pages/taches/TacheForm.jsx`
+- `src/pages/taches/TacheNew.jsx`
+- `src/pages/taches/Taches.jsx`
+
+## Stats
+- Pages: 199
+- Routes: 8
+- Pages routées: 6
+- Orphelines: 193


### PR DESCRIPTION
## Summary
- add src scanner script to collect pages, routes and dependency graph
- generate updated src inventory and sidebar plan

## Testing
- `node scripts/scan-src.js`
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c541c32d50832da7944c9ddaad0bc3