### PR TITLE
feat: lazy load heavy deps and split routes

### DIFF
--- a/src/components/FactureImportModal.jsx
+++ b/src/components/FactureImportModal.jsx
@@ -9,7 +9,7 @@ import {
 "@/components/ui/SmartDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export default function FactureImportModal({ open, onClose, onImport }) {
   const [rows, setRows] = useState([]);
@@ -20,6 +20,7 @@ export default function FactureImportModal({ open, onClose, onImport }) {
     if (!file) return;
     setFileName(file.name);
     const data = await file.arrayBuffer();
+    const XLSX = await loadXLSX();
     const wb = XLSX.read(data, { type: "array" });
     const ws = wb.Sheets[wb.SheetNames[0]];
     const json = XLSX.utils.sheet_to_json(ws, { defval: "" });

--- a/src/components/Reporting/GraphMultiZone.jsx
+++ b/src/components/Reporting/GraphMultiZone.jsx
@@ -1,18 +1,10 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/components/Reporting/GraphMultiZone.jsx
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer } from
-"recharts";
-import { useRef, useState, useMemo } from "react";
-import html2canvas from "html2canvas";
+import { useRef, useState, useMemo, lazy, Suspense } from "react";
 import { makeId } from "@/utils/formIds";import { isTauri } from "@/lib/tauriEnv";
+import { loadHtml2Canvas } from "@/lib/lazy/vendors";
+
+const RechartsWrapper = lazy(() => import("@/components/charts/RechartsWrapper"));
 
 const allZones = [
 { key: "cost_cuisine", label: "Cuisine", color: "#bfa14d" },
@@ -34,6 +26,7 @@ export default function GraphMultiZone({ data }) {
 
   const exportImage = async () => {
     if (chartRef.current) {
+      const html2canvas = await loadHtml2Canvas();
       const canvas = await html2canvas(chartRef.current);
       const link = document.createElement("a");
       link.download = "comparatif_zones.png";
@@ -72,28 +65,34 @@ export default function GraphMultiZone({ data }) {
       </div>
 
       <div ref={chartRef}>
-        <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="periode" />
-            <YAxis />
-            <Tooltip />
-            <Legend />
-            {allZones.
-            filter((z) => selectedZones.includes(z.key)).
-            map((zone) =>
-            <Line
-              key={zone.key}
-              type="monotone"
-              dataKey={zone.key}
-              name={zone.label}
-              stroke={zone.color}
-              strokeWidth={2}
-              dot={false} />
-
+        <Suspense fallback={null}>
+          <RechartsWrapper>
+            {({ ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, Legend }) => (
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={data}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="periode" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  {allZones
+                    .filter((z) => selectedZones.includes(z.key))
+                    .map((zone) => (
+                      <Line
+                        key={zone.key}
+                        type="monotone"
+                        dataKey={zone.key}
+                        name={zone.label}
+                        stroke={zone.color}
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                    ))}
+                </LineChart>
+              </ResponsiveContainer>
             )}
-          </LineChart>
-        </ResponsiveContainer>
+          </RechartsWrapper>
+        </Suspense>
       </div>
     </div>);
 

--- a/src/components/charts/RechartsWrapper.jsx
+++ b/src/components/charts/RechartsWrapper.jsx
@@ -1,0 +1,8 @@
+import * as Recharts from 'recharts';
+
+export default function RechartsWrapper({ children }) {
+  if (typeof children === 'function') {
+    return children(Recharts);
+  }
+  return null;
+}

--- a/src/components/dashboard/WidgetRenderer.jsx
+++ b/src/components/dashboard/WidgetRenderer.jsx
@@ -1,6 +1,69 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { ResponsiveContainer, LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, Tooltip } from "recharts";
+import { lazy, Suspense } from "react";
 import DashboardCard from "./DashboardCard";import { isTauri } from "@/lib/tauriEnv";
+
+const RechartsWrapper = lazy(() => import("@/components/charts/RechartsWrapper"));
+
+function LineWidget({ config }) {
+  return (
+    <Suspense fallback={null}>
+      <RechartsWrapper>
+        {({ ResponsiveContainer, LineChart, Line, Tooltip }) => (
+          <ResponsiveContainer width="100%" height={220}>
+            <LineChart data={config.data || []}>
+              <Line type="monotone" dataKey={config.dataKey} stroke={config.color || "#bfa14d"} />
+              <Tooltip />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </RechartsWrapper>
+    </Suspense>
+  );
+}
+
+function BarWidget({ config }) {
+  return (
+    <Suspense fallback={null}>
+      <RechartsWrapper>
+        {({ ResponsiveContainer, BarChart, Bar, Tooltip }) => (
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={config.data || []}>
+              <Bar dataKey={config.dataKey} fill={config.color || "#bfa14d"} />
+              <Tooltip />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </RechartsWrapper>
+    </Suspense>
+  );
+}
+
+function PieWidget({ config }) {
+  return (
+    <Suspense fallback={null}>
+      <RechartsWrapper>
+        {({ ResponsiveContainer, PieChart, Pie, Cell, Tooltip }) => (
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={config.data || []}
+                dataKey={config.dataKey}
+                nameKey={config.nameKey}
+                outerRadius={80}
+                fill={config.color || "#bfa14d"}
+              >
+                {(config.data || []).map((_, idx) => (
+                  <Cell key={idx} fill={config.colors?.[idx % config.colors.length] || "#bfa14d"} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </RechartsWrapper>
+    </Suspense>
+  );
+}
 
 export default function WidgetRenderer({ config }) {
   if (!config) return null;
@@ -8,48 +71,21 @@ export default function WidgetRenderer({ config }) {
 
   switch (type) {
     case "line":
-      return (
-        <ResponsiveContainer width="100%" height={220}>
-          <LineChart data={config.data || []}>
-            <Line type="monotone" dataKey={config.dataKey} stroke={config.color || "#bfa14d"} />
-            <Tooltip />
-          </LineChart>
-        </ResponsiveContainer>);
-
+      return <LineWidget config={config} />;
     case "bar":
-      return (
-        <ResponsiveContainer width="100%" height={220}>
-          <BarChart data={config.data || []}>
-            <Bar dataKey={config.dataKey} fill={config.color || "#bfa14d"} />
-            <Tooltip />
-          </BarChart>
-        </ResponsiveContainer>);
-
+      return <BarWidget config={config} />;
     case "pie":
-      return (
-        <ResponsiveContainer width="100%" height={220}>
-          <PieChart>
-            <Pie data={config.data || []} dataKey={config.dataKey} nameKey={config.nameKey} outerRadius={80} fill={config.color || "#bfa14d"}>
-              {(config.data || []).map((_, idx) =>
-              <Cell key={idx} fill={config.colors?.[idx % config.colors.length] || "#bfa14d"} />
-              )}
-            </Pie>
-            <Tooltip />
-          </PieChart>
-        </ResponsiveContainer>);
-
+      return <PieWidget config={config} />;
     case "list":
       return (
         <ul className="list-disc pl-4 text-sm">
-          {(config.items || []).map((it, idx) =>
-          <li key={idx}>{it}</li>
-          )}
-        </ul>);
-
+          {(config.items || []).map((it, idx) => (
+            <li key={idx}>{it}</li>
+          ))}
+        </ul>
+      );
     case "indicator":
     default:
-      return (
-        <DashboardCard title={config.label} value={config.value} type={config.indicatorType} />);
-
+      return <DashboardCard title={config.label} value={config.value} type={config.indicatorType} />;
   }
 }

--- a/src/components/engineering/ImportVentesExcel.jsx
+++ b/src/components/engineering/ImportVentesExcel.jsx
@@ -1,19 +1,21 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import * as XLSX from 'xlsx';
 import { Button } from '@/components/ui/button';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from '@/lib/lazy/vendors';
 
 export default function ImportVentesExcel({ onImport }) {
   const handleFile = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
     const buf = await file.arrayBuffer();
+    const XLSX = await loadXLSX();
     const wb = XLSX.read(buf);
     const sheet = wb.Sheets[wb.SheetNames[0]];
     const rows = XLSX.utils.sheet_to_json(sheet);
     onImport(rows);
   };
 
-  const downloadTemplate = () => {
+  const downloadTemplate = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet([{ fiche_id: '', ventes: 0 }]);
     XLSX.utils.book_append_sheet(wb, ws, 'ventes');

--- a/src/components/gadgets/GadgetEvolutionAchats.jsx
+++ b/src/components/gadgets/GadgetEvolutionAchats.jsx
@@ -1,6 +1,8 @@
-import { ResponsiveContainer, LineChart, Line, Tooltip } from 'recharts';
+import { lazy, Suspense } from 'react';
 import useEvolutionAchats from '@/hooks/gadgets/useEvolutionAchats';
 import LoadingSkeleton from '@/components/ui/LoadingSkeleton';import { isTauri } from "@/lib/tauriEnv";
+
+const RechartsWrapper = lazy(() => import('@/components/charts/RechartsWrapper'));
 
 export default function GadgetEvolutionAchats() {
   const { data, loading } = useEvolutionAchats();
@@ -16,12 +18,18 @@ export default function GadgetEvolutionAchats() {
   return (
     <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Évolution des achats</h3>
-      <ResponsiveContainer width="100%" height={200}>
-        <LineChart data={data} margin={{ left: -10, right: 10 }}>
-          <Line type="monotone" dataKey="montant" stroke="#F6C343" />
-          <Tooltip />
-        </LineChart>
-      </ResponsiveContainer>
+      <Suspense fallback={null}>
+        <RechartsWrapper>
+          {({ ResponsiveContainer, LineChart, Line, Tooltip }) => (
+            <ResponsiveContainer width="100%" height={200}>
+              <LineChart data={data} margin={{ left: -10, right: 10 }}>
+                <Line type="monotone" dataKey="montant" stroke="#F6C343" />
+                <Tooltip />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </RechartsWrapper>
+      </Suspense>
     </div>);
 
 }

--- a/src/components/inventaires/InventaireDetail.jsx
+++ b/src/components/inventaires/InventaireDetail.jsx
@@ -1,13 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Button } from "@/components/ui/button";
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
 import { toast } from 'sonner';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export default function InventaireDetail({ inventaire, onClose }) {
 
   // Export Excel
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(inventaire.lignes || []);
     XLSX.utils.book_append_sheet(wb, ws, "LignesInventaire");

--- a/src/components/parametrage/ParamCostCenters.jsx
+++ b/src/components/parametrage/ParamCostCenters.jsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { Button } from '@/components/ui/button';
 import TableContainer from '@/components/ui/TableContainer';
 import { toast } from 'sonner';
-import * as XLSX from 'xlsx';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from '@/lib/lazy/vendors';import { isTauri } from "@/lib/tauriEnv";
 
 export default function ParamCostCenters() {
   const {
@@ -96,7 +96,8 @@ export default function ParamCostCenters() {
     }
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(filtered);
     XLSX.utils.book_append_sheet(wb, ws, 'CostCenters');

--- a/src/components/parametrage/ParamFamilles.jsx
+++ b/src/components/parametrage/ParamFamilles.jsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { toast } from 'sonner';
 import { saveAs } from 'file-saver';
-import * as XLSX from 'xlsx';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from '@/lib/lazy/vendors';import { isTauri } from "@/lib/tauriEnv";
 
 export default function ParamFamilles() {
   const {
@@ -75,7 +75,8 @@ export default function ParamFamilles() {
     }
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(filtered);
     XLSX.utils.book_append_sheet(wb, ws, 'Familles');

--- a/src/components/parametrage/ParamUnites.jsx
+++ b/src/components/parametrage/ParamUnites.jsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { toast } from 'sonner';
 import { saveAs } from 'file-saver';
-import * as XLSX from 'xlsx';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from '@/lib/lazy/vendors';import { isTauri } from "@/lib/tauriEnv";
 
 export default function ParamUnites() {
   const { unites, listUnites, addUnite, updateUnite, deleteUnite } =
@@ -65,7 +65,8 @@ export default function ParamUnites() {
     }
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(unites);
     XLSX.utils.book_append_sheet(wb, ws, 'Unités');

--- a/src/components/simulation/SimulationDetailsModal.jsx
+++ b/src/components/simulation/SimulationDetailsModal.jsx
@@ -2,12 +2,13 @@
 import ModalGlass from "@/components/ui/ModalGlass";
 import Button from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
-import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export default function SimulationDetailsModal({ open, onClose, result }) {
-  const exportExcel = () => {
+  const exportExcel = async () => {
     if (!result) return;
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(
       wb,

--- a/src/hooks/useConsolidation.js
+++ b/src/hooks/useConsolidation.js
@@ -2,9 +2,7 @@
 import { useState, useCallback } from "react";
 import { consolidation_performance } from "@/lib/db";
 import { readConfig } from "@/appFs";
-import * as XLSX from "xlsx";
-import JSPDF from "jspdf";
-import "jspdf-autotable";import { isTauri } from "@/lib/tauriEnv";
+import { loadJsPDF, loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export function useConsolidation() {
   const [sites, setSites] = useState([]);
@@ -55,13 +53,15 @@ export function useConsolidation() {
     []
   );
 
-  const exportExcel = useCallback((data) => {
+  const exportExcel = useCallback(async (data) => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(data), "Consolidation");
     XLSX.writeFile(wb, "consolidation.xlsx");
   }, []);
 
-  const exportPdf = useCallback((data) => {
+  const exportPdf = useCallback(async (data) => {
+    const JSPDF = await loadJsPDF();
     const doc = new JSPDF();
     if (data && data.length > 0) {
       const head = [Object.keys(data[0])];

--- a/src/hooks/useCostCenters.js
+++ b/src/hooks/useCostCenters.js
@@ -1,13 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 import { useAuditLog } from "@/hooks/useAuditLog";
 import { readCostCenters, writeCostCenters } from "@/local/costCenters";import { isTauri } from "@/lib/tauriEnv";
 
 export async function importCostCentersFromExcel(file, sheetName) {
   const buf = await file.arrayBuffer();
+  const XLSX = await loadXLSX();
   const wb = XLSX.read(buf, { type: "array" });
   const pick = sheetName && wb.Sheets[sheetName] ? sheetName : wb.SheetNames[0];
   const ws = wb.Sheets[pick];
@@ -100,11 +101,12 @@ export function useCostCenters() {
     }
   }
 
-  function exportCostCentersToExcel() {
+  async function exportCostCentersToExcel() {
     const datas = (costCenters || []).map((c) => ({
       nom: c.nom,
       actif: c.actif
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "CostCenters");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });

--- a/src/hooks/useCostingCarte.js
+++ b/src/hooks/useCostingCarte.js
@@ -3,9 +3,7 @@ import { costing_carte_list, settings_get } from '@/lib/db';
 import { useState, useCallback } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
-import * as XLSX from 'xlsx';
-import JSPDF from 'jspdf';
-import 'jspdf-autotable';import { isTauri } from "@/lib/tauriEnv";
+import { loadJsPDF, loadXLSX } from '@/lib/lazy/vendors';import { isTauri } from "@/lib/tauriEnv";
 
 export function useCostingCarte() {
   const { mama_id } = useAuth();
@@ -49,13 +47,15 @@ export function useCostingCarte() {
     [mama_id]
   );
 
-  const exportExcel = useCallback((rows) => {
+  const exportExcel = useCallback(async (rows) => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), 'Costing');
     XLSX.writeFile(wb, 'costing_carte.xlsx');
   }, []);
 
-  const exportPdf = useCallback((rows) => {
+  const exportPdf = useCallback(async (rows) => {
+    const JSPDF = await loadJsPDF();
     const doc = new JSPDF();
     const headers = [
     ['Nom fiche', 'Type', 'Coût/portion', 'Prix vente', 'Marge €', 'Marge %', 'Food cost %']];

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -9,10 +9,8 @@ import {
   fiches_delete,
   fiches_duplicate } from
 '@/lib/db';
-import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
-import JSPDF from "jspdf";
-import "jspdf-autotable";import { isTauri } from "@/lib/tauriEnv";
+import { loadJsPDF, loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export function useFiches() {
   const { mama_id } = useAuth();
@@ -138,7 +136,7 @@ export function useFiches() {
     }
   }
 
-  function exportFichesToExcel() {
+  async function exportFichesToExcel() {
     const datas = (fiches || []).map((f) => ({
       id: f.id,
       nom: f.nom,
@@ -147,13 +145,15 @@ export function useFiches() {
       cout_par_portion: f.cout_par_portion,
       actif: f.actif
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "Fiches");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     saveAs(new Blob([buf]), "fiches_mamastock.xlsx");
   }
 
-  function exportFichesToPDF() {
+  async function exportFichesToPDF() {
+    const JSPDF = await loadJsPDF();
     const doc = new JSPDF();
     const rows = (fiches || []).map((f) => [
     f.nom,

--- a/src/hooks/useInvoices.js
+++ b/src/hooks/useInvoices.js
@@ -9,9 +9,9 @@ import {
   facture_delete,
   factures_update_status } from
 "@/lib/db";
-import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";
 import { saveAs } from "file-saver";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export function useInvoices() {
   const [invoices, setInvoices] = useState([]);
@@ -127,7 +127,7 @@ export function useInvoices() {
   }
 
   // 8. Export Excel
-  function exportInvoicesToExcel() {
+  async function exportInvoicesToExcel() {
     const datas = (invoices || []).map((f) => ({
       id: f.id,
       numero: f.numero,
@@ -136,6 +136,7 @@ export function useInvoices() {
       montant: f.montant,
       statut: f.statut
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "Factures");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -2,8 +2,8 @@
 import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { logs_list, logs_add, rapports_list } from "@/local/logs";
-import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { saveAs } from "file-saver";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export function useLogs() {
   const { mama_id } = useAuth();
@@ -57,8 +57,9 @@ export function useLogs() {
     }
   }
 
-  function exportLogs(format = "csv") {
+  async function exportLogs(format = "csv") {
     if (format === "xlsx") {
+      const XLSX = await loadXLSX();
       const ws = XLSX.utils.json_to_sheet(logs);
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Logs");

--- a/src/hooks/useMamas.js
+++ b/src/hooks/useMamas.js
@@ -3,9 +3,9 @@ import { useState } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
 import { readConfig, writeConfig } from '@/appFs';
-import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";
 import { saveAs } from "file-saver";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export function useMamas() {
   const { mama_id, role } = useAuth();
@@ -105,13 +105,14 @@ export function useMamas() {
 
 
   // 5. Export Excel
-  function exportMamasToExcel() {
+  async function exportMamasToExcel() {
     const datas = (mamas || []).map((m) => ({
       id: m.id,
       nom: m.nom,
       ville: m.ville,
       email: m.email
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "Mamas");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });

--- a/src/hooks/usePermissions.js
+++ b/src/hooks/usePermissions.js
@@ -8,9 +8,9 @@ import {
 import { useState } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
-import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";
 import { saveAs } from "file-saver";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export function usePermissions() {
   const { mama_id, role } = useAuth();
@@ -85,7 +85,7 @@ export function usePermissions() {
   }
 
   // 5. Export Excel
-  function exportPermissionsToExcel() {
+  async function exportPermissionsToExcel() {
     const datas = (permissions || []).map((p) => ({
       id: p.id,
       role_id: p.role_id,
@@ -94,6 +94,7 @@ export function usePermissions() {
       actif: p.actif,
       mama_id: p.mama_id
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "Permissions");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -1,11 +1,11 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { listLocalUsers, registerLocal, updateRoleLocal, deleteUserLocal } from "@/auth/localAccount";
-import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { exportToCSV } from "@/lib/export/exportHelpers";
 import { DEFAULT_ROLES } from "@/constants/roles";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export function useUtilisateurs() {
   const [users, setUsers] = useState([]);
@@ -62,7 +62,8 @@ export function useUtilisateurs() {
     await getUtilisateurs();
   }
 
-  function exportUsersToExcel(data = users) {
+  async function exportUsersToExcel(data = users) {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(data), "Utilisateurs");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -1,12 +1,10 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import JSPDF from 'jspdf';
-import 'jspdf-autotable';
-import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { dump } from 'js-yaml';
 import { join } from '@tauri-apps/api/path';
 import { getExportDir } from '@/lib/db';
 import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { loadJsPDF, loadXLSX } from '@/lib/lazy/vendors';
 
 async function resolveExportPath(filename) {
   const dir = await getExportDir();
@@ -40,6 +38,7 @@ export async function exportToPDF(data = [], config = {}) {
   const orient = ['portrait', 'landscape'].includes(String(orientation).toLowerCase())
     ? String(orientation).toLowerCase()
     : 'portrait';
+  const JSPDF = await loadJsPDF();
   const doc = new JSPDF({ orientation: orient });
   if (!Array.isArray(data)) data = [data];
   const headers = columns.length
@@ -73,6 +72,7 @@ export async function exportToExcel(data = [], config = {}) {
     }
     return item;
   });
+  const XLSX = await loadXLSX();
   const wb = XLSX.utils.book_new();
   const ws = XLSX.utils.json_to_sheet(arr);
   XLSX.utils.book_append_sheet(wb, ws, sheet);

--- a/src/lib/lazy/vendors.js
+++ b/src/lib/lazy/vendors.js
@@ -1,0 +1,27 @@
+let xlsxPromise;
+let jsPDFPromise;
+let html2canvasPromise;
+
+export function loadXLSX() {
+  if (!xlsxPromise) {
+    xlsxPromise = import("xlsx");
+  }
+  return xlsxPromise;
+}
+
+export async function loadJsPDF() {
+  if (!jsPDFPromise) {
+    jsPDFPromise = Promise.all([
+      import("jspdf"),
+      import("jspdf-autotable")
+    ]).then(([jsPDFModule]) => jsPDFModule.default);
+  }
+  return jsPDFPromise;
+}
+
+export async function loadHtml2Canvas() {
+  if (!html2canvasPromise) {
+    html2canvasPromise = import("html2canvas").then((mod) => mod.default);
+  }
+  return html2canvasPromise;
+}

--- a/src/lib/xlsx/safeImportXLSX.js
+++ b/src/lib/xlsx/safeImportXLSX.js
@@ -1,9 +1,10 @@
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export async function safeImportXLSX(file, sheetName = null, maxSize = 1000000) {
   if (!file || file.size > maxSize) throw new Error("Fichier invalide ou trop volumineux");
 
   const buffer = await file.arrayBuffer();
+  const XLSX = await loadXLSX();
   const workbook = XLSX.read(buffer, { type: "array" });
   const sheet = workbook.Sheets[sheetName || workbook.SheetNames[0]];
   if (!sheet) throw new Error("Onglet introuvable");

--- a/src/pages/Stock.jsx
+++ b/src/pages/Stock.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
+import { loadXLSX } from "@/lib/lazy/vendors";
 import { motion as Motion } from "framer-motion";import { isTauri } from "@/lib/tauriEnv";
 
 const PAGE_SIZE = 20;
@@ -28,7 +28,8 @@ export default function Stock() {
   const nbPages = Math.ceil(filtered.length / PAGE_SIZE);
   const paged = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(filtered);
     XLSX.utils.book_append_sheet(wb, ws, "Stock");

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -11,7 +11,7 @@ import TableHeader from "@/components/ui/TableHeader";
 import GlassCard from "@/components/ui/GlassCard";
 import { toast } from 'sonner';
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
+import { loadXLSX } from "@/lib/lazy/vendors";
 import { motion as Motion } from "framer-motion";import { isTauri } from "@/lib/tauriEnv";
 
 const PAGE_SIZE = 20;
@@ -39,7 +39,8 @@ export default function Utilisateurs() {
   const nbPages = Math.ceil(filtres.length / PAGE_SIZE);
   const paged = filtres.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(filtres);
     XLSX.utils.book_append_sheet(wb, ws, "Utilisateurs");

--- a/src/pages/carte/Carte.jsx
+++ b/src/pages/carte/Carte.jsx
@@ -8,7 +8,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { toast } from 'sonner';
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 const FOOD_COST_SEUIL = 35;
 
@@ -51,7 +51,7 @@ function CarteTable({ type }) {
     return true;
   });
 
-  const handleExport = () => {
+  const handleExport = async () => {
     const rows = filtered.map((f) => ({
       Nom: f.nom,
       Famille: f.famille || "",
@@ -60,6 +60,7 @@ function CarteTable({ type }) {
       "Marge (€)": f.prix_vente && f.cout_portion ? (f.prix_vente - f.cout_portion).toFixed(2) : "",
       "Food cost (%)": f.prix_vente && f.cout_portion ? (f.cout_portion / f.prix_vente * 100).toFixed(1) : ""
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Carte");
     XLSX.writeFile(wb, "carte_plats.xlsx");

--- a/src/pages/cuisine/MenuDuJour.jsx
+++ b/src/pages/cuisine/MenuDuJour.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useMenuDuJour } from "@/hooks/useMenuDuJour";
 import { useFiches } from "@/hooks/useFiches";
 import { Button } from "@/components/ui/button";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 const CATEGORIES = ["entrée", "plat", "dessert"];
 const COST_THRESHOLD = 5;
@@ -63,7 +63,7 @@ export default function MenuDuJour() {
     setMenu(data || {});
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
     const rows = CATEGORIES.map((cat) => {
       const item = menu[cat] || {};
       const total = (item.portions || 0) * (item.cout_unitaire || 0);
@@ -75,6 +75,7 @@ export default function MenuDuJour() {
         total
       };
     });
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(rows);
     XLSX.utils.book_append_sheet(wb, ws, "Menu");

--- a/src/pages/emails/EmailsEnvoyes.jsx
+++ b/src/pages/emails/EmailsEnvoyes.jsx
@@ -12,12 +12,12 @@ import { Button } from '@/components/ui/button';
 import PaginationFooter from '@/components/ui/PaginationFooter';
 import { Badge } from '@/components/ui/badge';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { pdf } from '@react-pdf/renderer';
 import CommandePDF from '@/components/pdf/CommandePDF';
 
 import { toast } from 'sonner';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export default function EmailsEnvoyes() {
   const { mama_id, loading: authLoading, role } = useAuth();
@@ -54,13 +54,14 @@ export default function EmailsEnvoyes() {
     await load();
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
     const rows = emails.map((e) => ({
       envoye_le: e.envoye_le,
       email: e.email,
       commande: e.commandes?.reference || e.commande_id,
       statut: e.statut
     }));
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), 'Emails');
     const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });

--- a/src/pages/engineering/MenuEngineering.jsx
+++ b/src/pages/engineering/MenuEngineering.jsx
@@ -8,9 +8,7 @@ import { useMenuEngineering } from '@/hooks/useMenuEngineering';
 import EngineeringFilters from '@/components/engineering/EngineeringFilters';
 import EngineeringChart from '@/components/engineering/EngineeringChart';
 import ImportVentesExcel from '@/components/engineering/ImportVentesExcel';
-import html2canvas from 'html2canvas';
-import JSPDF from 'jspdf';
-import * as XLSX from 'xlsx';import { isTauri } from "@/lib/tauriEnv";
+import { loadHtml2Canvas, loadJsPDF, loadXLSX } from '@/lib/lazy/vendors';import { isTauri } from "@/lib/tauriEnv";
 
 export default function MenuEngineering() {
   const { mama_id, roles = [], loading: authLoading } = useAuth();
@@ -43,7 +41,8 @@ export default function MenuEngineering() {
     toast.success('Import réussi');
   };
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const ws = XLSX.utils.json_to_sheet(rows);
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, 'engineering');
@@ -53,6 +52,8 @@ export default function MenuEngineering() {
   const exportPdf = async () => {
     const el = document.getElementById('chart-container');
     if (!el) return;
+    const html2canvas = await loadHtml2Canvas();
+    const JSPDF = await loadJsPDF();
     const canvas = await html2canvas(el);
     const pdf = new JSPDF();
     const img = canvas.toDataURL('image/png');

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 // src/pages/Fournisseurs.jsx
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
 import { useFournisseurs as useFournisseursData } from '@/hooks/data/useFournisseurs';
 import { useFournisseurs as useFournisseursActions } from '@/hooks/useFournisseurs';
 import { useFournisseurStats } from '@/hooks/useFournisseurStats';
@@ -18,17 +18,7 @@ import { Dialog, DialogContent } from '@/components/ui/SmartDialog';
 import { toast } from 'sonner';
 import useExport from '@/hooks/useExport';
 import { isTauri } from "@/lib/tauriEnv";
-import {
-  ResponsiveContainer,
-  LineChart,
-  Line,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  Legend,
-} from 'recharts';
+const RechartsWrapper = lazy(() => import('@/components/charts/RechartsWrapper'));
 import FournisseurDetail from './FournisseurDetail';
 import FournisseurForm from './FournisseurForm';
 import { PlusCircle, Search } from 'lucide-react';
@@ -265,20 +255,32 @@ export default function Fournisseurs() {
                 Aucune donnée disponible pour le moment
               </div>
             ) : (
-              <ResponsiveContainer width="100%" height={180}>
-                <LineChart data={stats}>
-                  <XAxis dataKey="mois" fontSize={11} />
-                  <YAxis fontSize={11} />
-                  <Tooltip />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="total_achats"
-                    stroke="#bfa14d"
-                    name="Total Achats"
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+              <Suspense
+                fallback={
+                  <div className="min-h-[180px] bg-white/5 rounded-xl flex items-center justify-center text-white/50">
+                    Chargement du graphique…
+                  </div>
+                }
+              >
+                <RechartsWrapper>
+                  {({ ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend }) => (
+                    <ResponsiveContainer width="100%" height={180}>
+                      <LineChart data={stats}>
+                        <XAxis dataKey="mois" fontSize={11} />
+                        <YAxis fontSize={11} />
+                        <Tooltip />
+                        <Legend />
+                        <Line
+                          type="monotone"
+                          dataKey="total_achats"
+                          stroke="#bfa14d"
+                          name="Total Achats"
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )}
+                </RechartsWrapper>
+              </Suspense>
             )}
           </CardContent>
         </Card>
@@ -292,15 +294,27 @@ export default function Fournisseurs() {
                 Aucune donnée disponible pour le moment
               </div>
             ) : (
-              <ResponsiveContainer width="100%" height={180}>
-                <BarChart data={topProducts}>
-                  <XAxis dataKey="nom" fontSize={11} />
-                  <YAxis fontSize={11} />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="total" fill="#0f1c2e" name="Quantité achetée" />
-                </BarChart>
-              </ResponsiveContainer>
+              <Suspense
+                fallback={
+                  <div className="min-h-[180px] bg-white/5 rounded-xl flex items-center justify-center text-white/50">
+                    Chargement du graphique…
+                  </div>
+                }
+              >
+                <RechartsWrapper>
+                  {({ ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend }) => (
+                    <ResponsiveContainer width="100%" height={180}>
+                      <BarChart data={topProducts}>
+                        <XAxis dataKey="nom" fontSize={11} />
+                        <YAxis fontSize={11} />
+                        <Tooltip />
+                        <Legend />
+                        <Bar dataKey="total" fill="#0f1c2e" name="Quantité achetée" />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </RechartsWrapper>
+              </Suspense>
             )}
           </CardContent>
         </Card>

--- a/src/pages/menus/MenuDetail.jsx
+++ b/src/pages/menus/MenuDetail.jsx
@@ -1,13 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { toast } from 'sonner';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export default function MenuDetail({ menu, onClose, onDuplicate }) {
   // Export Excel d'un menu
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet([{
       ...menu,

--- a/src/pages/menus/MenuDuJourDetail.jsx
+++ b/src/pages/menus/MenuDuJourDetail.jsx
@@ -1,12 +1,13 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
 import { toast } from 'sonner';import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 export default function MenuDuJourDetail({ menu, onClose }) {
   // Export Excel du menu du jour
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet([{
       ...menu,

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -9,7 +9,7 @@ import MenuDetail from './MenuDetail.jsx';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { saveAs } from 'file-saver';
-import * as XLSX from 'xlsx';
+import { loadXLSX } from '@/lib/lazy/vendors';
 import { motion as Motion } from 'framer-motion';
 import ListingContainer from '@/components/ui/ListingContainer';
 import PaginationFooter from '@/components/ui/PaginationFooter';
@@ -84,7 +84,8 @@ export default function Menus() {
     return <LoadingSpinner message="Chargement..." />;
   }
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(
       menus.map((m) => ({

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -1,13 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, lazy, Suspense } from 'react';
 import { useProducts } from '@/hooks/useProducts';
 import ProduitFormModal from '@/components/produits/ProduitFormModal';
 import GlassCard from '@/components/ui/GlassCard';
 import { LiquidBackground } from '@/components/LiquidBackground';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { buildPriceData } from '@/components/produits/priceHelpers';import { isTauri } from "@/lib/tauriEnv";
+
+const RechartsWrapper = lazy(() => import('@/components/charts/RechartsWrapper'));
 
 export default function ProduitDetailPage() {
   const { id } = useParams();
@@ -177,21 +178,27 @@ export default function ProduitDetailPage() {
             </table>
           </>
         }
-        {chartData.length > 0 &&
+        {chartData.length > 0 && (
         <div className="mt-6">
-            <ResponsiveContainer width="100%" height={200}>
-              <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-                <XAxis dataKey="date" fontSize={11} />
-                <YAxis fontSize={11} />
-                <Tooltip />
-                <Legend />
-                {Object.keys(chartData[0]).filter((k) => k !== 'date').map((key) =>
-              <Line key={key} type="monotone" dataKey={key} stroke="#bfa14d" />
-              )}
-              </LineChart>
-            </ResponsiveContainer>
+            <Suspense fallback={null}>
+              <RechartsWrapper>
+                {({ ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend }) => (
+                  <ResponsiveContainer width="100%" height={200}>
+                    <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                      <XAxis dataKey="date" fontSize={11} />
+                      <YAxis fontSize={11} />
+                      <Tooltip />
+                      <Legend />
+                      {Object.keys(chartData[0]).filter((k) => k !== 'date').map((key) => (
+                        <Line key={key} type="monotone" dataKey={key} stroke="#bfa14d" />
+                      ))}
+                    </LineChart>
+                  </ResponsiveContainer>
+                )}
+              </RechartsWrapper>
+            </Suspense>
           </div>
-        }
+        )}
       </GlassCard>
       <ProduitFormModal
         open={showForm}

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -7,12 +7,10 @@ import { useRequisitions } from '@/hooks/useRequisitions';
 import { useProducts } from '@/hooks/useProducts';
 import { useUtilisateurs } from '@/hooks/useUtilisateurs';
 import { toast } from 'sonner';
-import * as XLSX from 'xlsx';
-import JSPDF from 'jspdf';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import 'jspdf-autotable';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';import { isTauri } from "@/lib/tauriEnv";
+import { loadJsPDF, loadXLSX } from '@/lib/lazy/vendors';
 
 export default function Requisitions() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -70,7 +68,8 @@ export default function Requisitions() {
   const filtered = requisitions;
 
   // Export Excel
-  const handleExportExcel = () => {
+  const handleExportExcel = async () => {
+    const XLSX = await loadXLSX();
     const ws = XLSX.utils.json_to_sheet(
       filtered.map((r) => ({
         Numero: r.id,
@@ -86,7 +85,8 @@ export default function Requisitions() {
   };
 
   // Export PDF
-  const handleExportPDF = () => {
+  const handleExportPDF = async () => {
+    const JSPDF = await loadJsPDF();
     const doc = new JSPDF();
     doc.text('Historique Réquisitions', 10, 12);
     doc.autoTable({

--- a/src/pages/stats/StatsConsolidation.jsx
+++ b/src/pages/stats/StatsConsolidation.jsx
@@ -5,13 +5,14 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export default function StatsConsolidation() {
   const { stats, loading, error, fetchStats } = useConsolidatedStats();
   const { isAuthenticated, loading: authLoading } = useAuth();
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(stats), "Stats");
     XLSX.writeFile(wb, "consolidation_stats.xlsx");

--- a/src/pages/stats/StatsCostCenters.jsx
+++ b/src/pages/stats/StatsCostCenters.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export default function StatsCostCenters() {
   const { fetchStats } = useCostCenterStats();
@@ -13,7 +13,8 @@ export default function StatsCostCenters() {
   const [stats, setStats] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(stats);
     XLSX.utils.book_append_sheet(wb, ws, 'Stats');

--- a/src/pages/stats/StatsCostCentersPivot.jsx
+++ b/src/pages/stats/StatsCostCentersPivot.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export default function StatsCostCentersPivot() {
   const { fetchMonthly } = useCostCenterMonthlyStats();
@@ -13,12 +13,13 @@ export default function StatsCostCentersPivot() {
   const [rows, setRows] = useState([]);
   const [months, setMonths] = useState([]);
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
     const data = rows.map((r) => {
       const obj = { nom: r.nom };
       months.forEach((m) => {obj[m] = r[m] || 0;});
       return obj;
     });
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(data), 'Stats');
     XLSX.writeFile(wb, 'cost_center_monthly.xlsx');

--- a/src/pages/stats/StatsStock.jsx
+++ b/src/pages/stats/StatsStock.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import * as XLSX from "xlsx";import { isTauri } from "@/lib/tauriEnv";
+import { loadXLSX } from "@/lib/lazy/vendors";import { isTauri } from "@/lib/tauriEnv";
 
 export default function StatsStock() {
   const { stats, loading, error, fetchStats } = useDashboardStats({ pageSize: 1000 });
@@ -23,7 +23,8 @@ export default function StatsStock() {
     setRows(arr);
   }, [stats]);
 
-  const exportExcel = () => {
+  const exportExcel = async () => {
+    const XLSX = await loadXLSX();
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Stocks");
     XLSX.writeFile(wb, "stocks_dashboard.xlsx");

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -1,6 +1,6 @@
 import { query } from '@/local/db';
-import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 
 // Colonnes exportées avec libellés lisibles
@@ -59,6 +59,7 @@ export async function exportExcelProduits(mama_id) {
     seuil_min: p.seuil_min ?? 0
   }));
 
+  const XLSX = await loadXLSX();
   const wb = XLSX.utils.book_new();
   const ws = XLSX.utils.json_to_sheet(rows, {
     header: EXPORT_HEADERS.map((h) => h.key)
@@ -74,8 +75,9 @@ export async function exportExcelProduits(mama_id) {
   saveAs(new Blob([buf]), "produits_export_mamastock.xlsx");
 }
 
-export function downloadProduitsTemplate() {
+export async function downloadProduitsTemplate() {
   const example = Object.fromEntries(TEMPLATE_HEADERS.map((h) => [h, ""]));
+  const XLSX = await loadXLSX();
   const wb = XLSX.utils.book_new();
   const ws = XLSX.utils.json_to_sheet([example], { header: TEMPLATE_HEADERS });
   XLSX.utils.book_append_sheet(wb, ws, "Template");

--- a/src/utils/importExcelProduits.js
+++ b/src/utils/importExcelProduits.js
@@ -1,6 +1,6 @@
 import { query, getDb } from '@/local/db';
-import * as XLSX from "xlsx";
 import { v4 as uuidv4 } from "uuid";
+import { loadXLSX } from "@/lib/lazy/vendors";
 
 import { fetchFamillesForValidation } from "@/hooks/useFamilles";
 import { listUnitesForValidation } from "@/hooks/useUnites";
@@ -49,6 +49,7 @@ export function validateProduitRow(row, maps) {
 
 export async function parseProduitsFile(file, mama_id) {
   const data = await file.arrayBuffer();
+  const XLSX = await loadXLSX();
   const workbook = XLSX.read(data, { type: "array" });
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
   const raw = XLSX.utils.sheet_to_json(sheet, { defval: "" });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, splitVendorChunkPlugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
 import { VitePWA as pwa } from "vite-plugin-pwa";
@@ -9,6 +9,7 @@ const isTauri =
 export default defineConfig(({ mode }) => {
   const plugins = [
     react(),
+    splitVendorChunkPlugin(),
     !isTauri &&
       pwa({
         registerType: "autoUpdate",


### PR DESCRIPTION
## Summary
- defer loading heavy libraries like XLSX, jsPDF and html2canvas through a shared lazy vendor loader and update consumers to await imports on demand
- introduce a reusable RechartsWrapper component and refactor chart screens to render through React.lazy + Suspense, keeping routes/components split-friendly
- enable Vite's vendor chunk splitting and add new lazy modules for export utilities and chart rendering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ca57d0af20832db746ad3e96c748bf