### PR TITLE
chore: add tauri dev script and enable strict vite port

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --strictPort",
+    "tauri:dev": "cross-env TAURI_DEV_URL=http://localhost:5173/ npx tauri dev",
     "build": "node scripts/check-node-native.js && vite build",
     "lint:node": "node scripts/check-node-native.js",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- ensure Vite runs on a strict port
- add script for launching Tauri with a preset dev URL

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7c632cba4832dbcc6a32d2e097eca