### PR TITLE
Enable basic navigation for parametrage and data folder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import Router from "@/router";
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import nprogress from 'nprogress';
 import { useEffect } from 'react';
-import { HelpProvider } from "@/context/HelpProvider";
 import { MultiMamaProvider } from "@/context/MultiMamaContext";
 import { ThemeProvider } from "@/context/ThemeProvider";
 import CookieConsent from "@/components/CookieConsent";
@@ -68,16 +67,14 @@ export default function App() {
   }, []);
   return (
     <QueryClientProvider client={queryClient}>
-      <HelpProvider>
-        <MultiMamaProvider>
-          <ThemeProvider>
-            <ToastRoot />
-            <DebugRibbon />
-            <Router />
-            <CookieConsent />
-          </ThemeProvider>
-        </MultiMamaProvider>
-      </HelpProvider>
+      <MultiMamaProvider>
+        <ThemeProvider>
+          <ToastRoot />
+          <DebugRibbon />
+          <Router />
+          <CookieConsent />
+        </ThemeProvider>
+      </MultiMamaProvider>
     </QueryClientProvider>
   );
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,193 +1,60 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { Link, NavLink, useLocation } from "react-router-dom";
-import { useMemo } from "react";
-import { useAuth } from "@/hooks/useAuth";
-import useMamaSettings from "@/hooks/useMamaSettings";
+import { NavLink, useLocation } from "react-router-dom";
 import logo from "@/assets/logo-mamastock.png";
