### PR TITLE
fix: restore tauri configuration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,22 +1,43 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
+  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "productName": "MamaStock Local",
   "version": "0.1.0",
   "identifier": "com.mamastock.local",
+  "build": {
+    "beforeBuildCommand": "npm run build",
+    "frontendDist": "../dist"
+  },
   "app": {
+    "withGlobalTauri": true,
+    "security": {
+      "csp": null
+    },
     "windows": [
-      {"label": "main",
+      {
+        "label": "main",
         "title": "MamaStock",
         "width": 1280,
         "height": 800,
         "resizable": true,
         "fullscreen": false,
-        "visible": true}],
-    "security": {
-      "csp": null
-    },
-  "build": {
-  "beforeBuildCommand": "npm run build",
-  "frontendDist": "../dist"
+        "visible": true
+      }
+    ]
+  },
+  "bundle": {
+    "active": true,
+    "targets": [
+      "nsis",
+      "msi"
+    ]
+  },
+  "plugins": {
+    "fs": {},
+    "shell": {},
+    "dialog": {},
+    "process": {},
+    "log": {},
+    "devtools": {},
+    "sql": {}
+  }
 }
-


### PR DESCRIPTION
## Summary
- rebuild the truncated `src-tauri/tauri.conf.json` as valid Tauri 2.x JSON
- keep the existing product metadata and window settings while adding required build, bundle, and plugin sections

## Testing
- `npm run build`
- `npx tauri build` *(fails: missing system library `glib-2.0` required by `glib-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68c98e681a40832d9061df476173138b