### PR TITLE
feat: align sqlite path with node scripts

### DIFF
--- a/src/lib/db/sql.ts
+++ b/src/lib/db/sql.ts
@@ -1,66 +1,60 @@
-/* src/lib/db/sql.ts */
-import Database from "@tauri-apps/plugin-sql";
-import { appDataDir, join } from "@tauri-apps/api/path";
-import { isTauri } from "@/lib/runtime/isTauri";
+// src/lib/db/sql.ts
+import { appDataDir, homeDir, join } from "@tauri-apps/api/path";
+import { exists, mkdir } from "@tauri-apps/plugin-fs";
+import { Database } from "@tauri-apps/plugin-sql";
 
-let _db: any | null = null;
-let _opening: Promise<any> | null = null;
+export const isTauri = !!import.meta.env.TAURI_PLATFORM;
 
-async function dbPath(): Promise<string> {
-  // On stocke la DB dans l’AppData du profil Tauri, sous MamaStock/data/mamastock.db
-  const base = await appDataDir();
-  // on tolère l’absence de mkdir ici : la base est créée par SQLite si le dossier existe déjà
-  // Si besoin tu peux sécuriser avec plugin-fs mkdir récursif.
-  const dir = await join(base, "MamaStock", "data");
-  const file = await join(dir, "mamastock.db");
-  return file;
+const DB_NAME = "mamastock.db";
+const APP_FOLDER = "MamaStock";
+const DATA_FOLDER = "data";
+
+let _db: Database | null = null;
+
+async function ensureDir(p: string) {
+  if (!(await exists(p))) await mkdir(p, { recursive: true });
+}
+
+export async function locateDb() {
+  if (!isTauri) throw new Error("Tauri requis pour SQLite");
+
+  // 1) PRIORITÉ : ~/MamaStock/data/mamastock.db (utilisé par les scripts Node)
+  const home = await homeDir();
+  const homeRoot = await join(home, APP_FOLDER, DATA_FOLDER);
+  const homeFile = await join(homeRoot, DB_NAME);
+  if (await exists(homeFile)) {
+    return { file: homeFile, url: "sqlite:" + homeFile, location: "home" as const };
+  }
+
+  // 2) RETOMBÉE : %APPDATA%/com.mamastock.local/MamaStock/data/mamastock.db
+  const base = await appDataDir(); // pointe déjà sur ...\com.mamastock.local\
+  const dataDir = await join(base, APP_FOLDER, DATA_FOLDER);
+  await ensureDir(dataDir);
+  const appFile = await join(dataDir, DB_NAME);
+  return { file: appFile, url: "sqlite:" + appFile, location: "appdata" as const };
 }
 
 export async function getDb() {
-  if (!isTauri) {
-    throw new Error("Tauri requis : ouvre l’app via la fenêtre Tauri (pas le navigateur) pour activer SQLite.");
-  }
+  if (!isTauri) throw new Error("Vous êtes dans le navigateur. Ouvrez la fenêtre Tauri pour SQLite.");
   if (_db) return _db;
-  if (_opening) return _opening;
-
-  _opening = (async () => {
-    const file = await dbPath();
-    try {
-      // NOTE: v2 -> default import + Database.load("sqlite:<abs path>")
-      const db = await Database.load(`sqlite:${file}`);
-      _db = db;
-      return db;
-    } catch (e: any) {
-      // Cas de droits manquants (capabilities)
-      const msg = String(e?.message || e);
-      if (/sql\.load not allowed/i.test(msg)) {
-        console.error(
-          "[SQL] Permission manquante: sql:allow-load. " +
-          "Vérifie src-tauri/capabilities/sql.json (doit contenir sql:allow-load, sql:allow-select, sql:allow-execute, sql:allow-close)."
-        );
-      }
-      throw e;
-    } finally {
-      _opening = null;
-    }
-  })();
-
-  return _opening;
+  const { url, file, location } = await locateDb();
+  console.info("[SQLite] open", { file, location });
+  _db = await Database.load(url);
+  return _db;
 }
 
-export async function closeDb() {
-  try { await _db?.close?.(); } catch {}
-  _db = null;
-}
-
-export async function sqlSelfTest() {
-  if (!isTauri) {
-    console.info("[SQL SelfTest] hors Tauri -> ok (skip)");
-    return { ok: true, skipped: true };
-  }
+// Helpers utiles
+export async function tableExists(name: string) {
   const db = await getDb();
-  const rows = await db.select("SELECT 1 as v");
-  return { ok: rows?.[0]?.v === 1, rows };
+  const rows = await db.select("SELECT name FROM sqlite_master WHERE type='table' AND name = ?", [name]);
+  return rows.length > 0;
 }
 
-export { isTauri };
+export async function selectValue<T = any>(sql: string, params: any[] = []) {
+  const db = await getDb();
+  const rows = (await db.select(sql, params)) as any[];
+  if (!rows.length) return null as T | null;
+  const first = rows[0];
+  const key = Object.keys(first)[0];
+  return first[key] as T;
+}


### PR DESCRIPTION
## Summary
- replace the SQLite helper to reuse the shared MamaStock data directory when available
- ensure the appdata fallback path is created when needed and expose helpful helpers for consumers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c835c6de74832d9ad7dee979a4dd6c