### PR TITLE
Simplify router to use autogenerated routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,26 +1,8 @@
-import React, { Suspense } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import AppLayout from "@/layout/AppLayout";
-import Loading from "@/ui/Loading"; // spinner existant ou simple div
-import { buildAutoElements } from "./router.autogen";
+import routes from "@/router.autogen";
 
-const children = [
-  // ...tes routes statiques si tu en as
-  ...buildAutoElements()
-];
-
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <AppLayout />,
-    children,
-  },
-]);
+const router = createBrowserRouter([...routes]);
 
 export default function AppRouter() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <RouterProvider router={router} />
-    </Suspense>
-  );
+  return <RouterProvider router={router} />;
 }


### PR DESCRIPTION
## Summary
- replace complex router setup with a simple createBrowserRouter from auto-generated routes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c58658720c832da88f3b583c5f9364