### PR TITLE
feat: warn when running outside Tauri

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -3,6 +3,15 @@
 
 import Database from "@tauri-apps/plugin-sql";
 
+export const isTauri = !!import.meta.env.TAURI_PLATFORM;
+export { isTauri as IS_TAURI };
+
+if (typeof window !== "undefined" && !isTauri) {
+  console.warn(
+    "Vous êtes dans le navigateur. Ouvrez l’app dans la fenêtre Tauri pour activer SQLite."
+  );
+}
+
 const forceTauri = (() => {
   if (typeof window === "undefined") return false;
   try {
@@ -15,10 +24,7 @@ const forceTauri = (() => {
 const hasTauriEnv =
   (typeof window !== "undefined" &&
     ((window as any).__TAURI__ || (window as any).__TAURI_INTERNALS__)) ||
-  !!import.meta.env?.TAURI_PLATFORM;
-
-export const isTauri = !!(hasTauriEnv || forceTauri);
-export { isTauri as IS_TAURI };
+  isTauri;
 
 let _db: any | null = null;
 let _loading: Promise<any> | null = null;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -20,6 +20,16 @@ if (import.meta.env.DEV && import.meta.env.TAURI_PLATFORM) {
 
 runSqlSelfTest().catch(console.error);
 
+if (
+  typeof window !== "undefined" &&
+  window.location.hostname === "localhost" &&
+  !import.meta.env.TAURI_PLATFORM
+) {
+  console.warn(
+    "Vous êtes dans le navigateur. Ouvrez l’app dans la fenêtre Tauri pour activer SQLite."
+  );
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {


### PR DESCRIPTION
## Summary
- expose `isTauri` flag based on TAURI_PLATFORM and warn when not in Tauri
- inform localhost browser users to open app via Tauri

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5845f0164832d97591d0ea2179b0c