### PR TITLE
Refactor routing layouts and legal pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,13 +7,20 @@ import Dashboard from "./pages/Dashboard.jsx";
 import Login from "./pages/Login.jsx";
 import NotFound from "./pages/NotFound.jsx";
 import Settings from "./pages/Settings.jsx";
+import LegalLayout from "@/layout/LegalLayout";
+import Cgu from "@/pages/legal/Cgu";
+import Cgv from "@/pages/legal/Cgv";
+import Confidentialite from "@/pages/legal/Confidentialite";
+import Contact from "@/pages/legal/Contact";
+import Licence from "@/pages/legal/Licence";
+import MentionsLegales from "@/pages/legal/MentionsLegales";
+import Rgpd from "@/pages/Rgpd";
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<AppShell />}>
-        <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="login" element={<Login />} />
+      <Route element={<AppShell />}>
+        <Route index element={<Navigate to="dashboard" replace />} />
         <Route
           path="dashboard"
           element={
@@ -26,6 +33,24 @@ export default function App() {
           <Route path="settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<NotFound />} />
+      </Route>
+
+      <Route path="login" element={<Login />} />
+
+      <Route element={<LegalLayout />}>
+        <Route path="legal/cgu" element={<Cgu />} />
+        <Route path="legal/cgv" element={<Cgv />} />
+        <Route
+          path="legal/confidentialite"
+          element={<Confidentialite />}
+        />
+        <Route path="legal/contact" element={<Contact />} />
+        <Route path="legal/licence" element={<Licence />} />
+        <Route
+          path="legal/mentions-legales"
+          element={<MentionsLegales />}
+        />
+        <Route path="rgpd" element={<Rgpd />} />
       </Route>
     </Routes>
   );

--- a/src/layout/AdminLayout.jsx
+++ b/src/layout/AdminLayout.jsx
@@ -1,29 +1,32 @@
-// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { Outlet } from "react-router-dom";
+
 import Sidebar from "@/components/sidebar.autogen";
 import Navbar from "@/layout/Navbar";
 import {
   LiquidBackground,
   WavesBackground,
   MouseLight,
-  TouchLight } from
-"@/components/LiquidBackground";
+  TouchLight
+} from "@/components/LiquidBackground";
 
 /**
  * Layout général pour les pages accessibles aux admins/managers.
  * Inclut la Sidebar à gauche, et la Navbar en haut.
- */import { isTauri } from "@/lib/tauriEnv";
-export default function AdminLayout({ children }) {
+ */
+export default function AdminLayout() {
   return (
-    <div className="relative flex min-h-screen text-white text-shadow overflow-hidden">
+    <div className="relative flex min-h-screen overflow-hidden text-white text-shadow">
       <LiquidBackground showParticles />
       <WavesBackground className="opacity-40" />
       <MouseLight />
       <TouchLight />
       <Sidebar />
-      <div className="flex flex-col flex-1 relative z-10">
+      <div className="relative z-10 flex flex-1 flex-col">
         <Navbar />
-        <main className="flex-1 p-6 overflow-auto">{children}</main>
+        <main className="flex-1 overflow-auto p-6">
+          <Outlet />
+        </main>
       </div>
-    </div>);
-
+    </div>
+  );
 }

--- a/src/layout/AppLayout.jsx
+++ b/src/layout/AppLayout.jsx
@@ -1,6 +1,7 @@
+import { Outlet } from "react-router-dom";
+
 import Sidebar from "@/components/sidebar.autogen";
 import Footer from "@/components/Footer";
-import { Outlet } from "react-router-dom";import { isTauri } from "@/lib/tauriEnv";
 
 export default function AppLayout() {
   return (
@@ -12,6 +13,6 @@ export default function AppLayout() {
         </main>
         <Footer />
       </div>
-    </div>);
-
+    </div>
+  );
 }

--- a/src/layout/LegalLayout.jsx
+++ b/src/layout/LegalLayout.jsx
@@ -1,36 +1,44 @@
 import { useEffect } from "react";
+import { Outlet } from "react-router-dom";
+
 import Footer from "@/components/Footer";
 import {
   LiquidBackground,
   WavesBackground,
   MouseLight,
-  TouchLight } from
-"@/components/LiquidBackground";import { isTauri } from "@/lib/tauriEnv";
+  TouchLight
+} from "@/components/LiquidBackground";
 
