### PR TITLE
Update WiX per-user installer configuration

### DIFF
--- a/src-tauri/installer/wix/main.wxs
+++ b/src-tauri/installer/wix/main.wxs
@@ -1,20 +1,31 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="MAMASTOCK" Language="1033" Version="0.1.0" Manufacturer="MAMASTOCK" UpgradeCode="{a2cdad1f-49f8-4199-bfb7-50edc246bfe6}">
-    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
-    <MediaTemplate />
-    <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+  <Product Id="*" Name="MAMASTOCK" Language="1033" Version="0.1.0"
+           Manufacturer="MAMASTOCK"
+           UpgradeCode="{<STABLE_UPGRADE_CODE_GUID>}">
 
+    <!-- Per-user, pas d'UAC -->
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" InstallPrivileges="limited"/>
+    <MediaTemplate />
+    <MajorUpgrade Schedule="afterInstallInitialize"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed."/>
+
+    <!-- UI & styles standards + notre UI additive -->
+    <UIRef Id="WixUI_Common"/>
+    <UIRef Id="WixUI_InstallDir"/>
+    <UIRef Id="WixUI_CustomWelcomeExit_MAMA"/>
+
+    <!-- Propriétés & variable d'image -->
     <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
     <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
-    <UIRef Id="WixUI_CustomWelcomeExit_MAMA" />
 
+    <!-- Dossiers per-user -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="LocalAppDataFolder">
         <Directory Id="INSTALLDIR" Name="MAMASTOCK">
-          <Component Id="MainExecutable" Guid="*">
-            <File Id="AppExe" Name="mamastock.exe" Source="C:\Users\dark_\Desktop\mamastock.com\MAMASTOCK-LOCAL\src-tauri\target\release\mamastock.exe" KeyPath="yes" />
+          <Component Id="MainExecutable" Guid="*" Win64="no">
+            <File Id="AppExe" Name="<EXE_NAME>" Source="<EXE_FULL_PATH>" KeyPath="yes" />
           </Component>
         </Directory>
       </Directory>

--- a/src-tauri/installer/wix/ui-custom.wxs
+++ b/src-tauri/installer/wix/ui-custom.wxs
@@ -1,12 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-
-  <!-- UI "additive" qui fournit 2 dialogs perso et les branche sur l'UI standard -->
   <Fragment>
     <UI Id="WixUI_CustomWelcomeExit_MAMA">
-
-      <!-- On garde tout le standard via WixUI_Common + DialogRef standards -->
-      <UIRef Id="WixUI_Common"/>
+      <!-- On s'appuie sur les dialogs standards (évite duplicates & manques) -->
       <DialogRef Id="BrowseDlg"/>
       <DialogRef Id="DiskCostDlg"/>
       <DialogRef Id="ErrorDlg"/>
@@ -20,7 +16,7 @@
       <DialogRef Id="InstallDirDlg"/>
       <DialogRef Id="VerifyReadyDlg"/>
 
-      <!-- Nos 2 écrans (fond = WixUIDialogBmp -> dialog.bmp) -->
+      <!-- Ecrans personnalisés avec IDs uniques -->
       <Dialog Id="WelcomeDlg_MAMA" Width="493" Height="312" Title="[ProductName] Setup" NoMinimize="yes">
         <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="493" Height="312" TabSkip="yes" Text="WixUI_Bmp_Dialog"/>
         <Control Id="Title" Type="Text" X="40" Y="150" Width="413" Height="30"
@@ -49,24 +45,19 @@
         <Control Id="Cancel" Type="PushButton" X="225" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUICancel)"/>
       </Dialog>
 
-      <!-- Branchement: Welcome -> InstallDir -> VerifyReady -> (Install) -> Exit -->
-      <Publish Dialog="InstallDirDlg"  Control="Back" Event="NewDialog"     Value="WelcomeDlg_MAMA">1</Publish>
-      <Publish Dialog="InstallDirDlg"  Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]">1</Publish>
-      <Publish Dialog="InstallDirDlg"  Control="Next" Event="NewDialog"     Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog"     Value="InstallDirDlg">1</Publish>
-      <Publish Dialog="BrowseDlg"      Control="OK"   Event="DoAction"      Value="WixUIValidatePath">1</Publish>
-      <Publish Dialog="BrowseDlg"      Control="Back" Event="NewDialog"     Value="InstallDirDlg">1</Publish>
-
-<InstallUISequence>
-  <Show Dialog="WelcomeDlg_MAMA" Before="ProgressDlg">NOT Installed</Show>
-  <Show Dialog="ProgressDlg"     Before="ExecuteAction">NOT Installed</Show>
-  <Show Dialog="ExitDlg_MAMA"    OnExit="success" />
-  <Show Dialog="FatalError"      OnExit="error" />
-  <Show Dialog="UserExit"        OnExit="cancel" />
-</InstallUISequence>
-
-
-
+      <!-- Séquences : OK car ProgressDlg vient de WixUI_InstallDir -->
+      <InstallUISequence>
+        <Show Dialog="WelcomeDlg_MAMA" Before="ProgressDlg">NOT Installed</Show>
+        <Show Dialog="ExitDlg_MAMA"   OnExit="success" />
+        <Show Dialog="FatalError"     OnExit="error" />
+        <Show Dialog="UserExit"       OnExit="cancel" />
+      </InstallUISequence>
+      <AdminUISequence>
+        <Show Dialog="WelcomeDlg_MAMA" Before="ProgressDlg">NOT Installed</Show>
+        <Show Dialog="ExitDlg_MAMA"   OnExit="success" />
+        <Show Dialog="FatalError"     OnExit="error" />
+        <Show Dialog="UserExit"       OnExit="cancel" />
+      </AdminUISequence>
     </UI>
   </Fragment>
 </Wix>


### PR DESCRIPTION
## Summary
- switch the WiX installer package to per-user scope with limited privileges and LocalAppData install directory
- retain standard WixUI dialogs while referencing the custom welcome and exit dialog fragment
- simplify the custom dialog fragment to rely on built-in navigation sequences and avoid duplicate control wiring

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5f3de0c4832d893c452392330eee