### PR TITLE
chore: update nav:gen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:cap:runtime": "set TAURI_DEV_URL=http://localhost:5173/?capcheck=1 && npx tauri dev",
     "fix:cap": "node scripts/normalize-capabilities.js",
     "sync:cap:window": "node scripts/sync-sql-cap-window.js",
-    "nav:gen": "ts-node --transpile-only scripts/generate-navigation.ts"
+    "nav:gen": "node --loader ts-node/esm --no-warnings scripts/generate-navigation.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -117,7 +117,7 @@
     "sql.js": "^1.11.2",
     "supertest": "^7.1.1",
     "tailwindcss": "^3.4.17",
-    "ts-node": "10.9.2",
+    "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.20.5",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- use ts-node ES module loader for navigation generation script
- bump ts-node dev dependency to ^10.9.2

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c599d1d574832daddf1f141b952f26