### PR TITLE
feat(db): expose helpers

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -6,6 +6,7 @@ export const isTauri =
 
 let _db: Database | null = null;
 const DB_PATH = "C:/Users/dark_/MamaStock/data/mamastock.db";
+const DB_URI = "sqlite:" + DB_PATH;
 
 export async function getDb(): Promise<Database> {
   if (!isTauri) {
@@ -13,7 +14,7 @@ export async function getDb(): Promise<Database> {
   }
   if (_db) return _db;
   const { Database } = await import("@tauri-apps/plugin-sql");
-  _db = await Database.load("sqlite:" + DB_PATH);
+  _db = await Database.load(DB_URI);
   return _db;
 }
 
@@ -33,5 +34,45 @@ export async function tableCount(name: string): Promise<number> {
     return rows?.[0]?.c ?? 0;
   } catch {
     return 0;
+  }
+}
+
+export async function locateDb(): Promise<string> {
+  return DB_URI;
+}
+
+export async function openDb(): Promise<Database> {
+  return getDb();
+}
+
+let seedWarned = false;
+export async function ensureSeeds() {
+  try {
+    const db = await getDb();
+    await db.execute(
+      "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);",
+    );
+    await db.execute(
+      "INSERT OR IGNORE INTO meta(key, value) VALUES ('init','ok');",
+    );
+  } catch (err) {
+    if (!seedWarned) {
+      console.info("ensureSeeds failed", err);
+      seedWarned = true;
+    }
+  }
+}
+
+export async function getMigrationsState(): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  try {
+    const db = await getDb();
+    await db.select("SELECT 1 AS ok");
+    return { ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
   }
 }


### PR DESCRIPTION
## Summary
- add locateDb, openDb, ensureSeeds, and getMigrationsState helpers
- centralize database URI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: Tauri required: open the native window)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c5befbb8832d96803688763075df