-import { normalizeAccessKey } from "@/lib/access";
 
 export default function Sidebar() {
-  const { loading: authLoading, hasAccess, userData, roles } = useAuth();
   const { pathname } = useLocation();
-  const { loading: settingsLoading, enabledModules } = useMamaSettings();
-  const rights = useMemo(() => userData?.access_rights ?? {}, [userData?.access_rights]);
-
-  const modules = useMemo(() => {
-    const em = enabledModules || {};
-    if (Object.keys(em).length > 0) return em;
-    return rights;
-  }, [enabledModules, rights]);
-
-  const has = (key) => {
-    const k = normalizeAccessKey(key);
-    const isEnabled = modules ? modules[k] !== false : true;
-    return hasAccess(k) && isEnabled;
-  };
-  const canAnalyse = has("analyse");
-  const isAdmin = roles.includes("siege") || roles.includes("admin");
-
-  const canParam = (key) =>
-    Object.prototype.hasOwnProperty.call(rights, key) ? has(key) : true;
-  const canFamilles = canParam("familles");
-  const canSousFamilles = canParam("sous_familles");
-  const canUnites = canParam("unites");
-  const canData = canParam("settings");
-  const hasParamModule =
-    enabledModules?.includes?.("parametrage") ||
-    rights?.enabledModules?.includes?.("parametrage");
-  const showParametrage =
-    isAdmin ||
-    import.meta.env.DEV ||
-    rights?.menus?.parametrage === true ||
-    hasParamModule ||
-    canFamilles ||
-    canSousFamilles ||
-    canUnites;
-
-  if (authLoading || settingsLoading) return null;
 
   return (
     <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
       <img src={logo} alt="MamaStock" className="h-20 mx-auto mt-4 mb-6" />
       <nav className="flex flex-col gap-2 text-sm">
-        {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
-
-        {(has("fournisseurs") || has("factures") || has("receptions")) && (
-          <details
-            open={
-              pathname.startsWith("/fournisseurs") ||
-              pathname.startsWith("/factures") ||
-              pathname.startsWith("/receptions")
-            }
-          >
-            <summary className="cursor-pointer">Achats</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("fournisseurs") && <Link to="/fournisseurs">Fournisseurs</Link>}
-              {has("factures") && <Link to="/factures">Factures</Link>}
-              {has("receptions") && <Link to="/receptions">Réceptions</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("fiches_techniques") || has("menus") || has("recettes") || has("menu_du_jour")) && (
-          <details
-            open={
-              pathname.startsWith("/fiches") ||
-              pathname.startsWith("/menus") ||
-              pathname.startsWith("/recettes") ||
-              pathname.startsWith("/menu")
-            }
-          >
-            <summary className="cursor-pointer">Cuisine</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("fiches_techniques") && <Link to="/fiches">Fiches</Link>}
-              {has("menus") && <Link to="/menus">Menus</Link>}
-              {has("menu_du_jour") && <Link to="/menu">Menu du jour</Link>}
-              {has("recettes") && <Link to="/recettes">Recettes</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("produits") || has("inventaires")) && (
-          <details open={pathname.startsWith("/produits") || pathname.startsWith("/inventaire")}>
-            <summary className="cursor-pointer">Stock</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("produits") && <Link to="/produits">Produits</Link>}
-              {has("inventaires") && <Link to="/inventaire">Inventaire</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("alertes") || has("promotions")) && (
-          <details open={pathname.startsWith("/alertes") || pathname.startsWith("/promotions")}>
-            <summary className="cursor-pointer">Alertes / Promotions</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("alertes") && <Link to="/alertes">Alertes</Link>}
-              {has("promotions") && <Link to="/promotions">Promotions</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("documents") || canAnalyse || has("menu_engineering")) && (
-          <details
-            open={
-              pathname.startsWith("/documents") ||
-              pathname.startsWith("/analyse") ||
-              pathname.startsWith("/tableaux-de-bord") ||
-              pathname.startsWith("/comparatif") ||
-              pathname.startsWith("/surcouts") ||
-              pathname.startsWith("/engineering") ||
-              pathname.startsWith("/menu-engineering")
-            }
-          >
-            <summary className="cursor-pointer">Documents / Analyse</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("documents") && <Link to="/documents">Documents</Link>}
-              {canAnalyse && <Link to="/analyse">Analyse</Link>}
-              {canAnalyse && <Link to="/tableaux-de-bord">Tableaux de bord</Link>}
-              {canAnalyse && <Link to="/comparatif">Comparatif</Link>}
-              {canAnalyse && <Link to="/surcouts">Surcoûts</Link>}
-              {has("menu_engineering") && (
-                <Link to="/menu-engineering">Menu Engineering</Link>
-              )}
-              {canAnalyse && <Link to="/engineering">Engineering</Link>}
-              {has("costing_carte") && <Link to="/costing/carte">Costing Carte</Link>}
-            </div>
-          </details>
-        )}
-
-        {has("notifications") && <Link to="/notifications">Notifications</Link>}
-
-        {showParametrage && (
-          <details open={pathname.startsWith("/parametrage")}>
-            <summary className="cursor-pointer">Paramétrage</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {canFamilles && (
-                <NavLink
-                  to="/parametrage/familles"
-                  className={({ isActive }) =>
-                    isActive ? "text-mamastockGold" : ""
-                  }
-                >
-                  Familles
-                </NavLink>
-              )}
-              {canSousFamilles && (
-                <NavLink
-                  to="/parametrage/sous-familles"
-                  className={({ isActive }) =>
-                    isActive ? "text-mamastockGold" : ""
-                  }
-                >
-                  Sous-familles
-                </NavLink>
-              )}
-              {canUnites && (
-                <NavLink
-                  to="/parametrage/unites"
-                  className={({ isActive }) =>
-                    isActive ? "text-mamastockGold" : ""
-                  }
-                >
-                  Unités
-                </NavLink>
-              )}
-              {canData && (
-                <NavLink
-                  to="/parametrage/dossier-donnees"
-                  className={({ isActive }) =>
-                    isActive ? "text-mamastockGold" : ""
-                  }
-                >
-                  Dossier données
-                </NavLink>
-              )}
-            </div>
-          </details>
-        )}
-        {has("feedback") && <Link to="/feedback">Feedback</Link>}
         <NavLink
-          to="/debug/auth"
+          to="/dashboard"
+          className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+        >
+          Dashboard
+        </NavLink>
+
+        <details open={pathname.startsWith("/parametrage")}>
+          <summary className="cursor-pointer">Paramétrage</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            <NavLink
+              to="/parametrage/familles"
+              className={({ isActive }) =>
+                isActive ? "text-mamastockGold" : ""
+              }
+            >
+              Familles
+            </NavLink>
+            <NavLink
+              to="/parametrage/sousfamilles"
+              className={({ isActive }) =>
+                isActive ? "text-mamastockGold" : ""
+              }
+            >
+              Sous-familles
+            </NavLink>
+            <NavLink
+              to="/parametrage/unites"
+              className={({ isActive }) =>
+                isActive ? "text-mamastockGold" : ""
+              }
+            >
+              Unités
+            </NavLink>
+          </div>
+        </details>
+
+        <NavLink
+          to="/dossierdonnees"
+          className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+        >
+          Dossier données
+        </NavLink>
+
+        <NavLink
+          to="/debug/authdebug"
           className={({ isActive }) =>
             `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`
           }
@@ -198,3 +65,4 @@ export default function Sidebar() {
     </aside>
   );
 }
+

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -103,7 +103,7 @@ export default function Sidebar() {
               )}
               {canConfigure && (
                 <NavLink
-                  to="/parametrage/sous-familles"
+                  to="/parametrage/sousfamilles"
                   className={({ isActive }) =>
                     isActive ? "text-mamastockGold" : ""
                   }
@@ -123,7 +123,7 @@ export default function Sidebar() {
               )}
               {canConfigure && (
                 <NavLink
-                  to="/parametrage/dossier-donnees"
+                  to="/dossierdonnees"
                   className={({ isActive }) =>
                     isActive ? "text-mamastockGold" : ""
                   }
@@ -139,9 +139,8 @@ export default function Sidebar() {
             </div>
           </details>
         )}
-        {has("feedback") && <Link to="/feedback">Feedback</Link>}
         <NavLink
-          to="/debug/auth"
+          to="/debug/authdebug"
           className={({ isActive }) =>
             `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`
           }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/context/AuthContext";
-import { HelpProvider } from "@/context/HelpProvider";
 import { MultiMamaProvider } from "@/context/MultiMamaContext";
 import { ThemeProvider } from "@/context/ThemeProvider";
 import CookieConsent from "@/components/CookieConsent";
@@ -77,16 +76,14 @@ function Root() {
   return (
     <AuthProvider>
       <QueryClientProvider client={queryClient}>
-        <HelpProvider>
-          <MultiMamaProvider>
-            <ThemeProvider>
-              <ToastRoot />
-              <DebugRibbon />
-              <AppRouter />
-              <CookieConsent />
-            </ThemeProvider>
-          </MultiMamaProvider>
-        </HelpProvider>
+        <MultiMamaProvider>
+          <ThemeProvider>
+            <ToastRoot />
+            <DebugRibbon />
+            <AppRouter />
+            <CookieConsent />
+          </ThemeProvider>
+        </MultiMamaProvider>
       </QueryClientProvider>
     </AuthProvider>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -7,21 +7,9 @@ import GadgetEvolutionAchats from '@/components/gadgets/GadgetEvolutionAchats';
 import GadgetTachesUrgentes from '@/components/gadgets/GadgetTachesUrgentes';
 import GadgetConsoMoyenne from '@/components/gadgets/GadgetConsoMoyenne';
 import GadgetDerniersAcces from '@/components/gadgets/GadgetDerniersAcces';
-import React, { useEffect, useState } from 'react';
-import { isTauri, getDb, tableCount } from '@/lib/db/sql';
+import React from 'react';
 
 export default function Dashboard() {
-  const [needsOnboarding, setNeedsOnboarding] = useState(false);
-
-  useEffect(() => {
-    if (!isTauri) return;
-    (async () => {
-      try {
-        const n = await tableCount("unites");
-        if (n == 0) setNeedsOnboarding(true);
-      } catch {}
-    })();
-  }, []);
 
   const gadgets = [
     GadgetBudgetMensuel,
@@ -36,11 +24,6 @@ export default function Dashboard() {
 
   return (
     <div className="p-6">
-      {needsOnboarding && (
-        <div className="mb-4 p-4 bg-amber-100 text-gray-900 rounded">
-          Données de base manquantes.
-        </div>
-      )}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
         {gadgets.map((Component, idx) => (
           <Component key={idx} />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,7 +13,7 @@ import Unites from "@/pages/parametrage/Unites";
 import DossierDonnees from "@/pages/DossierDonnees";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import Sidebar from "@/components/Sidebar";
-import { isTauri, getDb } from "@/lib/db/sql";
+import { isTauri } from "@/lib/db/sql";
 
 function AppLayout() {
   return (
@@ -34,10 +34,10 @@ const routes = [
       { index: true, element: <Dashboard /> },
       { path: "dashboard", element: <Dashboard /> },
       { path: "parametrage/familles", element: <Familles /> },
-      { path: "parametrage/sous-familles", element: <SousFamilles /> },
+      { path: "parametrage/sousfamilles", element: <SousFamilles /> },
       { path: "parametrage/unites", element: <Unites /> },
-      { path: "parametrage/dossier-donnees", element: <DossierDonnees /> },
-      { path: "debug/auth", element: <AuthDebug /> },
+      { path: "dossierdonnees", element: <DossierDonnees /> },
+      { path: "debug/authdebug", element: <AuthDebug /> },
       { path: "*", element: <Navigate to="/" replace /> },
     ],
   },


### PR DESCRIPTION
## Summary
- activate routes for parametrage and data folder and simplify router
- trim sidebar to dashboard, parametrage, data folder and debug
- remove onboarding notice and help provider

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5479d24f4832d8a8844c725ef3da1