### PR TITLE
Fix Card component re-export loop and update imports

### DIFF
--- a/src-inventory.json
+++ b/src-inventory.json
@@ -1468,7 +1468,7 @@
       ],
       "missing": []
     },
-    "src/components/ui/card.jsx": {
+    "src/components/ui/Card.jsx": {
       "internal": [],
       "external": [],
       "missing": []
@@ -4644,7 +4644,7 @@
         "src/hooks/useProduitsFournisseur.js",
         "src/hooks/useProducts.js",
         "src/hooks/useFournisseursInactifs.js",
-        "src/components/ui/card.jsx",
+        "src/components/ui/Card.jsx",
         "src/components/ui/button.jsx",
         "src/components/ui/ListingContainer.jsx",
         "src/components/ui/PaginationFooter.jsx",
@@ -5493,7 +5493,7 @@
         "src/components/ui/TableHeader.jsx",
         "src/components/ui/input.jsx",
         "src/components/ui/select.jsx",
-        "src/components/ui/card.jsx",
+        "src/components/ui/Card.jsx",
         "src/hooks/useAuth.ts",
         "src/components/produits/ProduitRow.jsx",
         "src/components/produits/ModalImportProduits.jsx",
@@ -10269,7 +10269,7 @@
     },
     {
       "from": "src/pages/fournisseurs/Fournisseurs.jsx",
-      "to": "src/components/ui/card.jsx"
+      "to": "src/components/ui/Card.jsx"
     },
     {
       "from": "src/pages/fournisseurs/Fournisseurs.jsx",
@@ -11385,7 +11385,7 @@
     },
     {
       "from": "src/pages/produits/Produits.jsx",
-      "to": "src/components/ui/card.jsx"
+      "to": "src/components/ui/Card.jsx"
     },
     {
       "from": "src/pages/produits/Produits.jsx",

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,2 +1,79 @@
-export * from "./card";
-export { default } from "./card";
+import React, { forwardRef } from "react";
+
+/** utilitaire simple pour concaténer des classes */
+const cx = (...c) => c.filter(Boolean).join(" ");
+
+const base =
+  "rounded-2xl border bg-white/70 dark:bg-zinc-900/60 text-inherit shadow-sm backdrop-blur-sm";
+
+export const Card = forwardRef(function Card({ className, ...props }, ref) {
+  return <div ref={ref} className={cx(base, className)} {...props} />;
+});
+
+export const CardHeader = forwardRef(function CardHeader(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cx(
+        "p-4 sm:p-6 border-b border-black/5 dark:border-white/10",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+export const CardTitle = forwardRef(function CardTitle(
+  { className, ...props },
+  ref
+) {
+  return (
+    <h3
+      ref={ref}
+      className={cx("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  );
+});
+
+export const CardDescription = forwardRef(function CardDescription(
+  { className, ...props },
+  ref
+) {
+  return (
+    <p
+      ref={ref}
+      className={cx("text-sm text-neutral-600 dark:text-neutral-400", className)}
+      {...props}
+    />
+  );
+});
+
+export const CardContent = forwardRef(function CardContent(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={cx("p-4 sm:p-6", className)} {...props} />;
+});
+
+export const CardFooter = forwardRef(function CardFooter(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={cx(
+        "p-4 sm:p-6 border-t border-black/5 dark:border-white/10",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+// Compatibilité : default + nommés
+export default Card;

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,2 +1,0 @@
-export * from "./card";
-export { default } from "./card";

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -8,7 +8,7 @@ import { useFournisseurStats } from '@/hooks/useFournisseurStats';
 import { useProduitsFournisseur } from '@/hooks/useProduitsFournisseur';
 import { useProducts } from '@/hooks/useProducts';
 import { useFournisseursInactifs } from '@/hooks/useFournisseursInactifs';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import ListingContainer from '@/components/ui/ListingContainer';
 import PaginationFooter from '@/components/ui/PaginationFooter';

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -13,7 +13,7 @@ import PaginationFooter from "@/components/ui/PaginationFooter";
 import TableHeader from "@/components/ui/TableHeader";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import { Card } from "@/components/ui/card";
+import { Card } from "@/components/ui/Card";
 import { Plus as PlusIcon, FileDown as FileDownIcon } from "lucide-react";
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';

--- a/var/schema-coverage.json
+++ b/var/schema-coverage.json
@@ -135,7 +135,7 @@
     "src/components/ui/TableHeader.jsx",
     "src/components/ui/badge.jsx",
     "src/components/ui/button.jsx",
-    "src/components/ui/card.jsx",
+    "src/components/ui/Card.jsx",
     "src/components/ui/checkbox.jsx",
     "src/components/ui/controls/index.jsx",
     "src/components/ui/dialog.jsx",


### PR DESCRIPTION
## Summary
- replace the self-reexported stub in `src/components/ui/Card.jsx` with a concrete implementation and drop the duplicate lowercase file
- retarget imports and metadata to reference `@/components/ui/Card` using PascalCase

## Testing
- npm run build *(fails: existing self-reexport in `src/pages/Debug/Auth.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c976591d28832d8978dd8259e5a05e