### PR TITLE
refactor: guard non-tauri db access

### DIFF
--- a/src/lib/dal/facturePieces.ts
+++ b/src/lib/dal/facturePieces.ts
@@ -1,5 +1,8 @@
 import { getDb, isTauri } from "@/lib/db/sql";
 
+const NOT_TAURI_HINT =
+  "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
+
 export type FacturePiece = {
   id: string;
   facture_id: string;
@@ -27,7 +30,10 @@ function guessMime(e?: string | null) {
 }
 
 async function piecesDirForFacture(factureId: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return "";
+  }
   const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   const base = await appDataDir();
@@ -48,7 +54,10 @@ async function safeCopy(src: string, dst: string) {
 }
 
 export async function listPieces(factureId: string): Promise<FacturePiece[]> {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return [];
+  }
   const db = await getDb();
   const rows = await db.select<FacturePiece[]>(
     "SELECT * FROM facture_pieces WHERE facture_id = ? ORDER BY created_at DESC",
@@ -58,7 +67,10 @@ export async function listPieces(factureId: string): Promise<FacturePiece[]> {
 }
 
 export async function attachFromPicker(factureId: string): Promise<FacturePiece[]> {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return [];
+  }
   const { open: dialogOpen } = await import("@tauri-apps/plugin-dialog");
   const sel = await dialogOpen({
     multiple: true,
@@ -73,8 +85,14 @@ export async function attachFromPicker(factureId: string): Promise<FacturePiece[
   return await attachFiles(factureId, paths);
 }
 
-export async function attachFiles(factureId: string, paths: string[]): Promise<FacturePiece[]> {
-  if (!isTauri) throw new Error("Tauri requis");
+export async function attachFiles(
+  factureId: string,
+  paths: string[]
+): Promise<FacturePiece[]> {
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return [];
+  }
   const dir = await piecesDirForFacture(factureId);
   const db = await getDb();
 
@@ -112,7 +130,10 @@ export async function attachFiles(factureId: string, paths: string[]): Promise<F
 }
 
 export async function removePiece(id: string): Promise<void> {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   const db = await getDb();
 
   const rows = await db.select<FacturePiece[]>(
@@ -130,7 +151,10 @@ export async function removePiece(id: string): Promise<void> {
 }
 
 export async function openPiece(path: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   try {
     const { shell } = await import("@tauri-apps/plugin-shell");
     await shell.open(path);

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -1,5 +1,8 @@
 import type { Database } from "@tauri-apps/plugin-sql";
 
+const NOT_TAURI_HINT =
+  "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
+
 export const isTauri =
   typeof window !== "undefined" &&
   (location.protocol === "tauri:" || !!import.meta.env.TAURI_PLATFORM);
@@ -9,7 +12,8 @@ const DB_PATH = "C:/Users/dark_/MamaStock/data/mamastock.db";
 
 export async function getDb(): Promise<Database> {
   if (!isTauri) {
-    throw new Error("Tauri required: open the native window");
+    console.warn(NOT_TAURI_HINT);
+    return Promise.reject(new Error("SQLite indisponible hors Tauri"));
   }
   if (_db) return _db;
   const { Database } = await import("@tauri-apps/plugin-sql");

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,14 +1,23 @@
 // src/lib/paths.ts
 import { isTauri } from "@/lib/db/sql";
+
+const NOT_TAURI_HINT =
+  "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
 export const APP_DIR = "MamaStock";
 export async function getAppDir() {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return "";
+  }
   const { appDataDir, join } = await import("@tauri-apps/api/path");
   const base = await appDataDir();
   return join(base, APP_DIR);
 }
 export async function inAppDir(...parts: string[]) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return "";
+  }
   const root = await getAppDir();
   const { join } = await import("@tauri-apps/api/path");
   let p = root;

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -3,10 +3,13 @@ import { isTauri } from "@/lib/db/sql";
 
 export { isTauri };
 
+const NOT_TAURI_HINT =
+  "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
+
 export function requireTauri(message?: string) {
   if (!isTauri) {
-    throw new Error(
-      message || "Tauri required: open the native window"
-    );
+    console.warn(message || NOT_TAURI_HINT);
+    return false;
   }
+  return true;
 }

--- a/src/local/files.ts
+++ b/src/local/files.ts
@@ -1,9 +1,15 @@
 import { isTauri } from "@/lib/db/sql";
 
+const NOT_TAURI_HINT =
+  "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
+
 const APP_DIR = "MamaStock";
 
 async function baseDir() {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return "";
+  }
   const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   const base = await appDataDir();
@@ -13,13 +19,20 @@ async function baseDir() {
 }
 
 async function resolve(path: string) {
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return path;
+  }
   const root = await baseDir();
   const { join } = await import("@tauri-apps/api/path");
   return await join(root, path);
 }
 
 export async function saveText(relPath: string, content: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   const file = await resolve(relPath);
   const { dirname } = await import("@tauri-apps/api/path");
   const { exists, mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
@@ -29,28 +42,40 @@ export async function saveText(relPath: string, content: string) {
 }
 
 export async function readText(relPath: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return "";
+  }
   const file = await resolve(relPath);
   const { readTextFile } = await import("@tauri-apps/plugin-fs");
   return await readTextFile(file);
 }
 
 export async function existsFile(relPath: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return false;
+  }
   const file = await resolve(relPath);
   const { exists } = await import("@tauri-apps/plugin-fs");
   return await exists(file);
 }
 
 export async function mkdirp(relDir: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   const dir = await resolve(relDir);
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   if (!(await exists(dir))) await mkdir(dir, { recursive: true });
 }
 
 export async function saveBinary(relPath: string, data: Uint8Array) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   const file = await resolve(relPath);
   const { dirname } = await import("@tauri-apps/api/path");
   const { exists, mkdir, writeFile } = await import("@tauri-apps/plugin-fs");
@@ -60,14 +85,20 @@ export async function saveBinary(relPath: string, data: Uint8Array) {
 }
 
 export async function readBinary(relPath: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return new Uint8Array();
+  }
   const file = await resolve(relPath);
   const { readFile } = await import("@tauri-apps/plugin-fs");
   return await readFile(file);
 }
 
 export async function deleteFile(relPath: string) {
-  if (!isTauri) throw new Error("Tauri requis");
+  if (!isTauri) {
+    console.warn(NOT_TAURI_HINT);
+    return;
+  }
   const file = await resolve(relPath);
   const { exists, remove } = await import("@tauri-apps/plugin-fs");
   if (await exists(file)) await remove(file);


### PR DESCRIPTION
## Summary
- avoid throwing hard errors when running outside Tauri
- skip DB and file operations with a friendly hint when not in Tauri

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:node`


------
https://chatgpt.com/codex/tasks/task_e_68c7c6273fa4832d8657c31f4e754655