### PR TITLE
feat: make pwa plugin optional for tauri

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
+import { VitePWA as pwa } from "vite-plugin-pwa";
 
 const isTauri =
   !!process.env.TAURI_PLATFORM || process.env.VITE_TAURI === "1";
 
 export default defineConfig(({ mode }) => {
-  const plugins = [react()];
+  const plugins = [
+    react(),
+    !isTauri &&
+      pwa({
+        registerType: "autoUpdate",
+      }),
+  ].filter(Boolean);
 
   return {
     base: isTauri ? "./" : "/",


### PR DESCRIPTION
## Summary
- reintroduce VitePWA plugin only for non-Tauri builds

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7c456899c832dba317cfd9d643b3e