### PR TITLE
feat: per-user MSI and persistent shell

### DIFF
--- a/Build-UserMSI.ps1
+++ b/Build-UserMSI.ps1
@@ -1,27 +1,42 @@
 param(
-  [string]$ExeFullPath = (Get-ChildItem -Path "$PSScriptRoot\src-tauri\target\release" -Filter *.exe | Where-Object { $_.Name -notmatch 'setup|installer|unins' } | Select-Object -First 1).FullName
+  [string]$WixRoot = "$env:LOCALAPPDATA\tauri\WixTools314"
 )
 
-$repo    = $PSScriptRoot
+$ErrorActionPreference = 'Stop'
+$repo    = (Get-Location).Path
 $assets  = Join-Path $repo 'src-tauri\installer\wix'
-$wixRoot = "$env:LOCALAPPDATA\tauri\WixTools314"
+$mainWxs = Join-Path $assets 'main.wxs'
+$uiFile  = Join-Path $assets 'ui-custom.wxs'
 $wixDir  = Join-Path $repo 'src-tauri\target\release\wix\x64'
-$release = (Resolve-Path "$repo\src-tauri\target\release").Path
+$release = (Resolve-Path '.\src-tauri\target\release').Path
+
+if (!(Test-Path (Join-Path $assets 'dialog.bmp'))) { throw "Missing dialog.bmp in $assets" }
+
+# pick first .exe (excluding obvious installers)
+$exe = Get-ChildItem $release -Filter *.exe | ? { $_.Name -notmatch 'unins|setup|install' } | Select-Object -First 1
+if (-not $exe) { throw "No .exe in $release. Run 'tauri build' first." }
+$exeName = $exe.Name
+$exePath = $exe.FullName
+$upgrade = ([guid]::NewGuid()).Guid  # replace by a stable one once you ship
+
+# inject placeholders
+$text = Get-Content $mainWxs -Raw
+$text = $text.Replace('APP_EXE_NAME', $exeName).Replace('APP_EXE_ABS_PATH', $exePath).Replace('UPGRADE_CODE_GUID', $upgrade)
+Set-Content $mainWxs $text -Encoding UTF8
 
 New-Item -ItemType Directory -Force -Path $wixDir | Out-Null
 Get-ChildItem $wixDir -Include *.wixobj,*.wixpdb -EA SilentlyContinue | Remove-Item -Force -EA SilentlyContinue
-
 $custObj = Join-Path $wixDir 'custom_main.wixobj'
 $uiObj   = Join-Path $wixDir 'ui-custom.wixobj'
 
-& "$wixRoot\candle.exe" -nologo -arch x64 -ext WixUIExtension -ext WixUtilExtension -dExeFullPath="$ExeFullPath" -out $custObj (Resolve-Path "$assets\main.wxs")
-if ($LASTEXITCODE) { throw "Candle failed: main.wxs" }
+& "$WixRoot\candle.exe" -nologo -arch x64 -ext WixUIExtension -ext WixUtilExtension -out $custObj (Resolve-Path $mainWxs)
+if ($LASTEXITCODE) { throw "Candle failed on main.wxs" }
 
