### PR TITLE
Configure Tauri dev URL to use Vite server

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,10 +12,15 @@
         "height": 800,
         "resizable": true,
         "fullscreen": false,
-        "visible": true,
-        "url": "tauri://localhost"
+        "visible": true
       }
     ],
-    "security": { "csp": null }
+    "security": {
+      "csp": null
+    }
+  },
+  "build": {
+    "devUrl": "http://localhost:5173/",
+    "frontendDist": "../dist"
   }
 }


### PR DESCRIPTION
## Summary
- add build.devUrl to tauri.conf.json pointing to Vite dev server
- set frontendDist and remove hardcoded window URL so devUrl controls runtime

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6f1ea2718832d905aaf05b882b210