### PR TITLE
feat: setup hash router and update layout

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,7 @@ export default function Sidebar() {
       <img src={logo} alt="MamaStock" className="h-20 mx-auto mt-4 mb-6" />
       <nav className="flex flex-col gap-2 text-sm">
         <NavLink
-          to="/dashboard"
+          to="/"
           className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
         >
           Dashboard
@@ -28,7 +28,7 @@ export default function Sidebar() {
               Familles
             </NavLink>
             <NavLink
-              to="/parametrage/sousfamilles"
+              to="/parametrage/sous-familles"
               className={({ isActive }) =>
                 isActive ? "text-mamastockGold" : ""
               }
@@ -47,7 +47,7 @@ export default function Sidebar() {
         </details>
 
         <NavLink
-          to="/dossierdonnees"
+          to="/data"
           className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
         >
           Dossier données

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -1,0 +1,17 @@
+import Sidebar from "@/components/Sidebar";
+import Footer from "@/components/Footer";
+import { Outlet } from "react-router-dom";
+
+export default function AppLayout() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <main className="flex-1">
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,7 +34,7 @@ const queryClient = new QueryClient({
   },
 });
 
-function Root() {
+function AppRoot() {
   console.log("[debug] App mounted");
   useEffect(() => {
     testRandom().catch((err) =>
@@ -81,19 +81,23 @@ function Root() {
   }, []);
 
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <MultiMamaProvider>
-          <ThemeProvider>
-            <ToastRoot />
-            <DebugRibbon />
-            <AppRouter />
-            <CookieConsent />
-          </ThemeProvider>
-        </MultiMamaProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+    <>
+      <AppRouter />
+      <CookieConsent />
+    </>
   );
 }
 
-createRoot(document.getElementById("root")).render(<Root />);
+createRoot(document.getElementById("root")).render(
+  <AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <MultiMamaProvider>
+        <ThemeProvider>
+          <ToastRoot />
+          <DebugRibbon />
+          <AppRoot />
+        </ThemeProvider>
+      </MultiMamaProvider>
+    </QueryClientProvider>
+  </AuthProvider>
+);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,49 +1,24 @@
-import React from "react";
-import {
-  createBrowserRouter,
-  createHashRouter,
-  RouterProvider,
-  Outlet,
-  Navigate,
-} from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
+import AppLayout from "@/layout/AppLayout";
 import Dashboard from "@/pages/Dashboard";
+import Unites from "@/pages/parametrage/Unites";
 import Familles from "@/pages/parametrage/Familles";
 import SousFamilles from "@/pages/parametrage/SousFamilles";
-import Unites from "@/pages/parametrage/Unites";
 import DossierDonnees from "@/pages/DossierDonnees";
-import AuthDebug from "@/pages/debug/AuthDebug";
-import Sidebar from "@/components/Sidebar";
-import { isTauri } from "@/lib/db/sql";
 
-function AppLayout() {
-  return (
-    <div className="app-shell">
-      <Sidebar />
-      <main className="app-main">
-        <Outlet />
-      </main>
-    </div>
-  );
-}
-
-const routes = [
+const router = createHashRouter([
   {
     path: "/",
     element: <AppLayout />,
     children: [
       { index: true, element: <Dashboard /> },
-      { path: "dashboard", element: <Dashboard /> },
-      { path: "parametrage/familles", element: <Familles /> },
-      { path: "parametrage/sousfamilles", element: <SousFamilles /> },
       { path: "parametrage/unites", element: <Unites /> },
-      { path: "dossierdonnees", element: <DossierDonnees /> },
-      { path: "debug/authdebug", element: <AuthDebug /> },
-      { path: "*", element: <Navigate to="/" replace /> },
+      { path: "parametrage/familles", element: <Familles /> },
+      { path: "parametrage/sous-familles", element: <SousFamilles /> },
+      { path: "data", element: <DossierDonnees /> },
     ],
   },
-];
-
-const router = isTauri ? createHashRouter(routes) : createBrowserRouter(routes);
+]);
 
 export default function AppRouter() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
## Summary
- replace router with hash-based router and minimal routes
- add AppLayout with sidebar and footer
- adjust main entry to render AppRouter within providers
- update sidebar links for new routes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c56a17ea88832d8df10bcca711f78d