### PR TITLE
refactor: use named routes export

### DIFF
--- a/src/router.autogen.tsx
+++ b/src/router.autogen.tsx
@@ -1031,3 +1031,8 @@ export function buildAutoElements() {
   routes.push({ path: "*", element: <div style={{padding:16}}>Page introuvable</div> });
   return routes;
 }
+
+export const routes = buildAutoElements();
+
+// compat: allow both `import { routes }` and `import routes`
+export default routes;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import routes from "@/router.autogen";
+import { routes } from "@/router.autogen";
 
 const router = createBrowserRouter([...routes]);
 


### PR DESCRIPTION
## Summary
- export and re-export routes in router.autogen for compatibility
- consume routes via named import in router.tsx

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c58eaa61e8832dbf6c0f0de314eb10