### PR TITLE
Protect DB access for non-Tauri usage

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -3,6 +3,10 @@ import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
 export { getDb };
 
 export async function getMeta(key: string) {
+  if (!isTauri()) {
+    console.log("db/connection:getMeta ignoré hors Tauri");
+    return null;
+  }
   const db = await getDb();
   const row = await db.select<{value?: string;}[]>(
     "SELECT value FROM meta WHERE key = ? LIMIT 1",
@@ -12,6 +16,10 @@ export async function getMeta(key: string) {
 }
 
 export async function setMeta(key: string, value: string) {
+  if (!isTauri()) {
+    console.log("db/connection:setMeta ignoré hors Tauri");
+    return;
+  }
   const db = await getDb();
   await db.execute(
     "INSERT INTO meta(key,value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",

--- a/src/hooks/data/useFactures.js
+++ b/src/hooks/data/useFactures.js
@@ -3,9 +3,18 @@ import { useQuery } from "@tanstack/react-query";import { isTauri } from "@/lib/
 
 export function useFactures(filters = {}) {
   const { page = 1, pageSize = 20, search = "", fournisseur, statut } = filters;
+  const tauri = isTauri();
+  if (!tauri) {
+    console.info("useFactures(data): ignoré hors Tauri");
+  }
   return useQuery({
     queryKey: ["factures", filters],
+    enabled: tauri,
+    initialData: { factures: [], total: 0 },
     queryFn: async () => {
+      if (!isTauri()) {
+        return { factures: [], total: 0 };
+      }
       const { factures, total } = await factures_list({
         search,
         fournisseur_id: fournisseur?.id,

--- a/src/hooks/gadgets/useAchatsMensuels.js
+++ b/src/hooks/gadgets/useAchatsMensuels.js
@@ -15,6 +15,12 @@ export default function useAchatsMensuels() {
       setLoading(false);
       return;
     }
+    if (!isTauri()) {
+      console.info("useAchatsMensuels: ignoré hors Tauri");
+      setData([]);
+      setLoading(false);
+      return;
+    }
     (async () => {
       setLoading(true);
       setError(null);

--- a/src/hooks/useAlerts.js
+++ b/src/hooks/useAlerts.js
@@ -12,6 +12,12 @@ export function useAlerts() {
 
   const fetchRules = useCallback(async ({ search = "", actif = null } = {}) => {
     if (!mama_id) return [];
+    if (!isTauri()) {
+      console.info("useAlerts: fetch ignoré hors Tauri");
+      setRules([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {
@@ -30,6 +36,10 @@ export function useAlerts() {
 
   async function addRule(values) {
     if (!mama_id) return { error: "Aucun mama_id" };
+    if (!isTauri()) {
+      console.info("useAlerts: addRule ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -43,6 +53,10 @@ export function useAlerts() {
 
   async function updateRule(id, values) {
     if (!mama_id) return { error: "Aucun mama_id" };
+    if (!isTauri()) {
+      console.info("useAlerts: updateRule ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -56,6 +70,10 @@ export function useAlerts() {
 
   async function deleteRule(id) {
     if (!mama_id) return { error: "Aucun mama_id" };
+    if (!isTauri()) {
+      console.info("useAlerts: deleteRule ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useComparatif.js
+++ b/src/hooks/useComparatif.js
@@ -19,6 +19,12 @@ export function useComparatif(productId) {
       setLignes([]);
       return [];
     }
+    if (!isTauri()) {
+      console.info("useComparatif: ignoré hors Tauri");
+      setLignes([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useConsolidatedStats.js
+++ b/src/hooks/useConsolidatedStats.js
@@ -9,6 +9,12 @@ export function useConsolidatedStats() {
   const [error, setError] = useState(null);
 
   async function fetchStats() {
+    if (!isTauri()) {
+      console.info("useConsolidatedStats: ignoré hors Tauri");
+      setStats([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     try {
       const end = new Date().toISOString().slice(0, 10);

--- a/src/hooks/useConsolidation.js
+++ b/src/hooks/useConsolidation.js
@@ -30,6 +30,12 @@ export function useConsolidation() {
 
   const fetchConsoMensuelle = useCallback(
     async ({ mamaIds = [], start, end } = {}) => {
+      if (!isTauri()) {
+        console.info("useConsolidation: ignoré hors Tauri");
+        setRows([]);
+        setLoading(false);
+        return [];
+      }
       setLoading(true);
       try {
         const data = await consolidation_performance({ start, end });

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -7,6 +7,12 @@ export function useFactures() {
   const [error, setError] = useState(null);
 
   async function createFacture(facture, lignes) {
+    if (!isTauri()) {
+      console.info("useFactures: ignoré hors Tauri");
+      const err = new Error("Disponible uniquement dans l’app Tauri");
+      setError(err);
+      return { error: err };
+    }
     setLoading(true);
     try {
       const facture_id = await facture_create({

--- a/src/hooks/useFacturesAutocomplete.js
+++ b/src/hooks/useFacturesAutocomplete.js
@@ -7,6 +7,12 @@ export function useFacturesAutocomplete() {
   const [error, setError] = useState(null);
 
   const searchFactures = useCallback(async (query = "") => {
+    if (!isTauri()) {
+      console.info("useFacturesAutocomplete: ignoré hors Tauri");
+      setResults([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useFournisseurAPI.js
+++ b/src/hooks/useFournisseurAPI.js
@@ -11,6 +11,20 @@ export function useFournisseurAPI() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  if (!isTauri()) {
+    console.info("useFournisseurAPI: ignoré hors Tauri");
+    return {
+      loading: false,
+      error: null,
+      importFacturesFournisseur: async () => [],
+      syncCatalogue: async () => [],
+      envoyerCommande: async () => ({ error: "tauri_required" }),
+      getCommandeStatus: async () => ({ error: "tauri_required" }),
+      cancelCommande: async () => ({ error: "tauri_required" }),
+      testConnection: async () => false,
+    };
+  }
+
   async function getConfig(fournisseur_id) {
     if (!mama_id || !fournisseur_id) return null;
     const cfg = (await readConfig()) || {};

--- a/src/hooks/useFournisseursInactifs.js
+++ b/src/hooks/useFournisseursInactifs.js
@@ -6,6 +6,11 @@ export function useFournisseursInactifs() {
   const [fournisseurs, setFournisseurs] = useState([]);
 
   async function fetchInactifs() {
+    if (!isTauri()) {
+      console.info("useFournisseursInactifs: ignoré hors Tauri");
+      setFournisseurs([]);
+      return [];
+    }
     const rows = await fournisseurs_inactifs();
     setFournisseurs(Array.isArray(rows) ? rows : []);
     return rows || [];

--- a/src/hooks/useInvoiceImport.js
+++ b/src/hooks/useInvoiceImport.js
@@ -7,6 +7,12 @@ export function useInvoiceImport() {
   const [error, setError] = useState(null);
 
   async function importFromFile(file) {
+    if (!isTauri()) {
+      console.info("useInvoiceImport: ignoré hors Tauri");
+      const err = new Error("Disponible uniquement dans l’app Tauri");
+      setError(err.message);
+      return null;
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useOnboarding.js
+++ b/src/hooks/useOnboarding.js
@@ -8,11 +8,19 @@ export default function useOnboarding() {
 
   async function fetchProgress() {
     if (!user_id || !mama_id) return null;
+    if (!isTauri()) {
+      console.info("useOnboarding: ignoré hors Tauri");
+      return null;
+    }
     return onboarding_fetch(user_id, mama_id);
   }
 
   async function startOnboarding() {
     if (!user_id || !mama_id) return;
+    if (!isTauri()) {
+      console.info("useOnboarding: start ignoré hors Tauri");
+      return;
+    }
     await onboarding_start(user_id, mama_id);
   }
 

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -8,6 +8,12 @@ export function useProducts() {
   const [error, setError] = useState(null);
 
   const fetchProducts = useCallback(async () => {
+    if (!isTauri()) {
+      console.info("useProducts: ignoré hors Tauri");
+      setProducts([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     try {
       const rows = await produits_list();
@@ -25,6 +31,10 @@ export function useProducts() {
 
   const addProduct = useCallback(
     async (product) => {
+      if (!isTauri()) {
+        console.info("useProducts: addProduct ignoré hors Tauri");
+        return { error: new Error("Disponible uniquement dans l’app Tauri") };
+      }
       await produits_create(product);
       await fetchProducts();
       return { error: null };
@@ -34,6 +44,10 @@ export function useProducts() {
 
   const updateProduct = useCallback(
     async (id, fields) => {
+      if (!isTauri()) {
+        console.info("useProducts: updateProduct ignoré hors Tauri");
+        return { error: new Error("Disponible uniquement dans l’app Tauri") };
+      }
       await produits_update(id, fields);
       await fetchProducts();
       return { error: null };

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -12,6 +12,12 @@ export function useProduitsAutocomplete() {
 
   const searchProduits = useCallback(async (query = "") => {
     if (!mama_id) return [];
+    if (!isTauri()) {
+      console.info("useProduitsAutocomplete: ignoré hors Tauri");
+      setResults([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useReportingFinancier.js
+++ b/src/hooks/useReportingFinancier.js
@@ -12,6 +12,12 @@ export function useReportingFinancier({ start, end }) {
 
   useEffect(() => {
     if (!mama_id || !start || !end) return;
+    if (!isTauri()) {
+      console.info("useReportingFinancier: ignoré hors Tauri");
+      setData(null);
+      setLoading(false);
+      return;
+    }
     (async () => {
       setLoading(true);
       setError(null);
@@ -28,6 +34,10 @@ export function useReportingFinancier({ start, end }) {
   }, [mama_id, start, end]);
 
   async function exportCsv(path) {
+    if (!isTauri()) {
+      console.info("useReportingFinancier: export ignoré hors Tauri");
+      return;
+    }
     if (!data) return;
     const csv = [
     "poste,montant",

--- a/src/hooks/useTacheAssignation.js
+++ b/src/hooks/useTacheAssignation.js
@@ -8,6 +8,11 @@ export function useTacheAssignation() {
   const [error, setError] = useState(null);
 
   const assignUsers = useCallback(async (tacheId, userIds = []) => {
+    if (!isTauri()) {
+      console.info("useTacheAssignation: ignoré hors Tauri");
+      setLoading(false);
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -22,6 +27,11 @@ export function useTacheAssignation() {
   }, []);
 
   const unassignUser = useCallback(async (tacheId, userId) => {
+    if (!isTauri()) {
+      console.info("useTacheAssignation: ignoré hors Tauri");
+      setLoading(false);
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -11,6 +11,12 @@ export function useTasks() {
 
   const fetchTasks = useCallback(async () => {
     if (!mama_id) return [];
+    if (!isTauri()) {
+      console.info("useTasks: fetch ignoré hors Tauri");
+      setTasks([]);
+      setLoading(false);
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {
@@ -27,6 +33,10 @@ export function useTasks() {
 
   const fetchTaskById = useCallback(async (id) => {
     if (!mama_id || !id) return null;
+    if (!isTauri()) {
+      console.info("useTasks: fetchTaskById ignoré hors Tauri");
+      return null;
+    }
     try {
       return await tache_get(id, mama_id);
     } catch (e) {
@@ -37,6 +47,10 @@ export function useTasks() {
 
   const fetchTasksByStatus = useCallback(async (statut) => {
     if (!mama_id) return [];
+    if (!isTauri()) {
+      console.info("useTasks: fetchTasksByStatus ignoré hors Tauri");
+      return [];
+    }
     setLoading(true);
     setError(null);
     try {
@@ -52,6 +66,10 @@ export function useTasks() {
 
   const addTask = useCallback(async (values) => {
     if (!mama_id) return { error: "Aucun mama_id" };
+    if (!isTauri()) {
+      console.info("useTasks: addTask ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -67,6 +85,10 @@ export function useTasks() {
   }, [mama_id, fetchTasks]);
 
   const updateTask = useCallback(async (id, values) => {
+    if (!isTauri()) {
+      console.info("useTasks: updateTask ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -82,6 +104,10 @@ export function useTasks() {
   }, [mama_id, fetchTasks]);
 
   const deleteTask = useCallback(async (id) => {
+    if (!isTauri()) {
+      console.info("useTasks: deleteTask ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     setLoading(true);
     setError(null);
     try {

--- a/src/hooks/useZoneRights.js
+++ b/src/hooks/useZoneRights.js
@@ -7,6 +7,10 @@ export function useZoneRights() {
   const { mama_id } = useAuth();
 
   async function fetchZoneRights(zone_id) {
+    if (!isTauri()) {
+      console.info("useZoneRights: fetch ignoré hors Tauri");
+      return [];
+    }
     try {
       return await zones_droits_list(zone_id, mama_id);
     } catch (e) {
@@ -16,6 +20,10 @@ export function useZoneRights() {
   }
 
   async function setUserRights({ zone_id, user_id, lecture, ecriture, transfert, requisition }) {
+    if (!isTauri()) {
+      console.info("useZoneRights: setUserRights ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     try {
       await zones_droits_upsert({ zone_id, user_id, lecture, ecriture, transfert, requisition, mama_id });
       return { error: null };
@@ -26,6 +34,10 @@ export function useZoneRights() {
   }
 
   async function removeUserRights(id) {
+    if (!isTauri()) {
+      console.info("useZoneRights: removeUserRights ignoré hors Tauri");
+      return { error: new Error("Disponible uniquement dans l’app Tauri") };
+    }
     try {
       await zones_droits_delete(id);
       return { error: null };

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -7,7 +7,7 @@ import LanguageSelector from "@/components/ui/LanguageSelector";
 import { shutdownDbSafely } from "@/lib/shutdown";
 import { releaseLock } from "@/lib/lock";
 import { getDataDir } from "@/lib/db";
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { isTauri } from "@/lib/tauriEnv";
 
 export default function Navbar() {
   const { t } = useTranslation();

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -1,7 +1,15 @@
-import { getDb } from "./db";import { isTauri } from "@/lib/tauriEnv";
+import { getDb } from "@/lib/db/sql";
+import { isTauri } from "@/lib/tauriEnv";
 
 export async function shutdownDbSafely() {
+  if (!isTauri()) {
+    console.log("shutdownDbSafely: ignoré hors Tauri");
+    return;
+  }
+
   const db = await getDb();
   await db.execute("PRAGMA wal_checkpoint(TRUNCATE)");
-  await db.close();
+  if (typeof db.close === "function") {
+    await db.close();
+  }
 }

--- a/src/pages/CartePlats.jsx
+++ b/src/pages/CartePlats.jsx
@@ -18,6 +18,12 @@ export default function CartePlats() {
 
   useEffect(() => {
     if (!mama_id || authLoading) return;
+    if (!isTauri()) {
+      console.info('CartePlats: ignoré hors Tauri');
+      setFiches([]);
+      setFamilles([]);
+      return;
+    }
     Promise.all([
     fiches_actives_list(mama_id),
     familles_list(mama_id)]
@@ -39,6 +45,9 @@ export default function CartePlats() {
   });
 
 
+  if (!isTauri()) {
+    return <div className="p-8">Ouvrez l’app Tauri pour consulter la carte des plats.</div>;
+  }
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
   if (!mama_id) return null;
 

--- a/src/pages/Parametrage/Familles.tsx
+++ b/src/pages/Parametrage/Familles.tsx
@@ -18,7 +18,8 @@ export default function Familles() {
         .then(setDb)
         .catch(() => setError('Base de données indisponible'));
     } else {
-      setError('Base de données indisponible');
+      console.info('Parametrage/Familles: ignoré hors Tauri');
+      setError("Ouvrez l’app Tauri pour gérer les familles.");
     }
   }, []);
 

--- a/src/pages/Parametrage/SousFamilles.tsx
+++ b/src/pages/Parametrage/SousFamilles.tsx
@@ -18,7 +18,8 @@ export default function SousFamilles() {
         .then(setDb)
         .catch(() => setError('Base de données indisponible'));
     } else {
-      setError('Base de données indisponible');
+      console.info('Parametrage/SousFamilles: ignoré hors Tauri');
+      setError("Ouvrez l’app Tauri pour gérer les sous-familles.");
     }
   }, []);
 

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -38,6 +38,11 @@ export default function FactureDetail() {
   useEffect(() => {
     let isMounted = true;
     async function load() {
+      if (!isTauri()) {
+        console.info('FactureDetail: ignoré hors Tauri');
+        if (isMounted) setLoading(false);
+        return;
+      }
       setLoading(true);
       try {
         const data = await facture_get(Number(id));
@@ -63,6 +68,10 @@ export default function FactureDetail() {
       isMounted = false;
     };
   }, [id]);
+
+  if (!isTauri()) {
+    return <div className="p-6">Ouvrez l’app Tauri pour consulter cette facture.</div>;
+  }
 
   if (loading) return <LoadingSpinner message="Chargement..." />;
   const selectedFactureId = id;

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -80,6 +80,10 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
   const setFournisseurId = (val) =>
   setValue('fournisseur_id', val, { shouldDirty: true });
 
+  if (!isTauri()) {
+    return <div className="p-6">Ouvrez l’app Tauri pour créer des factures.</div>;
+  }
+
   const sum = (arr) => arr.reduce((acc, n) => acc + n, 0);
 
   const sumHT = useMemo(
@@ -150,6 +154,11 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
 
   const onSubmit = async (values) => {
     if (saving) return;
+    if (!isTauri()) {
+      console.info('FactureForm: onSubmit ignoré hors Tauri');
+      toast.error("Ouvrez l’app Tauri pour enregistrer une facture.");
+      return;
+    }
     setSaving(true);
     try {
       if (!values.fournisseur_id) {

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Menu } from 'lucide-react';
 import useExport from '@/hooks/useExport';
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { isTauri } from "@/lib/tauriEnv";
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import TableHeader from '@/components/ui/TableHeader';
 import GlassCard from '@/components/ui/GlassCard';
@@ -48,6 +48,11 @@ export default function Factures() {
   const pageSize = 10;
   const [loading, setLoading] = useState(false);
   const { exportData, loading: exporting } = useExport();
+
+  if (!isTauri()) {
+    console.log("Factures: ignoré hors Tauri");
+    return <div className="p-6">Ouvrez l’app Tauri pour gérer vos factures.</div>;
+  }
 
   const STATUTS = [
     { label: 'Tous', value: '' },

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -39,6 +39,13 @@ export default function FournisseurDetail({ id }) {
   useEffect(() => {
     if (!id || !mama_id) return;
     setLoading(true);
+    if (!isTauri()) {
+      console.info('FournisseurDetail: ignoré hors Tauri');
+      setStats([]);
+      setInvoices([]);
+      setLoading(false);
+      return;
+    }
     Promise.all([
     fetchStatsForFournisseur(id).then(setStats),
     factures_by_fournisseur(id).then(setInvoices),
@@ -63,6 +70,9 @@ export default function FournisseurDetail({ id }) {
   }, [id]);
 
   if (loading) return <LoadingSpinner message="Chargement..." />;
+  if (!isTauri()) {
+    return <div className="p-4">Ouvrez l’app Tauri pour consulter le détail fournisseur.</div>;
+  }
 
   return (
     <div className="space-y-8">

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -17,7 +17,7 @@ import FournisseurRow from '@/components/fournisseurs/FournisseurRow';
 import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
 import { toast } from 'sonner';
 import useExport from '@/hooks/useExport';
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { isTauri } from "@/lib/tauriEnv";
 import {
   ResponsiveContainer,
   LineChart,
@@ -104,6 +104,11 @@ export default function Fournisseurs() {
   const handleExport = (format) => {
     exportData({ type: 'fournisseurs', format });
   };
+
+  if (!isTauri()) {
+    console.log("Fournisseurs: ignoré hors Tauri");
+    return <div className="p-8">Ouvrez l’app Tauri pour gérer les fournisseurs.</div>;
+  }
 
   async function handleDiag() {
     try {

--- a/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
+++ b/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
@@ -19,6 +19,12 @@ export default function ComparatifPrix() {
       setLoading(true);
       setError(null);
       try {
+        if (!isTauri()) {
+          console.info('ComparatifPrix: ignoré hors Tauri');
+          setProduits([]);
+          setLoading(false);
+          return;
+        }
         const { rows } = await produits_list("", true, 1, 1000);
         setProduits(rows || []);
       } catch (err) {
@@ -32,6 +38,10 @@ export default function ComparatifPrix() {
 
     if (mama_id) fetchProduits();
   }, [mama_id]);
+
+  if (!isTauri()) {
+    return <div className="p-4">Ouvrez l’app Tauri pour comparer les prix fournisseurs.</div>;
+  }
 
   if (loading) {
     return <LoadingSpinner message="Chargement..." />;

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -15,6 +15,11 @@ export default function MobileInventaire() {
 
   useEffect(() => {
     if (authLoading || !mama_id) return;
+    if (!isTauri()) {
+      console.info('MobileInventaire: ignoré hors Tauri');
+      setProduits([]);
+      return;
+    }
     produits_list("", false, 1, 1000).then((rows) => setProduits(rows || []));
   }, [mama_id, authLoading]);
 
@@ -24,6 +29,10 @@ export default function MobileInventaire() {
 
   const handleSave = async () => {
     if (authLoading || !mama_id) return;
+    if (!isTauri()) {
+      console.info('MobileInventaire: save ignoré hors Tauri');
+      return;
+    }
     const lignes = Object.entries(stockFinal).map(([produit_id, q]) => ({
       produit_id,
       quantite: parseFloat(q)
@@ -36,6 +45,10 @@ export default function MobileInventaire() {
     });
     setStockFinal({});
   };
+
+  if (!isTauri()) {
+    return <div className="p-6">Ouvrez l’app Tauri pour réaliser un inventaire.</div>;
+  }
 
   return (
     <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-4 text-white">

--- a/src/pages/mobile/MobileRequisition.jsx
+++ b/src/pages/mobile/MobileRequisition.jsx
@@ -15,11 +15,21 @@ export default function MobileRequisition() {
 
   useEffect(() => {
     if (authLoading || !mama_id) return;
+    if (!isTauri()) {
+      console.info('MobileRequisition: ignoré hors Tauri');
+      setProduits([]);
+      return;
+    }
     produits_list("", false, 1, 1000).then((rows) => setProduits(rows || []));
   }, [mama_id, authLoading]);
 
   const handleSubmit = async () => {
     if (authLoading || !mama_id) return;
+    if (!isTauri()) {
+      console.info('MobileRequisition: submit ignoré hors Tauri');
+      toast.error("Ouvrez l’app Tauri pour créer une réquisition.");
+      return;
+    }
     if (!selectedId || quantite <= 0) {
       toast.error("Sélectionnez un produit et une quantité valide");
       return;
@@ -35,6 +45,10 @@ export default function MobileRequisition() {
       toast.error("Erreur lors de l'ajout du produit");
     }
   };
+
+  if (!isTauri()) {
+    return <div className="p-6">Ouvrez l’app Tauri pour gérer les réquisitions.</div>;
+  }
 
   return (
     <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-4 text-white">

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import TableContainer from '@/components/ui/TableContainer';
 import useExportCompta from '@/hooks/useExportCompta';
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { isTauri } from "@/lib/tauriEnv";
 
 export default function ExportComptaPage() {
   const { generateJournalCsv, exportToERP, loading } = useExportCompta();
@@ -13,6 +13,11 @@ export default function ExportComptaPage() {
   const [preview, setPreview] = useState([]);
   const [endpoint, setEndpoint] = useState('');
   const [token, setToken] = useState('');
+
+  if (!isTauri()) {
+    console.log("ExportComptaPage: ignoré hors Tauri");
+    return <div className="p-6">Ouvrez l’app Tauri pour accéder à l’export comptable.</div>;
+  }
 
   const handlePreview = async () => {
     const rows = await generateJournalCsv(mois, false);

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -20,7 +20,7 @@ import { useAuth } from '@/hooks/useAuth';
 import ProduitRow from "@/components/produits/ProduitRow";
 import ModalImportProduits from "@/components/produits/ModalImportProduits";
 import useExport from '@/hooks/useExport';
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { isTauri } from "@/lib/tauriEnv";
 
 const PAGE_SIZE = 50;
 
@@ -60,6 +60,11 @@ export default function Produits() {
   const canEdit = hasAccess("produits", "peut_modifier");
   const canView = hasAccess("produits", "peut_voir");
   const [showImport, setShowImport] = useState(false);
+
+  if (!isTauri()) {
+    console.log("Produits: ignoré hors Tauri");
+    return <div className="p-8">Ouvrez l’app Tauri pour gérer les produits.</div>;
+  }
 
   const rows = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- gate database-facing hooks behind `isTauri()` and return safe defaults outside the desktop runtime
- show a "Ouvrez l’app Tauri" notice on Tauri-only pages that previously hit SQLite directly
- normalize database imports to come from `@/lib/db/sql` and centralize onboarding/meta helpers

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68c921a1da14832daac713e799473ead