### PR TITLE
chore: disable service workers in dev

### DIFF
--- a/public/service-worker.dev-disabled.js
+++ b/public/service-worker.dev-disabled.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-// NOTE: Service worker désactivé en développement (fichier renommé en .dev-disabled.js)
+// Disabled in dev to avoid Tauri intercepts.
 
 const isTauri = self.location.protocol === "tauri:" || self.location.host === "tauri.localhost";
 

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -17,6 +17,7 @@
     "fs:allow-mkdir",
     "fs:create-app-specific-dirs",
     "fs:allow-appdata-write",
-    "fs:allow-appdata-write-recursive"
+    "fs:allow-appdata-write-recursive",
+    "core:webview:allow-clear-all-browsing-data"
   ]
 }

--- a/src/debug/clearWebview.ts
+++ b/src/debug/clearWebview.ts
@@ -1,0 +1,11 @@
+export async function clearWebviewOnDev() {
+  if (!import.meta.env.PROD) {
+    try {
+      const mod = await import("@tauri-apps/api/webview");
+      if (mod?.clearAllBrowsingData) {
+        await mod.clearAllBrowsingData();
+        console.info("[WebView] browsing data cleared (dev)");
+      }
+    } catch {}
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,19 +14,10 @@ import { testRandom } from "/src/shims/selftest";
 import "./globals.css";
 import "nprogress/nprogress.css";
 import { runSqlSelfTest } from "@/debug/sqlSelfTest";
+import { clearWebviewOnDev } from "@/debug/clearWebview";
 
+clearWebviewOnDev();
 setupPwaGuard();
-
-// Désactiver le service worker en DEV (évite les 500 et assets introuvables)
-if (!import.meta.env.PROD && 'serviceWorker' in navigator) {
-  navigator.serviceWorker
-    .getRegistrations()
-    .then((regs) => {
-      regs.forEach((r) => r.unregister());
-      console.info('[SW] unregistered in dev');
-    })
-    .catch(() => {});
-}
 
 if (import.meta.env.DEV && import.meta.env.TAURI_PLATFORM) {
   import("@/debug/check-capabilities-runtime");
@@ -110,6 +101,17 @@ function AppRoot() {
       <CookieConsent />
     </>
   );
+}
+
+// Dev: supprimer TOUT service worker (localhost & tauri.localhost le cas échéant)
+if (!import.meta.env.PROD && 'serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .getRegistrations()
+    .then((regs) => {
+      regs.forEach((r) => r.unregister());
+      console.info('[SW] unregistered in dev');
+    })
+    .catch(() => {});
 }
 
 createRoot(document.getElementById("root")).render(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,24 +6,29 @@ import { VitePWA as pwa } from "vite-plugin-pwa";
 const isTauri =
   !!process.env.TAURI_PLATFORM || process.env.VITE_TAURI === "1";
 
-const plugins = [
-  react(),
-  !isTauri &&
-    pwa({
-      registerType: "autoUpdate",
-    }),
-].filter(Boolean);
+export default defineConfig(({ mode }) => {
+  const plugins = [react()];
 
-export default defineConfig({
-  base: isTauri ? "./" : "/",
-  plugins,
-  resolve: {
-    alias: { "@": path.resolve(__dirname, "src") },
-  },
-  server: {
-    port: 5173,
-    strictPort: true,
-    host: true,
-    hmr: { overlay: true },
-  },
+  if (mode === "production" && !isTauri) {
+    plugins.push(
+      pwa({
+        registerType: "autoUpdate",
+      })
+    );
+  }
+
+  return {
+    base: isTauri ? "./" : "/",
+    plugins,
+    resolve: {
+      alias: { "@": path.resolve(__dirname, "src") },
+    },
+    server: {
+      port: 5173,
+      strictPort: true,
+      host: true,
+      hmr: { overlay: true },
+    },
+    appType: "spa",
+  };
 });


### PR DESCRIPTION
## Summary
- remove service worker and PWA plugin usage during development
- clear Tauri WebView data in dev and unregister all service workers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c5b27fc8a8832dabfb221afc333b2f