-& "$wixRoot\candle.exe" -nologo -arch x64 -ext WixUIExtension -ext WixUtilExtension -out $uiObj (Resolve-Path "$assets\ui-custom.wxs")
-if ($LASTEXITCODE) { throw "Candle failed: ui-custom.wxs" }
+& "$WixRoot\candle.exe" -nologo -arch x64 -ext WixUIExtension -ext WixUtilExtension -out $uiObj (Resolve-Path $uiFile)
+if ($LASTEXITCODE) { throw "Candle failed on ui-custom.wxs" }
 
 $msiOut = Join-Path $release ("bundle\msi\MAMASTOCK_{0}_x64_user.msi" -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
-& "$wixRoot\light.exe" -nologo -v -ext WixUIExtension -ext WixUtilExtension -b "$assets" -out "$msiOut" $custObj $uiObj
-if ($LASTEXITCODE) { throw "Light failed." }
+& "$WixRoot\light.exe" -nologo -v -ext WixUIExtension -ext WixUtilExtension -b "$assets" -out "$msiOut" $custObj $uiObj
+if ($LASTEXITCODE) { throw "Light failed" }
 
-Write-Host "`n✅ MSI per-user -> $msiOut" -ForegroundColor Green
+Write-Host "`nMSI generated -> $msiOut" -ForegroundColor Green

--- a/src-tauri/installer/wix/main.wxs
+++ b/src-tauri/installer/wix/main.wxs
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="MAMASTOCK" Language="1033" Version="0.1.0" Manufacturer="MAMASTOCK" UpgradeCode="{91E8C7A0-1553-461D-BBF8-5E0AE40575E7}">
+  <Product Id="*" Name="MAMASTOCK" Language="1033" Version="0.1.0" Manufacturer="MAMASTOCK" UpgradeCode="{UPGRADE_CODE_GUID}">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perUser" />
     <MediaTemplate />
     <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 
-    <!-- UI -->
-    <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+    <!-- Per-user install -->
+    <Property Id="ALLUSERS" Value="2" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+    <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
     <WixVariable Id="WixUIDialogBmp" Value="dialog.bmp" />
-    <UIRef Id="WixUI_InstallDir" />
+
+    <!-- Use our custom UI that imports WixUI_Common -->
     <UIRef Id="WixUI_CustomWelcomeExit_MAMA" />
 
-    <!-- Dossiers per-user -->
+    <!-- Layout under %LOCALAPPDATA%\MAMASTOCK -->
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="LocalAppDataFolder">
         <Directory Id="INSTALLDIR" Name="MAMASTOCK">
-          <Component Id="MainExecutable" Guid="*" Win64="no">
-            <File Id="AppExe" Source="$(var.ExeFullPath)" KeyPath="yes" />
+          <Component Id="MainExecutable" Guid="*">
+            <File Id="AppExe" Name="APP_EXE_NAME" Source="APP_EXE_ABS_PATH" KeyPath="yes" />
           </Component>
         </Directory>
       </Directory>

--- a/src-tauri/installer/wix/ui-custom.wxs
+++ b/src-tauri/installer/wix/ui-custom.wxs
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
+    <!-- Single UI that reuses WixUI_Common and adds two custom dialogs -->
     <UI Id="WixUI_CustomWelcomeExit_MAMA">
-      <!-- Styles/Dialogs standard -->
+      <!-- bring in all built-in styles, actions and dialogs -->
       <UIRef Id="WixUI_Common"/>
+
+      <!-- standard dialogs used by InstallDir flow -->
       <DialogRef Id="BrowseDlg"/>
       <DialogRef Id="DiskCostDlg"/>
       <DialogRef Id="ErrorDlg"/>
@@ -17,21 +20,20 @@
       <DialogRef Id="InstallDirDlg"/>
       <DialogRef Id="VerifyReadyDlg"/>
 
-      <!-- Welcome custom (fond = WixUIDialogBmp -> dialog.bmp) -->
+      <!-- Custom Welcome and Exit dialogs (use built-in text styles) -->
       <Dialog Id="WelcomeDlg_MAMA" Width="493" Height="312" Title="[ProductName] Setup" NoMinimize="yes">
         <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="493" Height="312" TabSkip="yes" Text="WixUI_Bmp_Dialog"/>
         <Control Id="Title" Type="Text" X="40" Y="150" Width="413" Height="30" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}!(loc.WelcomeDlgTitle)"/>
         <Control Id="Description" Type="Text" X="40" Y="190" Width="413" Height="60" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Normal}!(loc.WelcomeDlgDescription)"/>
-        <Control Id="Next" Type="PushButton" X="393" Y="276" Width="80" Height="17" Default="yes" Text="!(loc.WixUINext)">
+        <Control Id="Next"   Type="PushButton" X="393" Y="276" Width="80" Height="17" Default="yes" Text="!(loc.WixUINext)">
           <Publish Event="NewDialog" Value="InstallDirDlg">1</Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" X="309" Y="276" Width="80" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>
-        <Control Id="Back" Type="PushButton" X="225" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUIBack)"/>
+        <Control Id="Back"   Type="PushButton" X="225" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUIBack)"/>
       </Dialog>
 
-      <!-- Exit custom -->
       <Dialog Id="ExitDlg_MAMA" Width="493" Height="312" Title="[ProductName] Setup" NoMinimize="yes">
         <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="493" Height="312" TabSkip="yes" Text="WixUI_Bmp_Dialog"/>
         <Control Id="Title" Type="Text" X="40" Y="150" Width="413" Height="30" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}!(loc.ExitDialogTitle)"/>
