### PR TITLE
refactor: update tauri import

### DIFF
--- a/src/pages/parametrage/TemplateCommandeForm.jsx
+++ b/src/pages/parametrage/TemplateCommandeForm.jsx
@@ -5,7 +5,7 @@ import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import { Button } from "@/components/ui/button";
 import { saveBinary } from "@/local/files";
 import { appDataDir, join } from "@tauri-apps/api/path";
-import { convertFileSrc } from "@tauri-apps/api/tauri";
+import { convertFileSrc } from "@tauri-apps/api/core";
 
 export default function TemplateCommandeForm({ template = {}, onClose, fournisseurs = [] }) {
   const { createTemplate, updateTemplate } = useTemplatesCommandes();


### PR DESCRIPTION
## Summary
- fix Tauri v1 import by switching to `@tauri-apps/api/core`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check:tauri-imports`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa3cb3b8832dbcb8805b7e734e6d