### PR TITLE
chore: note service worker disabled in dev

### DIFF
--- a/public/service-worker.dev-disabled.js
+++ b/public/service-worker.dev-disabled.js
@@ -1,4 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+// NOTE: Service worker désactivé en développement (fichier renommé en .dev-disabled.js)
+
 const isTauri = self.location.protocol === "tauri:" || self.location.host === "tauri.localhost";
 
 if (isTauri) {


### PR DESCRIPTION
## Summary
- note in public service worker file that it's disabled in development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa8ed778832d8fedb0191dd897cb