### PR TITLE
chore: use ts-node for navigation generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:cap:runtime": "set TAURI_DEV_URL=http://localhost:5173/?capcheck=1 && npx tauri dev",
     "fix:cap": "node scripts/normalize-capabilities.js",
     "sync:cap:window": "node scripts/sync-sql-cap-window.js",
-    "nav:gen": "tsx scripts/generate-navigation.ts"
+    "nav:gen": "node --loader ts-node/esm --no-warnings scripts/generate-navigation.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -117,7 +117,7 @@
     "sql.js": "^1.11.2",
     "supertest": "^7.1.1",
     "tailwindcss": "^3.4.17",
-    "ts-node": "10.9.2",
+    "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.20.5",
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- update `nav:gen` script to run with ts-node esm loader
- ensure `ts-node` dev dependency uses caret

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c59b19347c832d8d330e31444e4452