-export default function LegalLayout({ title = "", description = "", children }) {
+export function useLegalMeta(title = "", description = "") {
   useEffect(() => {
     if (title) {
       document.title = `${title} - MamaStock`;
     }
     if (description) {
       const meta = document.querySelector('meta[name="description"]');
-      if (meta) meta.setAttribute("content", description);
+      if (meta) {
+        meta.setAttribute("content", description);
+      }
     }
   }, [title, description]);
+}
 
+export default function LegalLayout() {
   const updated = new Date().toLocaleDateString("fr-FR");
 
   return (
-    <div className="relative flex flex-col min-h-screen text-white overflow-hidden">
+    <div className="relative flex min-h-screen flex-col overflow-hidden text-white">
       <LiquidBackground showParticles />
       <WavesBackground className="opacity-40" />
       <MouseLight />
       <TouchLight />
-      <main className="flex-grow flex flex-col items-center px-4 py-16 relative z-10">
-        {children}
-        <p className="mt-4 text-sm opacity-70">Dernière mise à jour : {updated}</p>
+      <main className="relative z-10 flex flex-grow flex-col items-center px-4 py-16">
+        <Outlet />
+        <p className="mt-4 text-sm opacity-70">
+          Dernière mise à jour : {updated}
+        </p>
       </main>
       <Footer />
-    </div>);
-
+    </div>
+  );
 }

--- a/src/layout/ViewerLayout.jsx
+++ b/src/layout/ViewerLayout.jsx
@@ -1,29 +1,30 @@
-// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { Outlet } from "react-router-dom";
+
 import Navbar from "@/layout/Navbar";
 import {
   LiquidBackground,
   WavesBackground,
   MouseLight,
-  TouchLight } from
-"@/components/LiquidBackground";
+  TouchLight
+} from "@/components/LiquidBackground";
 
 /**
  * Layout pour les utilisateurs en lecture seule (viewer).
  * Pas de sidebar, uniquement la navbar + contenu centré.
- */import { isTauri } from "@/lib/tauriEnv";
-export default function ViewerLayout({ children }) {
+ */
+export default function ViewerLayout() {
   return (
-    <div className="relative flex flex-col min-h-screen text-white text-shadow overflow-hidden">
+    <div className="relative flex min-h-screen flex-col overflow-hidden text-white text-shadow">
       <LiquidBackground showParticles />
       <WavesBackground className="opacity-40" />
       <MouseLight />
       <TouchLight />
       <Navbar />
-      <main className="flex-1 px-4 py-6 flex justify-center items-start overflow-y-auto relative z-10">
-        <div className="w-full max-w-5xl bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-md p-6 text-white">
-          {children}
+      <main className="relative z-10 flex flex-1 items-start justify-center overflow-y-auto px-4 py-6">
+        <div className="w-full max-w-5xl rounded-xl border border-white/20 bg-white/10 p-6 text-white shadow-md backdrop-blur-xl">
+          <Outlet />
         </div>
       </main>
-    </div>);
-
+    </div>
+  );
 }

--- a/src/pages/Rgpd.jsx
+++ b/src/pages/Rgpd.jsx
@@ -1,91 +1,99 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link } from "react-router-dom";
 import { motion as Motion } from "framer-motion";
-import GlassCard from "@/components/ui/GlassCard";
-import ExportUserData from "@/pages/parametrage/ExportUserData";
+
 import DeleteAccountButton from "@/components/DeleteAccountButton";
