### PR TITLE
chore: expand SQL plugin capabilities

### DIFF
--- a/src-tauri/capabilities/sql.json
+++ b/src-tauri/capabilities/sql.json
@@ -1,15 +1,15 @@
 {
   "$schema": "../gen/schemas/plugin-sql.json",
   "identifier": "sql",
-  "description": "Permissions for SQL plugin",
-  "windows": [
-    "main"
-  ],
+  "description": "SQL plugin capabilities (dev wide-open)",
+  "windows": ["main"],
   "permissions": [
     "sql:default",
     "sql:allow-load",
+    "sql:allow-close",
     "sql:allow-select",
     "sql:allow-execute",
-    "sql:allow-close"
+    "sql:allow-batch",
+    "sql:allow-transaction"
   ]
 }


### PR DESCRIPTION
## Summary
- broaden SQL plugin permissions for development usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check:cap`


------
https://chatgpt.com/codex/tasks/task_e_68c54d19e6a4832d90c30307d549f211