### PR TITLE
Add Neon PostgreSQL support with configurable database

### DIFF
--- a/migrations/postgres/0001_init.sql
+++ b/migrations/postgres/0001_init.sql
@@ -1,0 +1,16 @@
+-- migrations/postgres/0001_init.sql
+-- Exemple basique : tables "produits" et "fournisseurs". Adapte selon ton schéma réel.
+CREATE TABLE IF NOT EXISTS produits (
+  id BIGSERIAL PRIMARY KEY,
+  code TEXT UNIQUE NOT NULL,
+  libelle TEXT NOT NULL,
+  prix NUMERIC(12,2) NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS fournisseurs (
+  id BIGSERIAL PRIMARY KEY,
+  nom TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 tauri-plugin-log = "2"
 tauri-plugin-devtools = "2"
-tauri-plugin-sql = { version = "2.3", features = ["sqlite"] }
+tauri-plugin-sql = { version = "2.3", features = ["sqlite", "postgres"] }
 log = "0.4"
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default permissions",
+  "platforms": ["windows"],
+  "permissions": [
+    "fs:allow-read-text-file",
+    "fs:allow-write-text-file",
+    "fs:allow-read-dir",
+    "fs:allow-create-dir",
+    "fs:allow-exists",
+    "sql:allow"
+  ],
+  "fs": {
+    "scope": [
+      "C:/ProgramData/MAMASTOCK/**",
+      "$RESOURCE/migrations/**"
+    ]
+  }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
   "bundle": {
     "active": true,
     "targets": ["nsis", "msi"],
+    "resources": ["../migrations/**"],
     "icon": ["icons/256x256.png", "icons/512x512.png", "icons/icon.ico"],
     "publisher": "Quentin Vanel",
     "windows": {
@@ -61,7 +62,12 @@
   },
   "plugins": {
     "fs": {
-      "scope": ["$APPDATA/**", "$LOCALAPPDATA/**", "$RESOURCE/**"]
+      "scope": [
+        "$APPDATA/**",
+        "$LOCALAPPDATA/**",
+        "$RESOURCE/**",
+        "C:/ProgramData/MAMASTOCK/**"
+      ]
     },
     "shell": {},
     "dialog": {},

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -157,6 +157,12 @@ export default function Sidebar() {
                 </NavLink>
               )}
               <NavLink
+                to="/parametrage/base-de-donnees"
+                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+              >
+                Base de données
+              </NavLink>
+              <NavLink
                 to="/parametrage/comptes-locaux"
                 className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
               >

--- a/src/debug/sqlSelfTest.ts
+++ b/src/debug/sqlSelfTest.ts
@@ -1,4 +1,5 @@
-import { getDb } from "@/lib/db/sql";import { isTauri } from "@/lib/tauriEnv";
+import { loadDb } from "@/lib/db";
+import { isTauri } from "@/lib/tauriEnv";
 
 let done = false;
 export async function runSqlSelfTest() {
@@ -9,14 +10,26 @@ export async function runSqlSelfTest() {
     return;
   }
   try {
-    const db = await getDb();
-    await db.select("SELECT 1 AS ok");
-    console.info("[SQL SelfTest] SELECT ok");
-    await db.execute("CREATE TABLE IF NOT EXISTS _ping (id INTEGER PRIMARY KEY, ts TEXT)");
-    await db.execute("DELETE FROM _ping");
-    await db.execute("INSERT INTO _ping(ts) VALUES (datetime('now'))");
-    const r = await db.select("SELECT COUNT(*) AS c FROM _ping");
-    console.info("[SQL SelfTest] write ok, rows:", r?.[0]?.c ?? 0);
+    const { db, cfg } = await loadDb();
+    if (cfg.database.driver === "postgres") {
+      await db.select("SELECT 1 AS ok");
+      console.info("[SQL SelfTest] SELECT ok (postgres)");
+      await db.execute(
+        "CREATE TABLE IF NOT EXISTS _ping (id BIGSERIAL PRIMARY KEY, ts TIMESTAMPTZ NOT NULL DEFAULT now())"
+      );
+      await db.execute("TRUNCATE TABLE _ping;");
+      await db.execute("INSERT INTO _ping(ts) VALUES (now())");
+      const r = await db.select("SELECT COUNT(*) AS c FROM _ping");
+      console.info("[SQL SelfTest] write ok (postgres), rows:", r?.[0]?.c ?? 0);
+    } else {
+      await db.select("SELECT 1 AS ok");
+      console.info("[SQL SelfTest] SELECT ok (sqlite)");
+      await db.execute("CREATE TABLE IF NOT EXISTS _ping (id INTEGER PRIMARY KEY, ts TEXT)");
+      await db.execute("DELETE FROM _ping");
+      await db.execute("INSERT INTO _ping(ts) VALUES (datetime('now'))");
+      const r = await db.select("SELECT COUNT(*) AS c FROM _ping");
+      console.info("[SQL SelfTest] write ok (sqlite), rows:", r?.[0]?.c ?? 0);
+    }
   } catch (e: any) {
     console.error("[SQL SelfTest] ERROR:", e?.message || e);
   }

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1,0 +1,36 @@
+import { readDir, readTextFile } from "@tauri-apps/plugin-fs";
+
+export async function migratePostgres(db: any) {
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS __migrations (
+      id BIGSERIAL PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+
+  const dir = "migrations/postgres";
+  let entries: Array<{ name?: string }> = [];
+  try {
+    entries = await readDir(dir, { recursive: false });
+  } catch {
+    return;
+  }
+
+  const files = entries
+    .filter((entry) => entry.name?.endsWith(".sql"))
+    .map((entry) => entry.name as string)
+    .sort();
+
+  for (const name of files) {
+    const seen = await db.select("SELECT 1 FROM __migrations WHERE name = $1", [name]);
+    if (seen.length) continue;
+
+    const sql = await readTextFile(`${dir}/${name}`);
+    if (sql.trim()) {
+      await db.execute(sql);
+    }
+
+    await db.execute("INSERT INTO __migrations(name) VALUES ($1)", [name]);
+  }
+}

--- a/src/lib/sql.ts
+++ b/src/lib/sql.ts
@@ -16,3 +16,23 @@ export async function tableCount(table: string): Promise<number> {
   const value = rows?.[0]?.count;
   return typeof value === "number" ? value : 0;
 }
+
+export function insertReturningId(
+  driver: "sqlite" | "postgres",
+  table: string,
+  cols: string[]
+) {
+  const placeholders = cols
+    .map((_, index) => (driver === "postgres" ? `$${index + 1}` : `?`))
+    .join(", ");
+  const colList = cols.map((col) => `"${col}"`).join(", ");
+
+  if (driver === "postgres") {
+    return `INSERT INTO "${table}" (${colList}) VALUES (${placeholders}) RETURNING id;`;
+  }
+
+  return {
+    insert: `INSERT INTO "${table}" (${colList}) VALUES (${placeholders});`,
+    lastId: `SELECT last_insert_rowid() AS id;`
+  };
+}

--- a/src/pages/Settings/Database.tsx
+++ b/src/pages/Settings/Database.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import Database from "@tauri-apps/plugin-sql";
+
+import { readConfig, writeConfig } from "@/lib/db";
+import { isTauri } from "@/lib/tauriEnv";
+
+type Driver = "sqlite" | "postgres";
+
+export default function DatabaseSettings() {
+  const [driver, setDriver] = useState<Driver>("postgres");
+  const [url, setUrl] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const cfg = await readConfig();
+        if (!mounted) return;
+        setDriver(cfg.database.driver);
+        setUrl(cfg.database.url);
+      } catch (error) {
+        console.error("[settings:db] unable to read config", error);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  async function testConnection() {
+    if (!isTauri()) {
+      alert("Test de connexion disponible uniquement dans l'application Tauri.");
+      return;
+    }
+
+    try {
+      const db = await Database.load(url);
+      await db.select(driver === "postgres" ? "SELECT 1" : "SELECT 1");
+      alert("Connexion OK ✅");
+    } catch (error: any) {
+      alert(`Erreur connexion ❌\n${error?.message || error}`);
+    }
+  }
+
+  async function save() {
+    await writeConfig({ database: { driver, url } });
+    alert("Configuration enregistrée.");
+  }
+
+  if (loading) {
+    return <div style={{ padding: "2rem" }}>Chargement…</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: 720, margin: "2rem auto", fontFamily: "sans-serif" }}>
+      <h2>Paramètres — Base de données</h2>
+      <label>Driver</label>
+      <br />
+      <select value={driver} onChange={(event) => setDriver(event.target.value as Driver)}>
+        <option value="postgres">PostgreSQL (Neon)</option>
+        <option value="sqlite">SQLite (local)</option>
+      </select>
+
+      <div style={{ height: 12 }} />
+
+      <label>URL de connexion</label>
+      <br />
+      <input
+        value={url}
+        onChange={(event) => setUrl(event.target.value)}
+        style={{ width: "100%" }}
+        placeholder="postgresql://user:pass@host/db?sslmode=require"
+      />
+
+      <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
+        <button onClick={testConnection}>Tester la connexion</button>
+        <button onClick={save}>Enregistrer</button>
+      </div>
+      <p style={{ marginTop: 8, fontSize: 12, opacity: 0.7 }}>
+        Astuce: Neon requiert <code>sslmode=require</code> (déjà présent).
+      </p>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,11 +7,13 @@ import { routes } from "@/router.autogen";
 
 const FirstRunSetupPage = lazy(() => import("@/pages/setup/FirstRun"));
 const LocalAccountsPage = lazy(() => import("@/pages/parametrage/ComptesLocaux"));
+const DatabaseSettingsPage = lazy(() => import("@/pages/Settings/Database"));
 
 const router = createHashRouter([
   { path: "/setup", element: <FirstRunSetupPage /> },
   // routes autogen
   ...routes,
+  { path: "/parametrage/base-de-donnees", element: <DatabaseSettingsPage /> },
   { path: "/parametrage/comptes-locaux", element: <LocalAccountsPage /> },
   // route par défaut ("/" => /dashboard si présent, sinon première route dispo)
   { path: "/", element: <Navigate to="/dashboard" replace /> },


### PR DESCRIPTION
## Summary
- enable the Tauri SQL plugin for PostgreSQL and allow the Windows ProgramData config path through the app capabilities
- add a shared database loader that seeds a Neon connection by default, runs PostgreSQL migrations, and exposes a helper for cross-driver insert IDs
- bootstrap the database on startup, extend the SQL self-test, and expose a database settings page linked from the Paramétrage menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca829cef54832da045f82e603153a8