### PR TITLE
feat: conditionally enable PWA plugin for Tauri

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,22 @@
 import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { VitePWA as pwa } from "vite-plugin-pwa";
 
-const isTauri = !!process.env.TAURI_PLATFORM;
+const isTauri =
+  !!process.env.TAURI_PLATFORM || process.env.VITE_TAURI === "1";
+
+const plugins = [
+  react(),
+  !isTauri &&
+    pwa({
+      registerType: "autoUpdate",
+    }),
+].filter(Boolean);
 
 export default defineConfig({
   base: isTauri ? "./" : "/",
-  plugins: [react()],
+  plugins,
   resolve: {
     alias: { "@": path.resolve(__dirname, "src") },
   },


### PR DESCRIPTION
## Summary
- include vite-plugin-pwa only when not running under Tauri
- expand Tauri environment detection

## Testing
- `npx vitest run` *(fails: Tauri requis: lance via `npx tauri dev`)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c5bd63c832d92703bc5bcfa7949