@@ -39,15 +41,17 @@
         <Control Id="Finish" Type="PushButton" X="393" Y="276" Width="80" Height="17" Default="yes" Text="!(loc.WixUIFinish)">
           <Publish Event="EndDialog" Value="Return">1</Publish>
         </Control>
-        <Control Id="Back" Type="PushButton" X="309" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUIBack)"/>
+        <Control Id="Back"   Type="PushButton" X="309" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUIBack)"/>
         <Control Id="Cancel" Type="PushButton" X="225" Y="276" Width="80" Height="17" Disabled="yes" Text="!(loc.WixUICancel)"/>
       </Dialog>
 
-      <!-- Branchement -->
+      <!-- Wiring identical to WixUI_InstallDir, but entry via WelcomeDlg_MAMA -->
       <Publish Dialog="InstallDirDlg"  Control="Back" Event="NewDialog"     Value="WelcomeDlg_MAMA">1</Publish>
       <Publish Dialog="InstallDirDlg"  Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]">1</Publish>
       <Publish Dialog="InstallDirDlg"  Control="Next" Event="NewDialog"     Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog"     Value="InstallDirDlg">1</Publish>
+      <Publish Dialog="BrowseDlg"      Control="OK"   Event="DoAction"      Value="WixUIValidatePath">1</Publish>
+      <Publish Dialog="BrowseDlg"      Control="Back" Event="NewDialog"     Value="InstallDirDlg">1</Publish>
 
       <InstallUISequence>
         <Show Dialog="WelcomeDlg_MAMA" Before="ProgressDlg">NOT Installed</Show>
@@ -55,6 +59,12 @@
         <Show Dialog="FatalError"  OnExit="error" />
         <Show Dialog="UserExit"   OnExit="cancel" />
       </InstallUISequence>
+      <AdminUISequence>
+        <Show Dialog="WelcomeDlg_MAMA" Before="ProgressDlg">NOT Installed</Show>
+        <Show Dialog="ExitDlg_MAMA" OnExit="success" />
+        <Show Dialog="FatalError"  OnExit="error" />
+        <Show Dialog="UserExit"   OnExit="cancel" />
+      </AdminUISequence>
     </UI>
   </Fragment>
 </Wix>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,41 @@
