### PR TITLE
fix: remove stray TypeScript annotation in consolidated stats

### DIFF
--- a/src/hooks/useConsolidatedStats.js
+++ b/src/hooks/useConsolidatedStats.js
@@ -13,7 +13,7 @@ export function useConsolidatedStats() {
     try {
       const end = new Date().toISOString().slice(0, 10);
       const data = await consolidation_performance({ start: "2000-01-01", end });
-      const mapped = (data || []).map((r: any) => ({
+      const mapped = (data || []).map((r) => ({
         mama_id: r.mama_id,
         nom: r.mama_id,
         stock_valorise: r.valeur_stock || 0,


### PR DESCRIPTION
## Summary
- drop TypeScript parameter typing in consolidated stats hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5a3a6abbc832d87773a45fc69a672