-import LegalLayout from "@/layout/LegalLayout";import { isTauri } from "@/lib/tauriEnv";
+import GlassCard from "@/components/ui/GlassCard";
+import { useLegalMeta } from "@/layout/LegalLayout";
+import ExportUserData from "@/pages/parametrage/ExportUserData";
 
 export default function Rgpd() {
-  return (
-    <LegalLayout title="Données & Confidentialité" description="Informations sur la protection des données personnelles par MamaStock">
-      <Motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="w-full max-w-3xl">
-        
-        <GlassCard className="space-y-6 text-white">
-          <h1 className="text-3xl font-bold text-center">Données &amp; Confidentialité</h1>
-            <Motion.section
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5 }}>
-            
-              <p className="leading-relaxed">
-                MamaStock attache une grande importance à la protection de vos données personnelles.
-              </p>
-            </Motion.section>
-            <Motion.section
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-            className="space-y-2">
-            
-              <h2 className="text-xl font-semibold">Traitement des données</h2>
-              <p>
-                Les données collectées (emails, identifiants, informations de gestion F&amp;B) servent uniquement à
-                faire fonctionner l’application, à améliorer votre expérience et à sécuriser l’accès.
-              </p>
-            </Motion.section>
-            <Motion.section
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.2 }}
-            className="space-y-2">
-            
-              <h2 className="text-xl font-semibold">Confidentialité</h2>
-              <p>
-                Les données ne sont ni vendues, ni partagées à des tiers extérieurs à l’application. Seules les personnes
-                autorisées au sein de votre établissement y ont accès.
-              </p>
-            </Motion.section>
-            <Motion.section
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.3 }}
-            className="space-y-2">
-            
-              <h2 className="text-xl font-semibold">Droits des utilisateurs</h2>
-              <p>
-                À tout moment, vous pouvez demander la consultation, la modification ou la suppression de vos données en
-                contactant votre administrateur ou l’équipe MamaStock.
-              </p>
-              <p>
-                Pour toute question&nbsp;:{' '}
-                <a href="mailto:support@mamastock.com" className="underline text-mamastockGold">support@mamastock.com</a>
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 pt-4">
-                <ExportUserData />
-                <DeleteAccountButton />
-              </div>
-            </Motion.section>
-            <div className="text-center pt-2">
-              <Motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                <Link
-                to="/"
-                className="inline-block px-6 py-2 rounded-xl bg-white/10 border border-white/20 hover:bg-white/20 transition backdrop-blur-xl">
-                
-                  Retour à l’accueil
-                </Link>
-              </Motion.div>
-            </div>
-          </GlassCard>
-        </Motion.div>
-    </LegalLayout>);
+  useLegalMeta(
+    "Données & Confidentialité",
+    "Informations sur la protection des données personnelles par MamaStock"
+  );
 
+  return (
+    <Motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="w-full max-w-3xl"
+    >
+      <GlassCard className="space-y-6 text-white">
+        <h1 className="text-center text-3xl font-bold">
+          Données &amp; Confidentialité
+        </h1>
+        <Motion.section
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          <p className="leading-relaxed">
+            MamaStock attache une grande importance à la protection de vos données personnelles.
+          </p>
+        </Motion.section>
+        <Motion.section
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="space-y-2"
+        >
+          <h2 className="text-xl font-semibold">Traitement des données</h2>
+          <p>
+            Les données collectées (emails, identifiants, informations de gestion F&amp;B) servent uniquement à faire
+            fonctionner l’application, à améliorer votre expérience et à sécuriser l’accès.
+          </p>
+        </Motion.section>
+        <Motion.section
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+          className="space-y-2"
+        >
+          <h2 className="text-xl font-semibold">Confidentialité</h2>
+          <p>
+            Les données ne sont ni vendues, ni partagées à des tiers extérieurs à l’application. Seules les personnes
+            autorisées au sein de votre établissement y ont accès.
+          </p>
+        </Motion.section>
+        <Motion.section
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, delay: 0.3 }}
+          className="space-y-2"
+        >
+          <h2 className="text-xl font-semibold">Droits des utilisateurs</h2>
+          <p>
+            À tout moment, vous pouvez demander la consultation, la modification ou la suppression de vos données en
+            contactant votre administrateur ou l’équipe MamaStock.
+          </p>
+          <p>
+            Pour toute question&nbsp;:{" "}
+            <a href="mailto:support@mamastock.com" className="text-mamastockGold underline">
+              support@mamastock.com
+            </a>
+          </p>
+          <div className="flex flex-col gap-4 pt-4 sm:flex-row">
+            <ExportUserData />
+            <DeleteAccountButton />
+          </div>
+        </Motion.section>
+        <div className="pt-2 text-center">
+          <Motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+            <Link
+              to="/"
+              className="inline-block rounded-xl border border-white/20 bg-white/10 px-6 py-2 transition hover:bg-white/20 backdrop-blur-xl"
+            >
+              Retour à l’accueil
+            </Link>
+          </Motion.div>
+        </div>
+      </GlassCard>
+    </Motion.div>
+  );
 }

