### PR TITLE
refactor: static tauri imports and chunk split config

### DIFF
--- a/src/auth/localAccount.ts
+++ b/src/auth/localAccount.ts
@@ -1,3 +1,4 @@
+import { appDataDir, join } from "@tauri-apps/api/path";
 import { isTauri } from "@/lib/tauriEnv";
 
 const APP_DIR = "MamaStock";
@@ -26,7 +27,6 @@ export type LocalUser = {
 async function usersPath() {
   if (!isTauri()) return "browser://users.json";
 
-  const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir, rename, readTextFile, writeTextFile } = await import("@tauri-apps/plugin-fs");
 
   const base = await appDataDir();

--- a/src/components/DebugRibbon.jsx
+++ b/src/components/DebugRibbon.jsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { appDataDir, join } from "@tauri-apps/api/path";
 
 export default function DebugRibbon() {
   const show = import.meta.env.DEV || window.DEBUG;
@@ -19,7 +20,6 @@ export default function DebugRibbon() {
       return console.debug('Tauri indisponible (navigateur): ne pas appeler les plugins ici.');
     }
     try {
-      const { appDataDir, join } = await import("@tauri-apps/api/path");
       const { open } = await import("@tauri-apps/plugin-shell");
       const dir = await appDataDir();
       const logDir = await join(dir, "logs");

--- a/src/debug/check-capabilities-runtime.ts
+++ b/src/debug/check-capabilities-runtime.ts
@@ -1,5 +1,6 @@
 // src/debug/check-capabilities-runtime.ts
 // Testeur runtime des permissions SQL (à exécuter DANS Tauri WebView)
+import Database from "@tauri-apps/plugin-sql";
 import { isTauri } from "@/lib/tauriEnv";
 
 type Step = { ok: boolean; error?: string };
@@ -90,7 +91,6 @@ export async function runCapCheck(): Promise<Report> {
 
   // 1) load
   try {
-    const Database = (await import("@tauri-apps/plugin-sql")).default;
     db = await Database.load("sqlite:mamastock.db");
     report.tests.load.ok = true;
   } catch (e) {

--- a/src/lib/dal/facturePieces.ts
+++ b/src/lib/dal/facturePieces.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { appDataDir, join } from "@tauri-apps/api/path";
 
 const NOT_TAURI_HINT =
   "Vous êtes dans le navigateur de développement. Ouvrez la fenêtre Tauri pour activer SQLite.";
@@ -34,7 +35,6 @@ async function piecesDirForFacture(factureId: string) {
     console.warn(NOT_TAURI_HINT);
     return "";
   }
-  const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   const base = await appDataDir();
   const dir = await join(base, "MamaStock", "pieces", "factures", factureId);
@@ -103,7 +103,6 @@ export async function attachFiles(
     const mime = guessMime(ex);
     const id = crypto.randomUUID();
     const targetName = `${id}-${base}`;
-    const { join } = await import("@tauri-apps/api/path");
     const dst = await join(dir, targetName);
 
     // copie physique dans AppData

--- a/src/lib/db/sqlite.ts
+++ b/src/lib/db/sqlite.ts
@@ -1,3 +1,5 @@
+import Database from "@tauri-apps/plugin-sql";
+import { appDataDir, join } from "@tauri-apps/api/path";
 import schemaSQL from "@/../db/sqlite/001_schema.sql?raw";
 import { devFlags } from "@/lib/devFlags";
 
@@ -37,16 +39,14 @@ function ensureDevStub(): SqliteDatabase {
 }
 
 async function createTauriDb(url: string): Promise<SqliteDatabase> {
-  const mod = await import("@tauri-apps/plugin-sql");
-  const Database: any = mod.default ?? mod;
-  if (typeof Database?.load !== "function") {
+  const DatabaseAny = Database as any;
+  if (typeof DatabaseAny?.load !== "function") {
     throw new Error("[@tauri-apps/plugin-sql] load() missing");
   }
-  return Database.load(url);
+  return DatabaseAny.load(url);
 }
 
 async function ensureDataDir() {
-  const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   const base = await appDataDir();
   const appDir = await join(base, "MamaStock");

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -4,6 +4,7 @@ import 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { dump } from 'js-yaml';
+import { join } from '@tauri-apps/api/path';
 import { getExportDir } from '@/lib/db';
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
 
@@ -11,7 +12,6 @@ async function resolveExportPath(filename) {
   const dir = await getExportDir();
   if (!isTauri()) return filename;
   const fs = await import('@tauri-apps/plugin-fs');
-  const { join } = await import('@tauri-apps/api/path');
   await fs.mkdir(dir, { recursive: true });
   return await join(dir, filename);
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,4 +1,5 @@
 // src/lib/paths.ts
+import { appDataDir, join } from "@tauri-apps/api/path";
 import { isTauri } from "@/lib/tauriEnv";
 
 const NOT_TAURI_HINT =
@@ -9,7 +10,6 @@ export async function getAppDir() {
     console.warn(NOT_TAURI_HINT);
     return "";
   }
-  const { appDataDir, join } = await import("@tauri-apps/api/path");
   const base = await appDataDir();
   return join(base, APP_DIR);
 }
@@ -19,7 +19,6 @@ export async function inAppDir(...parts: string[]) {
     return "";
   }
   const root = await getAppDir();
-  const { join } = await import("@tauri-apps/api/path");
   let p = root;
   for (const part of parts) p = await join(p, part);
   return p;

--- a/src/local/files.ts
+++ b/src/local/files.ts
@@ -1,3 +1,4 @@
+import { appDataDir, dirname, join } from "@tauri-apps/api/path";
 import { isTauri } from "@/lib/tauriEnv";
 
 const NOT_TAURI_HINT =
@@ -10,7 +11,6 @@ async function baseDir() {
     console.warn(NOT_TAURI_HINT);
     return "";
   }
-  const { appDataDir, join } = await import("@tauri-apps/api/path");
   const { exists, mkdir } = await import("@tauri-apps/plugin-fs");
   const base = await appDataDir();
   const dir = await join(base, APP_DIR);
@@ -24,7 +24,6 @@ async function resolve(path: string) {
     return path;
   }
   const root = await baseDir();
-  const { join } = await import("@tauri-apps/api/path");
   return await join(root, path);
 }
 
@@ -34,7 +33,6 @@ export async function saveText(relPath: string, content: string) {
     return;
   }
   const file = await resolve(relPath);
-  const { dirname } = await import("@tauri-apps/api/path");
   const { exists, mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
   const dir = await dirname(file);
   if (!(await exists(dir))) await mkdir(dir, { recursive: true });
@@ -77,7 +75,6 @@ export async function saveBinary(relPath: string, data: Uint8Array) {
     return;
   }
   const file = await resolve(relPath);
-  const { dirname } = await import("@tauri-apps/api/path");
   const { exists, mkdir, writeFile } = await import("@tauri-apps/plugin-fs");
   const dir = await dirname(file);
   if (!(await exists(dir))) await mkdir(dir, { recursive: true });

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,3 @@
-import "@/debug/dbIntrospect";
 import { setupPwaGuard } from "@/pwa/guard";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -14,6 +13,7 @@ clearWebviewOnDev();
 setupPwaGuard();
 
 if (import.meta.env.DEV && isTauri()) {
+  import("@/debug/dbIntrospect");
   import("@/debug/check-capabilities-runtime");
 }
 

--- a/src/pages/DossierDonnees.jsx
+++ b/src/pages/DossierDonnees.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { appDataDir, join } from '@tauri-apps/api/path';
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
 
 export default function DossierDonnees() {
@@ -9,7 +10,6 @@ export default function DossierDonnees() {
 
   const refresh = async () => {
     if (isTauri()) {
-      const { appDataDir, join } = await import('@tauri-apps/api/path');
       const { exists, mkdir } = await import('@tauri-apps/plugin-fs');
       const root = await appDataDir();
       const appDir = await join(root, 'MamaStock');
@@ -37,7 +37,6 @@ export default function DossierDonnees() {
   const ensureDir = async () => {
     if (isTauri()) {
       const { mkdir, exists } = await import('@tauri-apps/plugin-fs');
-      const { join } = await import('@tauri-apps/api/path');
       await mkdir(baseDir, { recursive: true });
       const dbDir = await join(baseDir, 'databases');
       await mkdir(dbDir, { recursive: true });

--- a/src/pages/parametrage/TemplateCommandeForm.jsx
+++ b/src/pages/parametrage/TemplateCommandeForm.jsx
@@ -5,6 +5,7 @@ import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import { Button } from "@/components/ui/button";
 import { saveBinary } from "@/local/files";
 import { isTauri } from "@/lib/tauriEnv";
+import { appDataDir, join } from "@tauri-apps/api/path";
 
 export default function TemplateCommandeForm({ template = {}, onClose, fournisseurs = [] }) {
   const { createTemplate, updateTemplate } = useTemplatesCommandes();
@@ -41,7 +42,6 @@ export default function TemplateCommandeForm({ template = {}, onClose, fournisse
     const array = new Uint8Array(await file.arrayBuffer());
     const rel = `templates/${Date.now()}-${file.name}`;
     await saveBinary(rel, array);
-    const { appDataDir, join } = await import("@tauri-apps/api/path");
     const base = await appDataDir();
     const full = await join(base, "MamaStock", rel);
     setLogoUrl(full);

--- a/src/tauri/fsStore.ts
+++ b/src/tauri/fsStore.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { join } from "@tauri-apps/api/path";
 import { inAppDir } from "@/lib/paths";
 
 type Json = unknown;
@@ -12,7 +13,6 @@ export async function readJsonFile(rel: string): Promise<Json | null> {
     const v = localStorage.getItem(lsKey(rel));
     return v ? JSON.parse(v) : null;
   }
-  const { join } = await import("@tauri-apps/api/path");
   const fs = await import("@tauri-apps/plugin-fs");
   const root = await inAppDir("data");
   const mkdir = (fs as any).createDir ?? (fs as any).mkdir; // support both names
@@ -28,7 +28,6 @@ export async function writeJsonFile(rel: string, data: Json): Promise<string> {
     localStorage.setItem(lsKey(rel), JSON.stringify(data));
     return rel;
   }
-  const { join } = await import("@tauri-apps/api/path");
   const fs = await import("@tauri-apps/plugin-fs");
   const root = await inAppDir("data");
   const mkdir = (fs as any).createDir ?? (fs as any).mkdir;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,8 +40,19 @@ export default defineConfig(({ mode }) => {
       ],
     },
     build: {
+      chunkSizeWarningLimit: 1600,
       rollupOptions: {
         input: resolve(__dirname, "index.html"),
+        output: {
+          manualChunks(id) {
+            if (id.includes("xlsx")) return "xlsx";
+            if (id.includes("jspdf")) return "jspdf";
+            if (id.includes("html2canvas")) return "html2canvas";
+            if (id.includes("recharts")) return "recharts";
+            if (id.includes("dompurify")) return "purify";
+            if (id.includes("@tauri-apps")) return "tauri";
+          },
+        },
       },
     },
     appType: "spa",


### PR DESCRIPTION
## Summary
- replace dynamic imports of @tauri-apps/api/path with static named imports across Tauri-related utilities
- switch @tauri-apps/plugin-sql usage to a shared static default import and load the debug introspection module only during dev
- increase the Vite chunk size warning limit and declare manual chunks for large third-party bundles

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c99a16e25c832d97f007f1812afa6c