### PR TITLE
Add installer config deployment for NSIS and WiX

### DIFF
--- a/src-tauri/installer/config.json
+++ b/src-tauri/installer/config.json
@@ -1,0 +1,3 @@
+{
+  "dbUrl": "postgresql://neondb_owner:npg_bM8mxANEGzd7@ep-falling-field-a9ppe70d-pooler.gwc.azure.neon.tech/neondb?sslmode=require"
+}

--- a/src-tauri/installer/nsis/01_write_config.nsh
+++ b/src-tauri/installer/nsis/01_write_config.nsh
@@ -1,0 +1,11 @@
+!include "FileFunc.nsh"
+!include "LogicLib.nsh"
+
+Function WriteConfigJson
+  StrCpy $0 "$PROGRAMDATA\\MAMASTOCK"
+  IfFileExists "$0\\config.json" +3 0
+    ; le fichier existe déjà → ne pas écraser
+    Return
+  CreateDirectory "$0"
+  CopyFiles /SILENT "$INSTDIR\\resources\\config.json" "$0\\config.json"
+FunctionEnd

--- a/src-tauri/installer/nsis/tauri.nsis
+++ b/src-tauri/installer/nsis/tauri.nsis
@@ -1,4 +1,5 @@
 !include "MUI2.nsh"
+!include "01_write_config.nsh"
 
 !define MUI_ICON "${INSTALLER_ICON}"
 !define MUI_HEADERIMAGE
@@ -48,6 +49,10 @@ Section "Install"
   SetOutPath "$INSTDIR"
   ; Tauri will inject files here
   CreateShortCut "$SMPROGRAMS\\MAMASTOCK.lnk" "$INSTDIR\\MAMASTOCK.exe"
+SectionEnd
+
+Section -Post
+  Call WriteConfigJson
 SectionEnd
 
 Section "Uninstall"

--- a/src-tauri/installer/wix/main.wxs
+++ b/src-tauri/installer/wix/main.wxs
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Product
     Id="*"
     Name="MAMASTOCK"
@@ -45,4 +46,25 @@
 
     <!-- Tauri will generate component and files in a separate fragment -->
   </Product>
+
+  <Fragment>
+    <DirectoryRef Id="ProgramDataFolder">
+      <Directory Id="DIR_MAMASTOCK_PD" Name="MAMASTOCK">
+        <Component Id="CMP_ConfigJson" Guid="*">
+          <File Id="FIL_ConfigJson"
+                Name="config.json"
+                Source="$(var.ProjectDir)src-tauri\installer\config.json"
+                Vital="yes"
+                KeyPath="yes"
+                NeverOverwrite="yes" />
+        </Component>
+      </Directory>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents">
+      <ComponentRef Id="CMP_ConfigJson" />
+    </ComponentGroup>
+  </Fragment>
 </Wix>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
     "active": true,
     "targets": ["nsis", "msi"],
     "icon": ["icons/256x256.png", "icons/512x512.png", "icons/icon.ico"],
+    "resources": ["src-tauri/installer/config.json"],
     "publisher": "Quentin Vanel",
     "windows": {
       "webviewInstallMode": {
@@ -54,6 +55,7 @@
           }
         },
         "template": "src-tauri/installer/wix/main.wxs",
+        "extensions": ["WixUtilExtension"],
         "bannerPath": "src-tauri/installer/wix/banner.bmp",
         "dialogImagePath": "src-tauri/installer/wix/dialog.bmp"
       }


### PR DESCRIPTION
## Summary
- add a bundled config.json containing the production database URL
- ensure the NSIS installer copies config.json into ProgramData without overwriting existing files
- update the WiX template to deploy the config file via ProgramData and register the resource with Tauri

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cab9b2cf0c832db2bdccb1f0ead24d