### PR TITLE
feat: add first-run setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Cette variante, basée sur **Tauri v2**, embarque une base SQLite locale pour f
 - Télécharger l'installateur **MSI** produit par la CI.
 - L'exécuter.
 
+## Première ouverture (local)
+- Au premier lancement, un écran de création de compte admin s’affiche.
+- Sous Tauri les comptes sont stockés dans `appDataDir/MamaStock/users.json`.
+- En navigateur DEV, c’est dans `localStorage` (`mama.users.json`).
+
 ## Vérification post-installation
 Après l'installation, le script suivant vérifie Node, npm, Rust (MSVC), WebView2 et la présence/lecture de la configuration et de la base de données :
 

--- a/src/pages/login.css
+++ b/src/pages/login.css
@@ -40,6 +40,21 @@
   letter-spacing: 0.2px;
 }
 
+.login-subtitle {
+  text-align: center;
+  margin: -4px 0 12px 0;
+  font-size: 15px;
+  color: #475569;
+}
+
+.login-helper {
+  margin: 0 0 16px 0;
+  font-size: 13px;
+  color: #4b5563;
+  text-align: center;
+  line-height: 1.4;
+}
+
 .login-error {
   background: #fee2e2;
   color: #991b1b;
@@ -80,6 +95,12 @@
   box-shadow: 0 0 0 3px rgba(99,102,241,.15);
 }
 
+.login-hint {
+  margin: -6px 0 6px 0;
+  font-size: 12px;
+  color: #6b7280;
+}
+
 .login-btn {
   width: 100%;
   margin-top: 8px;
@@ -94,10 +115,36 @@
 
 .login-btn:hover { filter: brightness(0.95); }
 
+.login-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .login-btn.secondary {
   background: #ffffff;
   color: #111827;
   border-color: #d1d5db;
+}
+
+.login-footer {
+  margin-top: 16px;
+  font-size: 13px;
+  color: #6b7280;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.login-link {
+  display: block;
+  margin-top: 16px;
+  text-align: center;
+  color: #4f46e5;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.login-link:hover {
+  text-decoration: underline;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -107,4 +154,9 @@
   .login-input:focus { border-color: #8b5cf6; box-shadow: 0 0 0 3px rgba(139,92,246,.2); }
   .login-btn { background: #8b5cf6; border-color: #8b5cf6; }
   .login-btn.secondary { background: #0b1220; color: #e5e7eb; border-color: #334155; }
+  .login-subtitle { color: #cbd5f5; }
+  .login-helper { color: #cbd5f5; }
+  .login-hint { color: #94a3b8; }
+  .login-footer { color: #94a3b8; }
+  .login-link { color: #c4b5fd; }
 }

--- a/src/pages/setup/FirstRun.jsx
+++ b/src/pages/setup/FirstRun.jsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { registerLocal, listLocalUsers } from "@/auth/localAccount";
+import { useAuth } from "@/context/AuthContext";
+import "../login.css";
+
+export default function FirstRun() {
+  const navigate = useNavigate();
+  const { signIn } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [existingUsers, setExistingUsers] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    listLocalUsers()
+      .then((users) => {
+        if (mounted) setExistingUsers(users.length);
+      })
+      .catch((err) => {
+        console.warn("[setup] Impossible de lire les comptes locaux", err);
+        if (mounted) setExistingUsers(0);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const baseTitle = (existingUsers ?? 0) > 0 ? "Créer un compte local" : "Configuration initiale";
+    document.title = `${baseTitle} • MamaStock`;
+  }, [existingUsers]);
+
+  const helperMessage = useMemo(() => {
+    if ((existingUsers ?? 0) > 0) {
+      if (existingUsers === 1) {
+        return "Un compte local existe déjà. Utilisez ce formulaire pour en ajouter un nouveau.";
+      }
+      return `${existingUsers} comptes locaux existent déjà. Utilisez ce formulaire pour en ajouter un nouveau.`;
+    }
+    return "Bienvenue ! Renseignez un email et un mot de passe pour créer l’administrateur local.";
+  }, [existingUsers]);
+
+  const hasExistingUsers = useMemo(() => (existingUsers ?? 0) > 0, [existingUsers]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (loading) return;
+    setError("");
+
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) {
+      setError("L’email est obligatoire.");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+      setError("L’email est invalide.");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Le mot de passe doit contenir au moins 8 caractères.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("La confirmation du mot de passe ne correspond pas.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const user = await registerLocal(normalizedEmail, password, "admin");
+      await signIn(user);
+      navigate("/dashboard", { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="login-wrapper">
+      <div className="login-card">
+        <img
+          src="/android-chrome-512x512.png"
+          alt="MamaStock"
+          className="login-logo"
+          width={72}
+          height={72}
+        />
+        <h1 className="login-title">Créer un compte administrateur</h1>
+        <p className="login-subtitle">Ce compte disposera de tous les droits sur cet appareil.</p>
+        <p className="login-helper">{helperMessage}</p>
+        {error ? <div className="login-error">{error}</div> : null}
+        <form onSubmit={handleSubmit} className="login-form">
+          <label className="login-label" htmlFor="setup-email">
+            Email
+          </label>
+          <input
+            id="setup-email"
+            className="login-input"
+            type="email"
+            placeholder="admin@exemple.com"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            autoComplete="username"
+            autoFocus
+            required
+          />
+
+          <label className="login-label" htmlFor="setup-password">
+            Mot de passe
+          </label>
+          <input
+            id="setup-password"
+            className="login-input"
+            type="password"
+            placeholder="••••••••"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+          <p className="login-hint">Minimum 8 caractères.</p>
+
+          <label className="login-label" htmlFor="setup-password-confirm">
+            Confirmer le mot de passe
+          </label>
+          <input
+            id="setup-password-confirm"
+            className="login-input"
+            type="password"
+            placeholder="••••••••"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+          />
+
+          <button type="submit" className="login-btn" disabled={loading}>
+            {loading ? "Création en cours…" : "Créer mon compte administrateur"}
+          </button>
+        </form>
+        <p className="login-footer">
+          Les comptes locaux sont enregistrés uniquement sur cet appareil. Pensez à sauvegarder ces informations en cas de
+          réinstallation.
+        </p>
+        {hasExistingUsers ? (
+          <Link to="/login" className="login-link">
+            Retour à la connexion
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a setup route and first-run guard that redirects to it when no local accounts exist
- implement the initial admin creation wizard and expose the link from the login page once accounts exist
- document where local accounts are stored during the first-run experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95b63c970832da13c62f6897ef5b4