### PR TITLE
chore(dev): unregister service workers

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,13 @@ import "./globals.css";
 import "nprogress/nprogress.css";
 import { runSqlSelfTest } from "@/debug/sqlSelfTest";
 
+// DEV only: unregister any service workers to avoid PWA caching in Tauri/Vite dev
+if (import.meta.env.DEV && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(regs => {
+    for (const r of regs) r.unregister().catch(() => {});
+  }).catch(() => {});
+}
+
 if (import.meta.env.DEV && import.meta.env.TAURI_PLATFORM) {
   import("@/debug/check-capabilities-runtime");
 }


### PR DESCRIPTION
## Summary
- prevent service worker caching during Vite/Tauri dev by unregistering any registered workers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c590e90f4c832db0a54ecb981f27bb