### PR TITLE
Configure Windows bundle icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "pwa:reset": "node scripts/pwa-reset.js",
     "webview:reset": "powershell -ExecutionPolicy Bypass -File scripts/reset-webview-cache.ps1",
     "codemod:isTauri": "node scripts/codemod-unify-isTauri.cjs",
-    "tauri:build": "npm run build && npx tauri build"
+    "tauri:build": "npm run build && npx tauri build",
+    "icons:generate": "npx @tauri-apps/cli icon src-tauri/icons/icon.png --output src-tauri/icons"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,9 @@
     "targets": [
       "nsis",
       "msi"
+    ],
+    "icon": [
+      "icons/icon.ico"
     ]
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- configure the Tauri bundle to reference the existing Windows icon
- add an npm script to regenerate the icon if ever needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c994649f08832da2fb53da12d745b1