### PR TITLE
feat: add parametrage DAL modules

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -48,6 +48,21 @@ export async function closeDb() {
   }
 }
 
+export async function selectAll<T = any>(sql: string, params: any[] = []): Promise<T[]> {
+  const db = await getDb();
+  return db.select<T[]>(sql, params);
+}
+
+export async function selectOne<T = any>(sql: string, params: any[] = []): Promise<T | null> {
+  const rows = await selectAll<T>(sql, params);
+  return rows[0] ?? null;
+}
+
+export async function exec(sql: string, params: any[] = []): Promise<void> {
+  const db = await getDb();
+  await db.execute(sql, params);
+}
+
 // ---------- Helpers Dashboard / util ----------
 
 function _assertIdent(name: string): string {

--- a/src/lib/familles.ts
+++ b/src/lib/familles.ts
@@ -1,35 +1,10 @@
-import { getDb } from "@/lib/db/sql";
-
-export interface Famille {
-  id: number;
-  code: string;
-  libelle: string;
-}
+import { selectAll, selectOne, exec } from "@/lib/db/sql";
+export type Famille = { id:number; nom:string; actif:number };
 
 export async function listFamilles(): Promise<Famille[]> {
-  const db = await getDb();
-  return await db.select<Famille[]>(
-    "SELECT id, code, libelle FROM familles ORDER BY libelle;"
-  );
+  return await selectAll<Famille>("SELECT id, nom, actif FROM familles ORDER BY nom ASC");
 }
-
-export async function createFamille(code: string, libelle: string) {
-  const db = await getDb();
-  await db.execute(
-    "INSERT INTO familles (code, libelle) VALUES (?, ?);",
-    [code.trim(), libelle.trim()]
-  );
-}
-
-export async function updateFamille(id: number, code: string, libelle: string) {
-  const db = await getDb();
-  await db.execute(
-    "UPDATE familles SET code = ?, libelle = ? WHERE id = ?;",
-    [code, libelle, id]
-  );
-}
-
-export async function deleteFamille(id: number) {
-  const db = await getDb();
-  await db.execute("DELETE FROM familles WHERE id = ?;", [id]);
-}
+export async function createFamille(nom:string){ await exec("INSERT INTO familles(nom, actif) VALUES(?,1)", [nom.trim()]); }
+export async function renameFamille(id:number, nom:string){ await exec("UPDATE familles SET nom=? WHERE id=?", [nom.trim(), id]); }
+export async function setFamilleActif(id:number, actif:boolean){ await exec("UPDATE familles SET actif=? WHERE id=?", [actif?1:0, id]); }
+export async function deleteFamille(id:number){ await exec("DELETE FROM familles WHERE id=?", [id]); }

--- a/src/lib/sousFamilles.ts
+++ b/src/lib/sousFamilles.ts
@@ -1,37 +1,17 @@
-import { getDb } from "@/lib/db/sql";
+import { selectAll, exec } from "@/lib/db/sql";
+export type SousFamille = { id:number; famille_id:number; nom:string; actif:number };
 
-export async function listSousFamilles() {
-  const db = await getDb();
-  return await db.select(
-    `SELECT sf.id, sf.code, sf.libelle, sf.famille_id, f.libelle as famille
-     FROM sous_familles sf
-     LEFT JOIN familles f ON f.id = sf.famille_id
-     ORDER BY sf.libelle;`
-  );
+export async function listSousFamilles(): Promise<SousFamille[]> {
+  return await selectAll<SousFamille>(`
+    SELECT sf.id, sf.famille_id, sf.nom, sf.actif
+    FROM sous_familles sf
+    JOIN familles f ON f.id = sf.famille_id
+    ORDER BY f.nom ASC, sf.nom ASC
+  `);
 }
-
-export async function createSousFamille(code: string, libelle: string, famille_id: number) {
-  const db = await getDb();
-  await db.execute(
-    "INSERT INTO sous_familles (code, libelle, famille_id) VALUES (?, ?, ?);",
-    [code.trim(), libelle.trim(), famille_id]
-  );
+export async function createSousFamille(familleId:number, nom:string){
+  await exec("INSERT INTO sous_familles(famille_id, nom, actif) VALUES(?,?,1)", [familleId, nom.trim()]);
 }
-
-export async function deleteSousFamille(id: number) {
-  const db = await getDb();
-  await db.execute("DELETE FROM sous_familles WHERE id = ?;", [id]);
-}
-
-export async function updateSousFamille(
-  id: number,
-  famille_id: number,
-  code: string,
-  libelle: string
-) {
-  const db = await getDb();
-  await db.execute(
-    "UPDATE sous_familles SET famille_id = ?, code = ?, libelle = ? WHERE id = ?;",
-    [famille_id, code, libelle, id]
-  );
-}
+export async function renameSousFamille(id:number, nom:string){ await exec("UPDATE sous_familles SET nom=? WHERE id=?", [nom.trim(), id]); }
+export async function setSousFamilleActif(id:number, actif:boolean){ await exec("UPDATE sous_familles SET actif=? WHERE id=?", [actif?1:0, id]); }
+export async function deleteSousFamille(id:number){ await exec("DELETE FROM sous_familles WHERE id=?", [id]); }

--- a/src/lib/unites.ts
+++ b/src/lib/unites.ts
@@ -1,27 +1,19 @@
-import { getDb } from "@/lib/db/sql";
+import { getDb, selectAll, selectOne, exec } from "@/lib/db/sql";
 
-export interface Unite {
-  id: number;
-  code: string;
-  libelle: string;
-}
+export type Unite = { id:number; nom:string; abbr?:string|null; actif:number };
 
 export async function listUnites(): Promise<Unite[]> {
-  const db = await getDb();
-  return db.select<Unite[]>(
-    "SELECT id, code, libelle FROM unites ORDER BY libelle;"
-  );
+  return await selectAll<Unite>("SELECT id, nom, abbr, actif FROM unites ORDER BY nom ASC");
 }
-
-export async function createUnite(code: string, libelle: string) {
-  const db = await getDb();
-  await db.execute(
-    "INSERT INTO unites (code, libelle) VALUES (?, ?);",
-    [code.trim(), libelle.trim()]
-  );
+export async function getUnite(id:number): Promise<Unite|null> {
+  return await selectOne<Unite>("SELECT id, nom, abbr, actif FROM unites WHERE id = ?", [id]);
 }
-
-export async function deleteUnite(id: number) {
-  const db = await getDb();
-  await db.execute("DELETE FROM unites WHERE id = ?;", [id]);
+export async function createUnite(nom:string, abbr?:string|null){
+  await exec("INSERT INTO unites(nom, abbr, actif) VALUES(?, ?, 1)", [nom.trim(), abbr ?? null]);
+}
+export async function updateUnite(id:number, nom:string, abbr?:string|null, actif:boolean=true){
+  await exec("UPDATE unites SET nom=?, abbr=?, actif=? WHERE id=?", [nom.trim(), abbr ?? null, actif?1:0, id]);
+}
+export async function deleteUnite(id:number){
+  await exec("DELETE FROM unites WHERE id=?", [id]);
 }

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -2,13 +2,13 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import { listFamilles, createFamille, updateFamille, deleteFamille } from '@/lib/familles';
+import { listFamilles, createFamille, renameFamille, deleteFamille } from '@/lib/familles';
 import ListingContainer from '@/components/ui/ListingContainer';
 import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri, getDb } from '@/lib/db/sql';
+import { isTauri } from '@/lib/db/sql';
 
 export default function Familles() {
   const { hasAccess, loading: authLoading } = useAuth();
@@ -37,9 +37,9 @@ export default function Familles() {
     e.preventDefault();
     try {
       if (edit?.id) {
-        await updateFamille(edit.id, edit.code || '', edit.libelle || '');
+        await renameFamille(edit.id, edit.nom || '');
       } else {
-        await createFamille(edit?.code || '', edit?.libelle || '');
+        await createFamille(edit?.nom || '');
       }
       toast.success('Famille enregistrée');
       setEdit(null);
@@ -70,22 +70,20 @@ export default function Familles() {
     <div className="p-6 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Familles</h1>
       <TableHeader className="gap-2">
-        <Button onClick={() => setEdit({ code: '', libelle: '' })}>+ Nouvelle famille</Button>
+        <Button onClick={() => setEdit({ nom: '' })}>+ Nouvelle famille</Button>
       </TableHeader>
       <ListingContainer className="w-full overflow-x-auto">
         <table className="text-sm w-full">
           <thead>
             <tr>
-              <th className="px-2 py-1">Code</th>
-              <th className="px-2 py-1">Libellé</th>
+              <th className="px-2 py-1">Nom</th>
               <th className="px-2 py-1">Actions</th>
             </tr>
           </thead>
           <tbody>
             {familles.map((f) => (
               <tr key={f.id}>
-                <td className="px-2 py-1">{f.code}</td>
-                <td className="px-2 py-1">{f.libelle}</td>
+                <td className="px-2 py-1">{f.nom}</td>
                 <td className="px-2 py-1 flex gap-2">
                   <Button size="sm" variant="outline" onClick={() => setEdit(f)}>
                     Modifier
@@ -101,11 +99,11 @@ export default function Familles() {
               </tr>
             ))}
             {familles.length === 0 && (
-              <tr>
-                <td colSpan="3" className="py-2">
-                  Aucune famille
-                </td>
-              </tr>
+            <tr>
+              <td colSpan="2" className="py-2">
+                Aucune famille
+              </td>
+            </tr>
             )}
           </tbody>
         </table>
@@ -117,16 +115,10 @@ export default function Familles() {
             <form onSubmit={handleSubmit} className="flex flex-col gap-2">
               <input
                 className="input"
-                placeholder="Code"
-                value={edit.code || ''}
-                onChange={(e) => setEdit({ ...edit, code: e.target.value })}
-              />
-              <input
-                className="input"
-                placeholder="Libellé"
+                placeholder="Nom"
                 required
-                value={edit.libelle || ''}
-                onChange={(e) => setEdit({ ...edit, libelle: e.target.value })}
+                value={edit.nom || ''}
+                onChange={(e) => setEdit({ ...edit, nom: e.target.value })}
               />
               <div className="flex justify-end gap-2 mt-2">
                 <Button type="button" variant="outline" onClick={() => setEdit(null)}>

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -2,14 +2,14 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import { listSousFamilles, createSousFamille, updateSousFamille, deleteSousFamille } from '@/lib/sousFamilles';
+import { listSousFamilles, createSousFamille, renameSousFamille, deleteSousFamille } from '@/lib/sousFamilles';
 import { listFamilles } from '@/lib/familles';
 import ListingContainer from '@/components/ui/ListingContainer';
 import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri, getDb } from '@/lib/db/sql';
+import { isTauri } from '@/lib/db/sql';
 
 export default function SousFamilles() {
   const { hasAccess, loading: authLoading } = useAuth();
@@ -42,9 +42,9 @@ export default function SousFamilles() {
     e.preventDefault();
     try {
       if (edit?.id) {
-        await updateSousFamille(edit.id, edit.famille_id, edit.code || '', edit.libelle || '');
+        await renameSousFamille(edit.id, edit.nom || '');
       } else {
-        await createSousFamille(edit?.famille_id, edit?.code || '', edit?.libelle || '');
+        await createSousFamille(edit?.famille_id, edit?.nom || '');
       }
       toast.success('Sous-famille enregistrée');
       setEdit(null);
@@ -75,14 +75,13 @@ export default function SousFamilles() {
     <div className="p-6 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Sous-familles</h1>
       <TableHeader className="gap-2">
-        <Button onClick={() => setEdit({ code: '', libelle: '', famille_id: familles[0]?.id })}>+ Nouvelle sous-famille</Button>
+        <Button onClick={() => setEdit({ nom: '', famille_id: familles[0]?.id })}>+ Nouvelle sous-famille</Button>
       </TableHeader>
       <ListingContainer className="w-full overflow-x-auto">
         <table className="text-sm w-full">
           <thead>
             <tr>
-              <th className="px-2 py-1">Code</th>
-              <th className="px-2 py-1">Libellé</th>
+              <th className="px-2 py-1">Nom</th>
               <th className="px-2 py-1">Famille</th>
               <th className="px-2 py-1">Actions</th>
             </tr>
@@ -90,9 +89,8 @@ export default function SousFamilles() {
           <tbody>
             {sousFamilles.map((sf) => (
               <tr key={sf.id}>
-                <td className="px-2 py-1">{sf.code}</td>
-                <td className="px-2 py-1">{sf.libelle}</td>
-                <td className="px-2 py-1">{sf.famille_libelle || ''}</td>
+                <td className="px-2 py-1">{sf.nom}</td>
+                <td className="px-2 py-1">{familles.find((f) => f.id === sf.famille_id)?.nom || ''}</td>
                 <td className="px-2 py-1 flex gap-2">
                   <Button size="sm" variant="outline" onClick={() => setEdit(sf)}>
                     Modifier
@@ -104,11 +102,11 @@ export default function SousFamilles() {
               </tr>
             ))}
             {sousFamilles.length === 0 && (
-              <tr>
-                <td colSpan="4" className="py-2">
-                  Aucune sous-famille
-                </td>
-              </tr>
+            <tr>
+              <td colSpan="3" className="py-2">
+                Aucune sous-famille
+              </td>
+            </tr>
             )}
           </tbody>
         </table>
@@ -120,16 +118,10 @@ export default function SousFamilles() {
             <form onSubmit={handleSubmit} className="flex flex-col gap-2">
               <input
                 className="input"
-                placeholder="Code"
-                value={edit.code || ''}
-                onChange={(e) => setEdit({ ...edit, code: e.target.value })}
-              />
-              <input
-                className="input"
-                placeholder="Libellé"
+                placeholder="Nom"
                 required
-                value={edit.libelle || ''}
-                onChange={(e) => setEdit({ ...edit, libelle: e.target.value })}
+                value={edit.nom || ''}
+                onChange={(e) => setEdit({ ...edit, nom: e.target.value })}
               />
               <select
                 className="input"
@@ -139,7 +131,7 @@ export default function SousFamilles() {
                 <option value="">Sélectionner une famille</option>
                 {familles.map((f) => (
                   <option key={f.id} value={f.id}>
-                    {f.libelle}
+                    {f.nom}
                   </option>
                 ))}
               </select>

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -8,14 +8,14 @@ import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { isTauri, getDb } from '@/lib/db/sql';
+import { isTauri } from '@/lib/db/sql';
 
 export default function Unites() {
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [unites, setUnites] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [form, setForm] = useState({ code: '', libelle: '' });
+  const [form, setForm] = useState({ nom: '', abbr: '' });
 
   const refresh = async () => {
     setLoading(true);
@@ -37,9 +37,9 @@ export default function Unites() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await createUnite(form.code, form.libelle);
+      await createUnite(form.nom, form.abbr);
       toast.success('Unité créée');
-      setForm({ code: '', libelle: '' });
+      setForm({ nom: '', abbr: '' });
       await refresh();
     } catch (err) {
       console.error(err);
@@ -68,16 +68,16 @@ export default function Unites() {
       <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
         <input
           className="input"
-          placeholder="Code"
-          value={form.code}
-          onChange={(e) => setForm({ ...form, code: e.target.value })}
+          placeholder="Nom"
+          required
+          value={form.nom}
+          onChange={(e) => setForm({ ...form, nom: e.target.value })}
         />
         <input
           className="input"
-          placeholder="Libellé"
-          required
-          value={form.libelle}
-          onChange={(e) => setForm({ ...form, libelle: e.target.value })}
+          placeholder="Abréviation"
+          value={form.abbr}
+          onChange={(e) => setForm({ ...form, abbr: e.target.value })}
         />
         <Button type="submit">Ajouter</Button>
       </form>
@@ -86,16 +86,16 @@ export default function Unites() {
         <table className="text-sm w-full">
           <thead>
             <tr>
-              <th className="px-2 py-1">Code</th>
-              <th className="px-2 py-1">Libellé</th>
+              <th className="px-2 py-1">Nom</th>
+              <th className="px-2 py-1">Abréviation</th>
               <th className="px-2 py-1">Actions</th>
             </tr>
           </thead>
           <tbody>
             {unites.map((u) => (
               <tr key={u.id}>
-                <td className="px-2 py-1">{u.code}</td>
-                <td className="px-2 py-1">{u.libelle}</td>
+                <td className="px-2 py-1">{u.nom}</td>
+                <td className="px-2 py-1">{u.abbr}</td>
                 <td className="px-2 py-1">
                   <Button size="sm" variant="outline" onClick={() => handleDelete(u.id)}>
                     Supprimer


### PR DESCRIPTION
## Summary
- implement SQLite DAL modules for units, families, and subfamilies
- add SQL helpers and update parametrage pages to use new DAL APIs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Tauri requis: lance via `npx tauri dev`.)*

------
https://chatgpt.com/codex/tasks/task_e_68c54789a074832d93b6d102fa4e02c6