### PR TITLE
Add PostgreSQL config support

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,8 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 use std::{fs, path::{Path, PathBuf}};
+use tauri_plugin_fs;
+use tauri_plugin_sql;
 
 #[allow(dead_code)]
 #[derive(Serialize)]

--- a/src/lib/config/pg.ts
+++ b/src/lib/config/pg.ts
@@ -1,0 +1,50 @@
+import { exists, readTextFile, writeTextFile, mkdir } from "@tauri-apps/plugin-fs";
+import { localDataDir, join } from "@tauri-apps/api/path";
+
+const DEFAULT_PG_URL = "postgresql://neondb_owner:npg_bM8mxANEGzd7@ep-falling-field-a9ppe70d-pooler.gwc.azure.neon.tech/neondb?sslmode=require&channel_binding=require";
+
+const PROGRAMDATA_CFG = "C:\\ProgramData\\MAMASTOCK\\config.json";
+
+async function readJson(path: string): Promise<any | null> {
+  try {
+    if (!(await exists(path))) return null;
+    const txt = await readTextFile(path);
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+export async function getUserCfgPath(): Promise<string> {
+  const dir = await localDataDir(); // e.g. C:\Users\...\AppData\Local\{org/app}\
+  // On force notre dossier app "MAMASTOCK" pour être stable
+  const base = dir.replace(/\\[^\\]+\\?$/i, ""); // retire le dernier segment si besoin
+  return join(base, "MAMASTOCK", "config.json");
+}
+
+/**
+ * Retourne l'URL PG selon cette priorité :
+ * 1) %ProgramData%\MAMASTOCK\config.json  (administrateur / machine)
+ * 2) %LOCALAPPDATA%\MAMASTOCK\config.json (utilisateur)
+ * 3) DEFAULT_PG_URL (Neon)
+ */
+export async function getPgUrl(): Promise<string> {
+  // 1) ProgramData (machine-wide)
+  const sysCfg = await readJson(PROGRAMDATA_CFG);
+  if (sysCfg?.pgUrl) return String(sysCfg.pgUrl);
+
+  // 2) LocalAppData (utilisateur)
+  const userCfgPath = await getUserCfgPath();
+  const userCfg = await readJson(userCfgPath);
+  if (userCfg?.pgUrl) return String(userCfg.pgUrl);
+
+  // 3) Default (Neon) + auto-crée un user config minimal (optionnel mais pratique)
+  try {
+    const userDir = userCfgPath.replace(/\\config\.json$/i, "");
+    if (!(await exists(userDir))) await mkdir(userDir, { recursive: true });
+    await writeTextFile(userCfgPath, JSON.stringify({ pgUrl: DEFAULT_PG_URL }, null, 2));
+  } catch {
+    // silencieux : si on n'a pas pu écrire, on garde juste le défaut en mémoire
+  }
+  return DEFAULT_PG_URL;
+}

--- a/src/lib/db/postgres.ts
+++ b/src/lib/db/postgres.ts
@@ -1,0 +1,22 @@
+import Database from "@tauri-apps/plugin-sql";
+import { getPgUrl } from "@/lib/config/pg";
+
+let _db: Database | null = null;
+
+export async function openPg(): Promise<Database> {
+  if (_db) return _db;
+  const url = await getPgUrl(); // e.g. postgresql://...
+  _db = await Database.load(url);
+  return _db;
+}
+
+/** Test simple de connectivité (SELECT 1) */
+export async function testPg(): Promise<boolean> {
+  try {
+    const db = await openPg();
+    const rows = await db.select("select 1 as ok");
+    return Array.isArray(rows) && rows.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,7 @@ import { runSqlSelfTest } from "@/debug/sqlSelfTest";
 import { clearWebviewOnDev } from "@/debug/clearWebview";
 import { isTauri } from "@/lib/tauriEnv";
 import { initLog } from "@/tauriLog";
+import { testPg } from "@/lib/db/postgres";
 
 clearWebviewOnDev();
 setupPwaGuard();
@@ -55,6 +56,16 @@ if (import.meta.env.DEV && isTauri()) {
 }
 
 runSqlSelfTest().catch(() => {});
+
+if (isTauri()) {
+  testPg()
+    .then((ok) => {
+      console.log(ok ? "PG OK (Neon)" : "PG KO (voir config)");
+    })
+    .catch(() => {
+      console.log("PG KO (voir config)");
+    });
+}
 
 if (
   typeof window !== "undefined" &&


### PR DESCRIPTION
## Summary
- add a Tauri-side PostgreSQL configuration helper that loads machine/user overrides with a Neon fallback and self-heals the user file
- expose a shared Postgres database opener plus connectivity probe for the SQL plugin
- trigger a startup connectivity check in the web entrypoint and ensure the fs/sql plugins are explicitly imported on the Rust side

## Testing
- npm run check:tauri-plugins
- cargo check *(fails: missing system glib-2.0 when building glib-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68cac49943e4832da025d039860c9342