### PR TITLE
chore: add script to clear WebView2 cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "fix:cap": "node scripts/normalize-capabilities.js",
     "sync:cap:window": "node scripts/sync-sql-cap-window.js",
     "nav:gen": "node scripts/generate-navigation.cjs",
-    "pwa:reset": "node scripts/pwa-reset.js"
+    "pwa:reset": "node scripts/pwa-reset.js",
+    "webview:reset": "powershell -ExecutionPolicy Bypass -File scripts/reset-webview-cache.ps1"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/reset-webview-cache.ps1
+++ b/scripts/reset-webview-cache.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = 'SilentlyContinue'
+
+# Close running MamaStock processes (best effort)
+Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.ProcessName -like '*mamastock*' } | ForEach-Object {
+    try {
+        $_.CloseMainWindow() | Out-Null
+        Start-Sleep -Milliseconds 500
+        if (-not $_.HasExited) {
+            $_.Kill()
+        }
+    } catch {}
+}
+
+$paths = @(
+    (Join-Path $env:LOCALAPPDATA 'com.mamastock.local\WebView2'),
+    (Join-Path $env:LOCALAPPDATA 'MamaStock Local\WebView2')
+)
+
+$removed = @()
+
+foreach ($path in $paths) {
+    if (Test-Path $path) {
+        try {
+            Remove-Item $path -Recurse -Force -ErrorAction Stop
+            $removed += $path
+        } catch {}
+    }
+}
+
+if ($removed.Count -gt 0) {
+    Write-Output ("Dossiers supprimés : {0}" -f ($removed -join ', '))
+} else {
+    Write-Output 'Rien à supprimer'
+}


### PR DESCRIPTION
## Summary
- add PowerShell script to remove WebView2 cache folders for com.mamastock.local
- expose npm `webview:reset` script to run the cleaner

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`
- `npm run webview:reset` *(fails: powershell: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e6f6b6d8832da5c3a6f09017bdae