### PR TITLE
feat: add SQL self test

### DIFF
--- a/src/debug/sqlSelfTest.ts
+++ b/src/debug/sqlSelfTest.ts
@@ -1,0 +1,17 @@
+import Database from "@tauri-apps/plugin-sql";
+
+export async function runSqlSelfTest() {
+  const inTauri = !!import.meta.env.TAURI_PLATFORM;
+  if (!inTauri) {
+    console.info("[SQL SelfTest] hors Tauri -> ok (skip)");
+    return;
+  }
+  try {
+    const db = await Database.load("sqlite:mamastock.db"); // nécessite sql:allow-load
+    const rows = await db.select("SELECT 1 AS ok");
+    console.info("[SQL SelfTest] OK, permissions actives:", rows);
+  } catch (e:any) {
+    console.error("[SQL SelfTest] ÉCHEC:", e?.message ?? e);
+    console.error("-> Vérifie src-tauri/capabilities/sql.json et relance complètement Tauri.");
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,9 @@ import nprogress from "nprogress";
 import { testRandom } from "/src/shims/selftest";
 import "./globals.css";
 import "nprogress/nprogress.css";
+import { runSqlSelfTest } from "@/debug/sqlSelfTest";
+
+runSqlSelfTest().catch(console.error);
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary
- add SQL self-test utility to debug database permissions
- invoke SQL self-test during app boot

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c54fb629e0832d8f8be5c4a57ae6c7