### PR TITLE
chore: add unified isTauri codemod

### DIFF
--- a/scripts/codemod-unify-isTauri.cjs
+++ b/scripts/codemod-unify-isTauri.cjs
@@ -1,16 +1,15 @@
-#!/usr/bin/env node
-try {
-  require.resolve("tsx");
-} catch {
-  console.error(
-    "Missing dependency 'tsx'. Install it with: npm i -D tsx @babel/parser @babel/traverse @babel/generator glob",
-  );
-  process.exit(1);
+"use strict";
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const tsFile = path.join(__dirname, "codemod-unify-isTauri.ts");
+
+// Prefer `tsx` runner to avoid ESM loader headaches on Windows
+const cmd = process.platform === "win32" ? "npx.cmd" : "npx";
+const args = ["-y", "tsx", tsFile];
+const res = spawnSync(cmd, args, { stdio: "inherit" });
+
+if (res.status !== 0) {
+  console.error("\nFailed to run codemod with `tsx`.");
+  console.error("Try installing dev deps: npm i -D tsx @babel/parser @babel/traverse @babel/generator glob");
+  process.exit(res.status || 1);
 }
-const { spawnSync } = require("child_process");
-const result = spawnSync(
-  process.execPath,
-  ["--import", "tsx", "scripts/codemod-unify-isTauri.ts"],
-  { stdio: "inherit" }
-);
-process.exit(result.status ?? 1);

--- a/scripts/codemod-unify-isTauri.ts
+++ b/scripts/codemod-unify-isTauri.ts
@@ -1,257 +1,255 @@
-import fs from "fs";
-import path from "path";
-import glob from "glob";
+import fs from "node:fs";
+import path from "node:path";
+import { globSync } from "glob";
 import * as parser from "@babel/parser";
-import traverseModule from "@babel/traverse";
-import type { NodePath } from "@babel/traverse";
-import generatorModule from "@babel/generator";
+import traverse, { NodePath } from "@babel/traverse";
+import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-const traverse = (traverseModule as any).default || (traverseModule as any);
-const generate = (generatorModule as any).default || (generatorModule as any);
+const ROOT = process.cwd();
+const SRC = path.join(ROOT, "src");
+const SKIP = [
+  path.join(ROOT, "src-tauri"),
+  path.join(ROOT, "node_modules"),
+  path.join(ROOT, "dist"),
+  path.join(ROOT, "build"),
+  path.join(ROOT, "reports"),
+  path.join(ROOT, "var"),
+];
 
-const files = glob.sync("src/**/*.{js,jsx,ts,tsx}", {
-  nodir: true,
-  ignore: [
-    "**/node_modules/**",
-    "**/dist/**",
-    "**/build/**",
-    "**/reports/**",
-    "**/src-tauri/**",
-  ],
-});
+const FILES = globSync("src/**/*.{js,jsx,ts,tsx}", { cwd: ROOT, absolute: true, dot: false });
 
-let scanned = 0;
-const changedFiles: string[] = [];
-
-function isWindowTauri(node: t.Node): boolean {
-  return (
-    t.isMemberExpression(node) &&
-    !node.computed &&
-    t.isIdentifier(node.property, { name: "__TAURI__" }) &&
-    (t.isIdentifier(node.object, { name: "window" }) ||
-      t.isIdentifier(node.object, { name: "globalThis" }))
-  );
+function inSkip(p: string) {
+  const norm = path.normalize(p);
+  return SKIP.some((s) => norm.startsWith(path.normalize(s)));
 }
 
-function isImportMetaTauri(node: t.Node): boolean {
-  return (
-    t.isMemberExpression(node) &&
-    !node.computed &&
-    t.isIdentifier(node.property) &&
-    node.property.name.startsWith("TAURI_") &&
-    t.isMemberExpression(node.object) &&
-    t.isIdentifier(node.object.property, { name: "env" }) &&
-    t.isMetaProperty(node.object.object) &&
-    node.object.object.meta.name === "import" &&
-    node.object.object.property.name === "meta"
-  );
-}
+function ensureIsTauriImport(ast: t.File) {
+  const body = ast.program.body;
+  let sqlImport: t.ImportDeclaration | null = null;
+  let lastImportIdx = -1;
 
-function isDoubleNotImportMeta(node: t.Node): boolean {
-  return (
-    t.isUnaryExpression(node, { operator: "!" }) &&
-    t.isUnaryExpression(node.argument, { operator: "!" }) &&
-    isImportMetaTauri(node.argument.argument)
-  );
-}
+  for (let i = 0; i < body.length; i++) {
+    const n = body[i];
+    if (t.isImportDeclaration(n)) {
+      lastImportIdx = i;
+      if (t.isStringLiteral(n.source) && n.source.value === "@/lib/db/sql") {
+        sqlImport = n;
+      }
+    }
+  }
 
-function isTypeofWindowUndefined(node: t.Node): boolean {
-  return (
-    t.isBinaryExpression(node) &&
-    (node.operator === "!==" || node.operator === "!=") &&
-    t.isUnaryExpression(node.left, { operator: "typeof" }) &&
-    t.isIdentifier(node.left.argument, { name: "window" }) &&
-    t.isStringLiteral(node.right, { value: "undefined" })
-  );
-}
-
-function isTypeofWindowTauriUndefined(node: t.Node): boolean {
-  return (
-    t.isBinaryExpression(node) &&
-    (node.operator === "!==" || node.operator === "!=") &&
-    t.isUnaryExpression(node.left, { operator: "typeof" }) &&
-    isWindowTauri(node.left.argument) &&
-    t.isStringLiteral(node.right, { value: "undefined" })
-  );
-}
-
-function matchesTauriChain(node: t.Expression): boolean {
-  if (
-    isWindowTauri(node) ||
-    isImportMetaTauri(node) ||
-    isDoubleNotImportMeta(node) ||
-    isTypeofWindowTauriUndefined(node)
-  ) {
+  if (sqlImport) {
+    const hasIsTauri =
+      sqlImport.specifiers?.some(
+        (s) => t.isImportSpecifier(s) && t.isIdentifier(s.imported, { name: "isTauri" })
+      ) ?? false;
+    if (!hasIsTauri) {
+      sqlImport.specifiers.push(
+        t.importSpecifier(t.identifier("isTauri"), t.identifier("isTauri"))
+      );
+      return true;
+    }
+    return false;
+  } else {
+    const decl = t.importDeclaration(
+      [t.importSpecifier(t.identifier("isTauri"), t.identifier("isTauri"))],
+      t.stringLiteral("@/lib/db/sql")
+    );
+    const insertIdx = lastImportIdx >= 0 ? lastImportIdx + 1 : 0;
+    body.splice(insertIdx, 0, decl);
     return true;
   }
-  if (t.isLogicalExpression(node)) {
-    const left = matchesTauriChain(node.left) || isTypeofWindowUndefined(node.left);
-    const right =
-      matchesTauriChain(node.right) || isTypeofWindowUndefined(node.right);
-    return left && right;
-  }
-  return false;
 }
 
-function isBooleanContext(path: NodePath<t.MemberExpression>): boolean {
-  const parent = path.parentPath;
-  if (!parent) return false;
+// Helpers to match patterns
+function isWindowOrGlobalThis(id: t.Node | null | undefined) {
+  return t.isIdentifier(id, { name: "window" }) || t.isIdentifier(id, { name: "globalThis" });
+}
+function isWindowTauri(node: t.Node | null | undefined) {
   return (
-    (parent.isIfStatement() && parent.node.test === path.node) ||
-    (parent.isConditionalExpression() && parent.node.test === path.node) ||
-    (parent.isWhileStatement() && parent.node.test === path.node) ||
-    (parent.isDoWhileStatement() && parent.node.test === path.node) ||
-    (parent.isForStatement() && parent.node.test === path.node) ||
-    parent.isLogicalExpression() ||
-    (parent.isUnaryExpression({ operator: "!" }) && parent.node.argument === path.node)
+    t.isMemberExpression(node) &&
+    isWindowOrGlobalThis(node.object as any) &&
+    ((t.isIdentifier(node.property, { name: "__TAURI__" }) && !node.computed) ||
+      (t.isStringLiteral(node.property, { value: "__TAURI__" }) && node.computed))
+  );
+}
+function isImportMeta(node: t.Node | null | undefined) {
+  return t.isMetaProperty(node) && t.isIdentifier(node.meta, { name: "import" }) &&
+         t.isIdentifier(node.property, { name: "meta" });
+}
+function isImportMetaEnv(node: t.Node | null | undefined) {
+  return t.isMemberExpression(node) && isImportMeta(node.object as any) &&
+         t.isIdentifier(node.property, { name: "env" }) && !node.computed;
+}
+function isTauriPlatform(node: t.Node | null | undefined) {
+  return t.isMemberExpression(node) && isImportMetaEnv(node.object as any) &&
+         ((t.isIdentifier(node.property, { name: "TAURI_PLATFORM" }) && !node.computed) ||
+          (t.isStringLiteral(node.property, { value: "TAURI_PLATFORM" }) && node.computed));
+}
+function isTypeof(node: t.Node | null | undefined, inner: (n: t.Node) => boolean) {
+  return t.isUnaryExpression(node, { operator: "typeof" }) && node.argument && inner(node.argument);
+}
+function isTypeofWindow(node: t.Node | null | undefined) {
+  return isTypeof(node, (n) => t.isIdentifier(n, { name: "window" }));
+}
+function isTypeofWindowTauri(node: t.Node | null | undefined) {
+  return isTypeof(node, (n) => isWindowTauri(n));
+}
+function isUndefinedLiteral(n: t.Node | null | undefined) {
+  return (t.isStringLiteral(n, { value: "undefined" }) || t.isIdentifier(n, { name: "undefined" }));
+}
+function isTypeofWindowNotUndefined(node: t.Node | null | undefined) {
+  return (
+    t.isBinaryExpression(node) &&
+    (node.operator === "!=" || node.operator === "!==") &&
+    isTypeofWindow(node.left) &&
+    isUndefinedLiteral(node.right)
+  );
+}
+function isTypeofWindowTauriNotUndefined(node: t.Node | null | undefined) {
+  return (
+    t.isBinaryExpression(node) &&
+    (node.operator === "!=" || node.operator === "!==") &&
+    isTypeofWindowTauri(node.left) &&
+    isUndefinedLiteral(node.right)
   );
 }
 
-for (const file of files) {
-  if (path.normalize(file) === path.normalize("src/lib/db/sql.ts")) continue;
-  scanned++;
+function replaceWithIsTauri(p: NodePath<t.Node>) {
+  p.replaceWith(t.identifier("isTauri"));
+}
+
+let scanned = 0;
+let changed = 0;
+const changedFiles: string[] = [];
+const errors: string[] = [];
+
+for (const file of FILES) {
+  if (inSkip(file)) continue;
+  if (path.normalize(file) === path.normalize(path.join(ROOT, "src/lib/db/sql.ts"))) continue;
+  let code: string;
   try {
-    const code = fs.readFileSync(file, "utf8");
-    const ast = parser.parse(code, {
+    code = fs.readFileSync(file, "utf8");
+  } catch (e: any) {
+    errors.push(`read fail ${file}: ${e.message}`);
+    continue;
+  }
+
+  let ast: t.File;
+  try {
+    ast = parser.parse(code, {
       sourceType: "module",
       plugins: [
         "jsx",
         "typescript",
-        "importMeta",
         "classProperties",
+        "importMeta",
         "topLevelAwait",
+        "decorators-legacy",
       ],
     });
+  } catch (e: any) {
+    errors.push(`parse fail ${file}: ${e.message}`);
+    continue;
+  }
 
-    let changed = false;
-    let importDecl: NodePath<t.ImportDeclaration> | null = null;
-    let hasIsTauriImport = false;
+  scanned++;
+  let fileChanged = false;
+  let removedLocalIsTauriDecl = false;
 
-    traverse(ast, {
-      ImportDeclaration(path) {
-        if (path.node.source.value === "@/lib/db/sql") {
-          importDecl = path;
-          if (
-            path.node.specifiers.some(
-              (s) =>
-                t.isImportSpecifier(s) &&
-                t.isIdentifier(s.imported, { name: "isTauri" })
-            )
-          ) {
-            hasIsTauriImport = true;
-          }
+  traverse(ast, {
+    // Collapse logical patterns: typeof window !== 'undefined' && window.__TAURI__  => isTauri
+    LogicalExpression(p) {
+      const { node } = p;
+      if (node.operator === "&&") {
+        const L = node.left;
+        const R = node.right;
+        if (isTypeofWindowNotUndefined(L) && (isWindowTauri(R) || isTauriPlatform(R))) {
+          replaceWithIsTauri(p);
+          fileChanged = true;
         }
-      },
-      VariableDeclarator(path) {
-        if (
-          t.isIdentifier(path.node.id, { name: "isTauri" }) &&
-          path.node.init &&
-          t.isExpression(path.node.init) &&
-          matchesTauriChain(path.node.init)
-        ) {
-          path.remove();
-          changed = true;
-        }
-      },
-      MemberExpression(path) {
-        if (isWindowTauri(path.node)) {
-          path.replaceWith(t.identifier("isTauri"));
-          changed = true;
-          return;
-        }
-        if (isImportMetaTauri(path.node) && isBooleanContext(path)) {
-          path.replaceWith(t.identifier("isTauri"));
-          changed = true;
-        }
-      },
-      UnaryExpression(path) {
-        if (isDoubleNotImportMeta(path.node)) {
-          path.replaceWith(t.identifier("isTauri"));
-          changed = true;
-        } else if (
-          path.node.operator === "!" &&
-          isImportMetaTauri(path.node.argument)
-        ) {
-          path.replaceWith(t.unaryExpression("!", t.identifier("isTauri")));
-          changed = true;
-        }
-      },
-      BinaryExpression(path) {
-        if (isTypeofWindowTauriUndefined(path.node)) {
-          path.replaceWith(t.identifier("isTauri"));
-          changed = true;
-        }
-      },
-      LogicalExpression(path) {
-        if (matchesTauriChain(path.node)) {
-          path.replaceWith(t.identifier("isTauri"));
-          changed = true;
-        }
-      },
-    });
-
-    traverse(ast, {
-      VariableDeclaration(path) {
-        if (path.node.declarations.length === 0) path.remove();
-      },
-    });
-
-    let usesIsTauri = false;
-    traverse(ast, {
-      Identifier(path) {
-        if (path.node.name === "isTauri") {
-          if (
-            !t.isImportSpecifier(path.parent) &&
-            !t.isImportDefaultSpecifier(path.parent) &&
-            !t.isImportNamespaceSpecifier(path.parent) &&
-            !t.isImportDeclaration(path.parent)
-          ) {
-            usesIsTauri = true;
-          }
-        }
-      },
-    });
-
-    if (usesIsTauri) {
-      if (importDecl) {
-        if (!hasIsTauriImport) {
-          importDecl.node.specifiers.push(
-            t.importSpecifier(t.identifier("isTauri"), t.identifier("isTauri"))
-          );
-          changed = true;
-        }
-      } else {
-        const newImport = t.importDeclaration(
-          [t.importSpecifier(t.identifier("isTauri"), t.identifier("isTauri"))],
-          t.stringLiteral("@/lib/db/sql")
-        );
-        const body = ast.program.body;
-        let lastImportIndex = -1;
-        for (let i = 0; i < body.length; i++) {
-          if (t.isImportDeclaration(body[i])) lastImportIndex = i;
-        }
-        body.splice(lastImportIndex + 1, 0, newImport);
-        changed = true;
       }
-    }
+    },
 
-    if (changed) {
-      const output = generate(ast, { retainLines: false, compact: false }, code);
-      fs.writeFileSync(file, output.code);
-      changedFiles.push(file);
-      console.log("updated", file);
+    // typeof window.__TAURI__ !== "undefined" => isTauri
+    BinaryExpression(p) {
+      const { node } = p;
+      if (isTypeofWindowTauriNotUndefined(node)) {
+        replaceWithIsTauri(p);
+        fileChanged = true;
+      }
+    },
+
+    // Member replacements:
+    MemberExpression(p) {
+      const { node } = p;
+      if (isWindowTauri(node) || isTauriPlatform(node)) {
+        replaceWithIsTauri(p);
+        fileChanged = true;
+      }
+    },
+
+    // !!(something we turned into isTauri) => isTauri
+    UnaryExpression(p) {
+      const { node } = p;
+      if (node.operator === "!" && t.isUnaryExpression(node.argument, { operator: "!" }) &&
+          t.isIdentifier(node.argument.argument, { name: "isTauri" })) {
+        replaceWithIsTauri(p);
+        fileChanged = true;
+      }
+    },
+
+    // Remove local const isTauri = <pattern>;
+    VariableDeclarator(p) {
+      const { node } = p;
+      if (t.isIdentifier(node.id, { name: "isTauri" }) && node.init) {
+        const init = node.init;
+        const matches =
+          isWindowTauri(init) ||
+          isTauriPlatform(init) ||
+          isTypeofWindowNotUndefined(init) ||
+          isTypeofWindowTauriNotUndefined(init) ||
+          (t.isUnaryExpression(init, { operator: "!" }) &&
+            t.isUnaryExpression(init.argument, { operator: "!" }) &&
+            (isWindowTauri(init.argument.argument) || isTauriPlatform(init.argument.argument)));
+
+        if (matches) {
+          // remove this declarator (and declaration if empty)
+          const parent = p.parentPath?.node;
+          p.remove();
+          if (t.isVariableDeclaration(parent) && parent.declarations.length === 0) {
+            p.parentPath?.remove();
+          }
+          removedLocalIsTauriDecl = true;
+          fileChanged = true;
+        }
+      }
+    },
+  });
+
+  // Ensure import { isTauri } from "@/lib/db/sql"
+  const addedImport = ensureIsTauriImport(ast);
+  if (addedImport) fileChanged = true;
+
+  if (fileChanged) {
+    const out = generate(ast, { retainLines: true, jsescOption: { minimal: true } }, code).code;
+    if (out !== code) {
+      fs.writeFileSync(file, out, "utf8");
+      changed++;
+      changedFiles.push(path.relative(ROOT, file));
     }
-  } catch (err) {
-    console.error("Error processing", file, err);
   }
 }
 
-console.log(`Files scanned: ${scanned}`);
-console.log(`Files changed: ${changedFiles.length}`);
+console.log(`\nCodemod isTauri summary: scanned=${scanned}, changed=${changed}`);
 if (changedFiles.length) {
-  const list = changedFiles.slice(0, 20);
-  for (const f of list) console.log(" -", f);
-  if (changedFiles.length > 20)
-    console.log(` +${changedFiles.length - 20} more...`);
+  const MAX = 20;
+  const head = changedFiles.slice(0, MAX);
+  for (const f of head) console.log("  •", f);
+  if (changedFiles.length > MAX) console.log(`  • +${changedFiles.length - MAX} more...`);
+}
+if (errors.length) {
+  console.warn("\nWarnings:");
+  for (const m of errors) console.warn("  -", m);
 }

--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -3,9 +3,7 @@ import type { Database } from "@tauri-apps/plugin-sql";
 const NOT_TAURI_HINT =
   "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
 
-export const isTauri =
-  typeof window !== "undefined" &&
-  (location.protocol === "tauri:" || !!import.meta.env.TAURI_PLATFORM);
+export const isTauri = (typeof window !== "undefined" && !!(window as any).__TAURI__) || !!import.meta.env.TAURI_PLATFORM;
 
 let _db: Database | null = null;
 const DB_PATH = "C:/Users/dark_/MamaStock/data/mamastock.db";


### PR DESCRIPTION
## Summary
- add codemod scripts to normalize Tauri detection
- export standard `isTauri` helper from SQL module

## Testing
- `node scripts/codemod-unify-isTauri.cjs` *(fails: traverse is not a function)*
- `npm test` *(fails: missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cd100848832db614301b9f132e5c