### PR TITLE
chore: disable service worker under Tauri

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MamaStock</title>
+    <link rel="icon" href="/icons/icon-512x512.png" sizes="512x512" />
+    <link rel="icon" href="/icons/icon-192x192.png" sizes="192x192" />
+    <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,53 +1,65 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-const CACHE_NAME = "mamastock-cache-v1";
-const OFFLINE_URL = "/index.html";
+const isTauri = self.location.protocol === "tauri:" || self.location.host === "tauri.localhost";
 
-// Fichiers à mettre en cache
-const ASSETS_TO_CACHE = [
-  OFFLINE_URL,
-  "/manifest.json",
-  "icons/icon-192x192.png",
-  "icons/icon-512x512.png",
-  "icons/maskable-icon-512x512.png",
-];
+if (isTauri) {
+  self.addEventListener('install', (e) => self.skipWaiting());
+  self.addEventListener('activate', (e) => self.clients.claim());
+  self.addEventListener('fetch', (e) => {
+    // bypass
+  });
+} else {
+  const CACHE_NAME = "mamastock-cache-v1";
+  const OFFLINE_URL = "/index.html";
 
-// Installation du Service Worker
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(ASSETS_TO_CACHE);
-    })
-  );
-  self.skipWaiting();
-});
+  // Fichiers à mettre en cache
+  const ASSETS_TO_CACHE = [
+    OFFLINE_URL,
+    "/manifest.json",
+    "icons/icon-192x192.png",
+    "icons/icon-512x512.png",
+    "icons/maskable-icon-512x512.png",
+  ];
 
-// Activation : nettoyage des anciens caches
-self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    caches.keys().then((keyList) =>
-      Promise.all(
-        keyList.map((key) => {
-          if (key !== CACHE_NAME) {
-            return caches.delete(key);
-          }
-        })
-      )
-    )
-  );
-  self.clients.claim();
-});
-
-// Interception des requêtes
-self.addEventListener("fetch", (event) => {
-  if (event.request.method !== "GET") return;
-
-  event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        return response;
+  // Installation du Service Worker
+  self.addEventListener("install", (event) => {
+    event.waitUntil(
+      caches.open(CACHE_NAME).then((cache) => {
+        return cache.addAll(ASSETS_TO_CACHE);
       })
-      .catch(() =>
-        caches.match(event.request).then((cached) => cached || caches.match(OFFLINE_URL))
+    );
+    self.skipWaiting();
+  });
+
+  // Activation : nettoyage des anciens caches
+  self.addEventListener("activate", (event) => {
+    event.waitUntil(
+      caches.keys().then((keyList) =>
+        Promise.all(
+          keyList.map((key) => {
+            if (key !== CACHE_NAME) {
+              return caches.delete(key);
+            }
+          })
+        )
       )
-  );
-});
+    );
+    self.clients.claim();
+  });
+
+  // Interception des requêtes
+  self.addEventListener("fetch", (event) => {
+    if (event.request.method !== "GET") return;
+
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          return response;
+        })
+        .catch(() =>
+          caches
+            .match(event.request)
+            .then((cached) => cached || caches.match(OFFLINE_URL))
+        )
+    );
+  });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,4 @@
-import "@/sw-guard";
+import { setupPwaGuard } from "@/pwa/guard";
 import React, { useEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -14,6 +14,8 @@ import { testRandom } from "/src/shims/selftest";
 import "./globals.css";
 import "nprogress/nprogress.css";
 import { runSqlSelfTest } from "@/debug/sqlSelfTest";
+
+setupPwaGuard();
 
 // DEV only: unregister any service workers to avoid PWA caching in Tauri/Vite dev
 if (import.meta.env.DEV && 'serviceWorker' in navigator) {

--- a/src/pwa/guard.ts
+++ b/src/pwa/guard.ts
@@ -1,0 +1,19 @@
+import { isTauri } from "@/tauriEnv";
+
+export function setupPwaGuard() {
+  if (isTauri) {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .getRegistrations?.()
+        .then((regs) => {
+          for (const reg of regs) {
+            reg.unregister().catch(() => {});
+          }
+        })
+        .catch(() => {});
+      navigator.serviceWorker.addEventListener("controllerchange", () => {
+        window.location.reload();
+      });
+    }
+  }
+}

--- a/src/registerSW.js
+++ b/src/registerSW.js
@@ -1,7 +1,8 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { isTauri } from "@/tauriEnv";
 import { canRegisterSW } from "@/sw-guard";
 // SW disabled in DEV
-if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+if (!isTauri && import.meta.env.PROD && 'serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     try {
       const registrations = await navigator.serviceWorker.getRegistrations();

--- a/src/tauriEnv.ts
+++ b/src/tauriEnv.ts
@@ -1,1 +1,1 @@
-export { isTauri } from "@/lib/db/sql";
+export const isTauri = !!import.meta.env.TAURI_PLATFORM;


### PR DESCRIPTION
## Summary
- detect Tauri via env variable
- guard service worker usage in Tauri and remove registrations
- skip service worker logic when running inside Tauri
- add fallback icons to index.html

## Testing
- `npm test` (fails: Missing script "test")
- `npx vitest run` (fails: Tauri requis: lance via `npx tauri dev`)


------
https://chatgpt.com/codex/tasks/task_e_68c59c2b12b0832db4f4c7632927891b