--- a/src/pages/legal/Cgu.jsx
+++ b/src/pages/legal/Cgu.jsx
@@ -1,15 +1,20 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useEffect, useState } from 'react';
-import LegalLayout from '@/layout/LegalLayout';import { isTauri } from "@/lib/tauriEnv";
+import { useEffect, useState } from "react";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
 
 export default function Cgu() {
-  const [text, setText] = useState('');
-  useEffect(() => {
-    fetch('/legal/CGU.md').then((r) => r.text()).then(setText);
-  }, []);
-  return (
-    <LegalLayout title="Conditions d'utilisation" description="CGU MamaStock">
-      <div className="p-8 max-w-3xl mx-auto whitespace-pre-wrap">{text}</div>
-    </LegalLayout>);
+  const [text, setText] = useState("");
 
+  useLegalMeta("Conditions d'utilisation", "CGU MamaStock");
+
+  useEffect(() => {
+    fetch("/legal/CGU.md")
+      .then((r) => r.text())
+      .then(setText);
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-3xl whitespace-pre-wrap p-8">{text}</div>
+  );
 }

--- a/src/pages/legal/Cgv.jsx
+++ b/src/pages/legal/Cgv.jsx
@@ -1,15 +1,20 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useEffect, useState } from 'react';
-import LegalLayout from '@/layout/LegalLayout';import { isTauri } from "@/lib/tauriEnv";
+import { useEffect, useState } from "react";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
 
 export default function Cgv() {
-  const [text, setText] = useState('');
-  useEffect(() => {
-    fetch('/legal/CGV.md').then((r) => r.text()).then(setText);
-  }, []);
-  return (
-    <LegalLayout title="Conditions de vente" description="CGV MamaStock">
-      <div className="p-8 max-w-3xl mx-auto whitespace-pre-wrap">{text}</div>
-    </LegalLayout>);
+  const [text, setText] = useState("");
 
+  useLegalMeta("Conditions de vente", "CGV MamaStock");
+
+  useEffect(() => {
+    fetch("/legal/CGV.md")
+      .then((r) => r.text())
+      .then(setText);
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-3xl whitespace-pre-wrap p-8">{text}</div>
+  );
 }

--- a/src/pages/legal/Confidentialite.jsx
+++ b/src/pages/legal/Confidentialite.jsx
@@ -1,11 +1,17 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import LegalLayout from "@/layout/LegalLayout";
-import useMamaSettings from "@/hooks/useMamaSettings";import { isTauri } from "@/lib/tauriEnv";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
+import useMamaSettings from "@/hooks/useMamaSettings";
 
 export default function Confidentialite() {
   const { settings } = useMamaSettings();
   const [text, setText] = useState("");
+
+  useLegalMeta(
+    "Politique de confidentialité",
+    "Politique de confidentialité MamaStock"
+  );
 
   useEffect(() => {
     async function fetchText() {
@@ -20,8 +26,9 @@ export default function Confidentialite() {
   }, [settings?.rgpd_text]);
 
   return (
-    <LegalLayout title="Politique de confidentialité" description="Politique de confidentialité MamaStock">
-      <div className="p-8 max-w-3xl mx-auto prose prose-invert whitespace-pre-wrap" dangerouslySetInnerHTML={{ __html: text }} />
-    </LegalLayout>);
-
+    <div
+      className="prose prose-invert mx-auto max-w-3xl whitespace-pre-wrap p-8"
+      dangerouslySetInnerHTML={{ __html: text }}
+    />
+  );
 }

--- a/src/pages/legal/Contact.jsx
+++ b/src/pages/legal/Contact.jsx
@@ -1,23 +1,28 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link } from "react-router-dom";
-import LegalLayout from "@/layout/LegalLayout";import { isTauri } from "@/lib/tauriEnv";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
 
 export default function Contact() {
+  useLegalMeta("Contact", "Support et assistance MamaStock");
+
   return (
-    <LegalLayout title="Contact" description="Support et assistance MamaStock">
-      <h1 className="text-3xl font-bold mb-4">Nous contacter</h1>
+    <div className="flex flex-col items-center text-center">
+      <h1 className="mb-4 text-3xl font-bold">Nous contacter</h1>
       <p className="mb-6 max-w-xl text-center">
         Pour toute question sur l'application ou l'utilisation de vos données, vous pouvez
         nous écrire à&nbsp;
-        <a href="mailto:contact@mamastock.com" className="underline text-mamastockGold">contact@mamastock.com</a>.
-        Nous répondons généralement sous 48&nbsp;heures ouvrées.
+        <a href="mailto:contact@mamastock.com" className="text-mamastockGold underline">
+          contact@mamastock.com
+        </a>
+        . Nous répondons généralement sous 48&nbsp;heures ouvrées.
       </p>
       <Link
         to="/"
-        className="inline-block px-6 py-2 rounded-xl bg-white/10 backdrop-blur-xl border border-white/20 hover:bg-white/20 transition">
-        
+        className="inline-block rounded-xl border border-white/20 bg-white/10 px-6 py-2 transition hover:bg-white/20 backdrop-blur-xl"
+      >
         Retour à l'accueil
       </Link>
-    </LegalLayout>);
-
+    </div>
+  );
 }