-import { Outlet } from "react-router-dom";
-import Sidebar from "./components/Sidebar";
+import { HashRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
+import Sidebar from "./Sidebar";
+import ProtectedRoute from "./ProtectedRoute";
+import Dashboard from "./pages/Dashboard.jsx";
+import Settings from "./pages/Settings.jsx";
+import NotFound from "./pages/NotFound.jsx";
 
-export default function AppLayout() {
+function Shell() {
   return (
-    <div className="flex h-screen">
-      <aside className="hidden md:flex w-64">
+    <div className="min-h-screen w-full flex">
+      <aside className="hidden md:flex w-64 shrink-0 border-r">
         <Sidebar />
       </aside>
-      <main className="flex-1 overflow-y-auto">
+      <main className="flex-1 min-w-0">
         <Outlet />
       </main>
     </div>
+  );
+}
+
+export default function App() {
+  return (
+    <HashRouter>
+      <Routes>
+        <Route element={<Shell />}>
+          <Route index element={<Navigate to="/dashboard" replace />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route
+            path="settings"
+            element={
+              <ProtectedRoute>
+                <Settings />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Routes>
+    </HashRouter>
   );
 }

--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,0 +1,26 @@
+import useAuth from "./hooks/useAuth";
+
+export default function ProtectedRoute({ children }) {
+  const { loading, user, devFakeAuth } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="p-6 text-sm text-zinc-500">
+        Chargement de votre session...
+      </div>
+    );
+  }
+
+  if (!user && !devFakeAuth) {
+    return (
+      <div className="p-6 space-y-3">
+        <div className="text-lg font-semibold">Connexion requise</div>
+        <p className="text-sm text-zinc-600">
+          Vous devez être connecté pour accéder à cette page.
+        </p>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/src/Sidebar.jsx
+++ b/src/Sidebar.jsx
@@ -1,0 +1,1 @@
+export { default, resolveSidebarState } from "./components/layout/Sidebar.jsx";

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,6 +1,0 @@
-// src/components/ProtectedRoute.jsx
-import { Outlet } from "react-router-dom";import { isTauri } from "@/lib/tauriEnv";
-export default function ProtectedRoute() {
-  // No-op : rend systématiquement les enfants
-  return <Outlet />;
-}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -25,9 +25,6 @@ export default function Sidebar() {
     userData
   });
 
-  if (state.hideBecauseLoading) return null;
-  if (!state.showSidebar) return null;
-
   const rights = access_rights ?? userData?.access_rights ?? {};
   const has = (key) => (devFlags.isDev ? true : hasAccess(key));
   const canAnalyse = devFlags.isDev || has("analyse");
@@ -38,6 +35,158 @@ export default function Sidebar() {
     has("parametrage");
 
   const showDevRibbon = devFlags.isDev || devFakeAuth;
+  const isLoading = state.hideBecauseLoading;
+  const canDisplayNav = state.showSidebar;
+
+  const navigation = (
+    <nav className="flex flex-col gap-2 text-sm">
+      {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
+
+      {(has("fournisseurs") || has("factures")) && (
+        <details open={pathname.startsWith("/fournisseurs") || pathname.startsWith("/factures")}>
+          <summary className="cursor-pointer">Achats</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {has("fournisseurs") && <Link to="/fournisseurs">Fournisseurs</Link>}
+            {has("factures") && <Link to="/factures">Factures</Link>}
+          </div>
+        </details>
+      )}
+
+      {(has("fiches_techniques") || has("menus")) && (
+        <details open={pathname.startsWith("/fiches") || pathname.startsWith("/menus")}>
+          <summary className="cursor-pointer">Cuisine</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {has("fiches_techniques") && <Link to="/fiches">Fiches</Link>}
+            {has("menus") && <Link to="/menus">Menus</Link>}
+            {has("menu_du_jour") && <Link to="/menu">Menu du jour</Link>}
+          </div>
+        </details>
+      )}
+
+      {(has("produits") || has("inventaires")) && (
+        <details open={pathname.startsWith("/produits") || pathname.startsWith("/inventaire")}>
+          <summary className="cursor-pointer">Stock</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {has("produits") && <Link to="/produits">Produits</Link>}
+            {has("inventaires") && <Link to="/inventaire">Inventaire</Link>}
+          </div>
+        </details>
+      )}
+
+      {(has("alertes") || has("promotions")) && (
+        <details open={pathname.startsWith("/alertes") || pathname.startsWith("/promotions")}>
+          <summary className="cursor-pointer">Alertes / Promotions</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {has("alertes") && <Link to="/alertes">Alertes</Link>}
+            {has("promotions") && <Link to="/promotions">Promotions</Link>}
+          </div>
+        </details>
+      )}
+
+      {(has("documents") || canAnalyse || has("menu_engineering")) && (
+        <details
+          open={
+            pathname.startsWith("/documents") ||
+            pathname.startsWith("/analyse") ||
+            pathname.startsWith("/engineering") ||
+            pathname.startsWith("/menu-engineering")
+          }
+        >
+          <summary className="cursor-pointer">Documents / Analyse</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {has("documents") && <Link to="/documents">Documents</Link>}
+            {canAnalyse && <Link to="/analyse">Analyse</Link>}
+            {has("menu_engineering") && <Link to="/menu-engineering">Menu Engineering</Link>}
+            {canAnalyse && <Link to="/engineering">Engineering</Link>}
+            {has("costing_carte") && <Link to="/costing/carte">Costing Carte</Link>}
+          </div>
+        </details>
+      )}
+
+      {has("notifications") && <Link to="/notifications">Notifications</Link>}
+
+      {(canConfigure || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
+        <details open={pathname.startsWith("/parametrage")}>
+          <summary className="cursor-pointer">Paramétrage</summary>
+          <div className="ml-4 flex flex-col gap-1 mt-1">
+            {canConfigure && (
+              <NavLink
+                to="/parametrage/familles"
+                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+              >
+                Familles
+              </NavLink>
+            )}
+            {canConfigure && (
+              <NavLink
+                to="/parametrage/sousfamilles"
+                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+              >
+                Sous-familles
+              </NavLink>
+            )}
+            {canConfigure && (
+              <NavLink
+                to="/parametrage/unites"
+                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+              >
+                Unités
+              </NavLink>
+            )}
+            {canConfigure && (
+              <NavLink
+                to="/dossierdonnees"
+                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+              >
+                Dossier données
+              </NavLink>
+            )}
+            <NavLink
+              to="/parametrage/comptes-locaux"
+              className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
+            >
+              Comptes locaux
+            </NavLink>
+            {has("utilisateurs") && <Link to="/parametrage/utilisateurs">Utilisateurs</Link>}
+            {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
+            {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}
+            {has("permissions") && <Link to="/parametrage/permissions">Permissions</Link>}
+            {has("access") && <Link to="/parametrage/access">Accès</Link>}
+          </div>
+        </details>
+      )}
+      <NavLink
+        to="/debug/authdebug"
+        className={({ isActive }) => `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`}
+      >
+        Debug Auth
+      </NavLink>
+    </nav>
+  );
+
+  const loadingState = (
+    <div className="mt-8 text-sm text-white/80">Chargement de vos accès…</div>
+  );
+
+  const signedOutState = (
+    <div className="mt-8 space-y-3 text-sm text-white/80">
+      <p className="leading-relaxed">
+        Connectez-vous pour accéder aux modules MamaStock.
+      </p>
+      <Link
+        to="/login"
+        className="inline-flex items-center justify-center rounded-md bg-mamastockGold px-3 py-1.5 text-xs font-semibold text-zinc-900"
+      >
+        Se connecter
+      </Link>
+    </div>
+  );
+
+  const footer = (
+    <div className="mt-6 text-xs text-white/60">
+      {userData?.email ? `Connecté en tant que ${userData.email}` : "Accès invité"}
+    </div>
+  );
 
   return (
     <aside className="relative w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
@@ -54,129 +203,14 @@ export default function Sidebar() {
         </div>
       )}
 
-      <nav className="flex flex-col gap-2 text-sm">
-        {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
-
-        {(has("fournisseurs") || has("factures")) && (
-          <details open={pathname.startsWith("/fournisseurs") || pathname.startsWith("/factures")}>
-            <summary className="cursor-pointer">Achats</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("fournisseurs") && <Link to="/fournisseurs">Fournisseurs</Link>}
-              {has("factures") && <Link to="/factures">Factures</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("fiches_techniques") || has("menus")) && (
-          <details open={pathname.startsWith("/fiches") || pathname.startsWith("/menus")}>
-            <summary className="cursor-pointer">Cuisine</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("fiches_techniques") && <Link to="/fiches">Fiches</Link>}
-              {has("menus") && <Link to="/menus">Menus</Link>}
-              {has("menu_du_jour") && <Link to="/menu">Menu du jour</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("produits") || has("inventaires")) && (
-          <details open={pathname.startsWith("/produits") || pathname.startsWith("/inventaire")}>
-            <summary className="cursor-pointer">Stock</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("produits") && <Link to="/produits">Produits</Link>}
-              {has("inventaires") && <Link to="/inventaire">Inventaire</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("alertes") || has("promotions")) && (
-          <details open={pathname.startsWith("/alertes") || pathname.startsWith("/promotions")}>
-            <summary className="cursor-pointer">Alertes / Promotions</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("alertes") && <Link to="/alertes">Alertes</Link>}
-              {has("promotions") && <Link to="/promotions">Promotions</Link>}
-            </div>
-          </details>
-        )}
-
-        {(has("documents") || canAnalyse || has("menu_engineering")) && (
-          <details
-            open={
-              pathname.startsWith("/documents") ||
-              pathname.startsWith("/analyse") ||
-              pathname.startsWith("/engineering") ||
-              pathname.startsWith("/menu-engineering")
-            }
-          >
-            <summary className="cursor-pointer">Documents / Analyse</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {has("documents") && <Link to="/documents">Documents</Link>}
-              {canAnalyse && <Link to="/analyse">Analyse</Link>}
-              {has("menu_engineering") && <Link to="/menu-engineering">Menu Engineering</Link>}
-              {canAnalyse && <Link to="/engineering">Engineering</Link>}
-              {has("costing_carte") && <Link to="/costing/carte">Costing Carte</Link>}
-            </div>
-          </details>
-        )}
-
-        {has("notifications") && <Link to="/notifications">Notifications</Link>}
-
-        {(canConfigure || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
-          <details open={pathname.startsWith("/parametrage")}>
-            <summary className="cursor-pointer">Paramétrage</summary>
-            <div className="ml-4 flex flex-col gap-1 mt-1">
-              {canConfigure && (
-                <NavLink
-                  to="/parametrage/familles"
-                  className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-                >
-                  Familles
-                </NavLink>
-              )}
-              {canConfigure && (
-                <NavLink
-                  to="/parametrage/sousfamilles"
-                  className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-                >
-                  Sous-familles
-                </NavLink>
-              )}
-              {canConfigure && (
-                <NavLink
-                  to="/parametrage/unites"
-                  className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-                >
-                  Unités
-                </NavLink>
-              )}
-              {canConfigure && (
-                <NavLink
-                  to="/dossierdonnees"
-                  className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-                >
-                  Dossier données
-                </NavLink>
-              )}
-              <NavLink
-                to="/parametrage/comptes-locaux"
-                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-              >
-                Comptes locaux
-              </NavLink>
-              {has("utilisateurs") && <Link to="/parametrage/utilisateurs">Utilisateurs</Link>}
-              {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
-              {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}
-              {has("permissions") && <Link to="/parametrage/permissions">Permissions</Link>}
-              {has("access") && <Link to="/parametrage/access">Accès</Link>}
-            </div>
-          </details>
-        )}
-        <NavLink
-          to="/debug/authdebug"
-          className={({ isActive }) => `text-xs opacity-50 mt-4 ${isActive ? "text-mamastockGold" : ""}`}
-        >
-          Debug Auth
-        </NavLink>
-      </nav>
+      {isLoading ? loadingState : canDisplayNav ? (
+        <>
+          {navigation}
+          {footer}
+        </>
+      ) : (
+        signedOutState
+      )}
     </aside>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,24 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter, Routes, Route, Navigate } from "react-router-dom";
-import AppLayout from "./App.jsx";
-import Dashboard from "./pages/Dashboard.jsx";
-import Settings from "./pages/Settings.jsx";
+import App from "./App.jsx";
 import { AuthProvider } from "./hooks/useAuth";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <AuthProvider>
-      <HashRouter>
-        <Routes>
-          <Route element={<AppLayout />}>
-            <Route index element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<Navigate to="/dashboard" replace />} />
-          </Route>
-        </Routes>
-      </HashRouter>
+      <App />
     </AuthProvider>
   </React.StrictMode>
 );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,21 +1,15 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
-  safelist: [
-    "fixed","md:relative","hidden","md:flex","w-64","md:w-64",
-    "z-50","h-screen","overflow-y-auto","flex","flex-col","space-y-1",
-    "px-2","px-3","py-2","rounded-md","items-center","justify-between","md:justify-start",
-    "bg-gray-900","text-white","text-gray-300","hover:bg-gray-700","hover:text-white",
-    "group","group-hover:text-white","group-hover:bg-gray-700"
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
   ],
-  theme: {
-    extend: {
-      colors: {
-        background: "var(--mamastock-bg)",
-        text: "var(--mamastock-text)",
-      },
-    },
-  },
+  safelist: [
+    "hidden","block","md:hidden","md:block",
+    "w-64","border-r","flex","min-h-screen","flex-1","min-w-0",
+    "opacity-0","opacity-100","translate-x-0","-translate-x-full","md:translate-x-0"
+  ],
+  theme: { extend: {} },
   plugins: [],
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(() => {
   ].filter(Boolean);
 
   return {
-    base: isTauri ? "./" : "/",
+    base: "./",
     plugins,
     resolve: {
       // CODEREVIEW: normalize absolute imports with @/*


### PR DESCRIPTION
## Summary
- replace the Wix authoring with a per-user InstallDir layout under `%LOCALAPPDATA%\MAMASTOCK` and new welcome/exit dialogs
- add a Build-UserMSI.ps1 helper that injects the built EXE then compiles the MSI with candle/light
- rework the React shell to keep the sidebar mounted via HashRouter, update ProtectedRoute, and safelist sidebar classes in Tailwind while forcing a relative Vite base

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf72e6560832d94395fc6076f9670