### PR TITLE
Fix self-reexporting debug and parametrage pages

### DIFF
--- a/src/pages/Debug/Auth.tsx
+++ b/src/pages/Debug/Auth.tsx
@@ -1,1 +1,3 @@
-export { default } from "@/pages/Debug/Auth";
+import Auth from "../debug/Auth";
+
+export default Auth;

--- a/src/pages/Parametrage/DossierDonnees.tsx
+++ b/src/pages/Parametrage/DossierDonnees.tsx
@@ -1,1 +1,3 @@
-export { default } from "@/pages/Parametrage/DossierDonnees";
+import DossierDonnees from "@/pages/parametrage/DossierDonnees";
+
+export default DossierDonnees;

--- a/src/pages/debug/Auth.tsx
+++ b/src/pages/debug/Auth.tsx
@@ -1,1 +1,5 @@
-export { default } from "@/pages/Debug/Auth";
+import AuthDebug from "./AuthDebug.jsx";
+
+export default function Auth(): JSX.Element {
+  return <AuthDebug />;
+}

--- a/src/pages/parametrage/DossierDonnees.tsx
+++ b/src/pages/parametrage/DossierDonnees.tsx
@@ -1,1 +1,3 @@
-export { default } from "@/pages/Parametrage/DossierDonnees";
+import DossierDonnees from "@/pages/DossierDonnees";
+
+export default DossierDonnees;


### PR DESCRIPTION
## Summary
- replace the debug Auth page self re-export with a concrete component that wraps AuthDebug
- route the capitalized Debug/Auth entry point through the lowercase file without looping
- wire the parametrage DossierDonnees pages to the real implementation instead of self-imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c984b2d7ec832da76fe94f8a697326