--- a/src/pages/legal/Licence.jsx
+++ b/src/pages/legal/Licence.jsx
@@ -1,27 +1,33 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link } from "react-router-dom";
-import LegalLayout from "@/layout/LegalLayout";import { isTauri } from "@/lib/tauriEnv";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
 
 export default function Licence() {
+  useLegalMeta("Licence", "Informations sur la licence MamaStock");
+
   return (
-    <LegalLayout title="Licence" description="Informations sur la licence MamaStock">
-      <h1 className="text-3xl font-bold mb-4">Licence et abonnement</h1>
+    <div className="flex flex-col items-center text-center">
+      <h1 className="mb-4 text-3xl font-bold">Licence et abonnement</h1>
       <p className="mb-4 max-w-xl text-center">
         MamaStock est proposé sous forme d'abonnement SaaS. Chaque licence donne
         droit à l'utilisation du logiciel pour un établissement identifié.
         Pour connaître nos offres et recevoir un devis personnalisé, contactez-nous
         à&nbsp;
-        <a href="mailto:commercial@mamastock.com" className="underline text-mamastockGold">commercial@mamastock.com</a>.
+        <a href="mailto:commercial@mamastock.com" className="text-mamastockGold underline">
+          commercial@mamastock.com
+        </a>
+        .
       </p>
       <p className="mb-6 max-w-xl text-center">
         Les conditions complètes de vente et de résiliation sont précisées dans les CGV.
       </p>
       <Link
         to="/"
-        className="inline-block px-6 py-2 rounded-xl bg-white/10 backdrop-blur-xl border border-white/20 hover:bg-white/20 transition">
-        
+        className="inline-block rounded-xl border border-white/20 bg-white/10 px-6 py-2 transition hover:bg-white/20 backdrop-blur-xl"
+      >
         Retour à l'accueil
       </Link>
-    </LegalLayout>);
-
+    </div>
+  );
 }

--- a/src/pages/legal/MentionsLegales.jsx
+++ b/src/pages/legal/MentionsLegales.jsx
@@ -1,11 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import LegalLayout from "@/layout/LegalLayout";
-import useMamaSettings from "@/hooks/useMamaSettings";import { isTauri } from "@/lib/tauriEnv";
+
+import { useLegalMeta } from "@/layout/LegalLayout";
+import useMamaSettings from "@/hooks/useMamaSettings";
 
 export default function MentionsLegales() {
   const { settings } = useMamaSettings();
   const [text, setText] = useState("");
+
+  useLegalMeta("Mentions légales", "Informations légales MamaStock");
 
   useEffect(() => {
     async function fetchText() {
@@ -20,8 +23,9 @@ export default function MentionsLegales() {
   }, [settings?.mentions_legales]);
 
   return (
-    <LegalLayout title="Mentions légales" description="Informations légales MamaStock">
-      <div className="p-8 max-w-3xl mx-auto prose prose-invert whitespace-pre-wrap" dangerouslySetInnerHTML={{ __html: text }} />
-    </LegalLayout>);
-
+    <div
+      className="prose prose-invert mx-auto max-w-3xl whitespace-pre-wrap p-8"
+      dangerouslySetInnerHTML={{ __html: text }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- centralize the router tree in `App.jsx` so AppShell and the legal section share a single top-level `<Routes>` configuration
- update the App/Admin/Viewer/Legal layouts to render `<Outlet />`, and expose `useLegalMeta` for legal pages
- convert legal pages to use `useLegalMeta` and rely on their parent layout instead of embedding layout components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd1056a3c0832dbc9d91f53ce7c624