### PR TITLE
Align Node SQLite scripts with Tauri app data paths

### DIFF
--- a/scripts/move-db-once.js
+++ b/scripts/move-db-once.js
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { getAppDataDbPath } from "./paths.js";
+import { dbFile } from "./paths.js";
 
 const oldPath = path.join(os.homedir(), "MamaStock", "data", "mamastock.db");
-const newPath = getAppDataDbPath();
+const newPath = dbFile();
 
 if (fs.existsSync(oldPath) && oldPath !== newPath) {
   fs.mkdirSync(path.dirname(newPath), { recursive: true });

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -1,11 +1,28 @@
-import os from "node:os";
-import path from "node:path";
-export function getAppDataDbPath() {
-  const home = os.homedir();
-  // même logique que dans src/db/connection.ts (AppData/Roaming sur Windows)
-  const base = process.env.APPDATA
-    || (process.platform === "darwin"
-        ? path.join(home, "Library", "Application Support")
-        : path.join(home, ".config"));
-  return path.join(base, "com.mamastock.local", "MamaStock", "data", "mamastock.db");
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const os = require("os");
+const path = require("path");
+
+const APP_ID = "com.mamastock.local";
+
+export function appDataBaseDir() {
+  if (process.platform === "win32") {
+    const base = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(base, APP_ID, "MamaStock");
+  }
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", APP_ID, "MamaStock");
+  }
+  return path.join(os.homedir(), ".local", "share", APP_ID, "MamaStock");
 }
+
+export function dbDir() {
+  return path.join(appDataBaseDir(), "data");
+}
+
+export function dbFile() {
+  return path.join(dbDir(), "mamastock.db");
+}
+
+export default { appDataBaseDir, dbDir, dbFile };

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -2,11 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
-import { getAppDataDbPath } from "./paths.js";
+import { appDataBaseDir } from "./paths.js";
 
 // Même hiérarchie que appDataDir() côté Tauri:
-const dbPath = getAppDataDbPath();
-const appRoot = path.dirname(path.dirname(dbPath));
+const appRoot = appDataBaseDir();
 const usersFile = path.join(appRoot, "users.json");
 
 fs.mkdirSync(appRoot, { recursive: true });

--- a/scripts/sqlite-apply.js
+++ b/scripts/sqlite-apply.js
@@ -2,10 +2,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import Database from "better-sqlite3";
+import { dbDir, dbFile } from "./paths.js";
 
 // Emplacement DB final (déjà utilisé dans le projet)
-const DB_PATH = process.env.MS_DB_PATH
-  || path.join(process.env.USERPROFILE || process.env.HOME, "MamaStock", "data", "mamastock.db");
+const DB_PATH = process.env.MS_DB_PATH || dbFile();
+const DB_DIR = process.env.MS_DB_PATH ? path.dirname(process.env.MS_DB_PATH) : dbDir();
 
 const SQL_DIR = path.join(process.cwd(), "db", "sqlite");
 
@@ -43,7 +44,7 @@ function markApplied(db, filename) {
 }
 
 function main() {
-  ensureDir(path.dirname(DB_PATH));
+  ensureDir(DB_DIR);
   const db = new Database(DB_PATH);
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");


### PR DESCRIPTION
## Summary
- add Tauri-style AppData resolution helpers in `scripts/paths.js`
- update SQLite migration/inspection scripts to rely on the shared db location
- adjust maintenance scripts to read the new helper exports

## Testing
- npm run lint:node

------
https://chatgpt.com/codex/tasks/task_e_68c82e37a38c832d9c362a90f72b6344