### PR TITLE
Disable file drag and drop in Tauri app

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::{Manager};
-use tauri::window::FileDropEvent;
-
 fn main() {
     let mut builder = tauri::Builder::default();
 
@@ -25,24 +22,6 @@ fn main() {
     {
         builder = builder.plugin(tauri_plugin_log::Builder::default().build());
     }
-
-    builder.setup(|app| {
-        if let Some(win) = app.get_webview_window("main") {
-            win.on_file_drop(|_w, ev| {
-                match ev {
-                    FileDropEvent::Hovered { .. } => true,
-                    FileDropEvent::Dropped { paths, .. } => {
-                        // Autorise UNIQUEMENT les fichiers réguliers (ignore dossiers/URLs/etc.)
-                        let only_files = paths.iter().all(|p| p.is_file());
-                        only_files
-                    }
-                    FileDropEvent::Cancelled => true,
-                    _ => true,
-                }
-            });
-        }
-        Ok(())
-    }).expect("setup failed");
 
     builder
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
                                     "height":  800,
                                     "resizable":  true,
                                     "center":  true,
-                                    "devtools":  true
+                                    "devtools":  true,
+                                    "fileDropEnabled":  false
                                 }
                             ],
                 "security":  {


### PR DESCRIPTION
## Summary
- remove file drag-and-drop handling from Tauri main window
- disable file drop in `tauri.conf.json`

## Testing
- `cargo check` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c57a94ed7c832da7e18414a46aa3ec