### PR TITLE
Enforce authenticated routing redirects

### DIFF
--- a/src/PrivateOutlet.jsx
+++ b/src/PrivateOutlet.jsx
@@ -1,9 +1,20 @@
-import { Outlet } from "react-router-dom";
+import { useEffect, useMemo } from "react";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 
-import useAuth from "./hooks/useAuth";
+import { buildRedirectHash, setRedirectTo } from "@/auth/redirect";
+import useAuth from "@/hooks/useAuth";
 
 export default function PrivateOutlet() {
   const { status } = useAuth();
+  const location = useLocation();
+  const redirectHash = useMemo(() => buildRedirectHash(location), [location]);
+  const loginPath = `/login?redirectTo=${encodeURIComponent(redirectHash)}`;
+
+  useEffect(() => {
+    if (status !== "authenticated") {
+      setRedirectTo(redirectHash);
+    }
+  }, [redirectHash, status]);
 
   if (status === "loading") {
     return (
@@ -13,14 +24,8 @@ export default function PrivateOutlet() {
     );
   }
 
-  if (status === "signedout") {
-    return (
-      <div className="flex h-full items-center justify-center p-6">
-        <div className="text-center text-base font-medium text-foreground/80">
-          Veuillez vous connecter pour accéder à cette section.
-        </div>
-      </div>
-    );
+  if (status !== "authenticated") {
+    return <Navigate to={loginPath} replace />;
   }
 
   return <Outlet />;

--- a/src/ProtectedRoute.jsx
+++ b/src/ProtectedRoute.jsx
@@ -1,7 +1,20 @@
-import useAuth from "./hooks/useAuth";
+import { useEffect, useMemo } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+import { buildRedirectHash, setRedirectTo } from "@/auth/redirect";
+import useAuth from "@/hooks/useAuth";
 
 export default function ProtectedRoute({ children }) {
   const { status } = useAuth();
+  const location = useLocation();
+  const redirectHash = useMemo(() => buildRedirectHash(location), [location]);
+  const loginPath = `/login?redirectTo=${encodeURIComponent(redirectHash)}`;
+
+  useEffect(() => {
+    if (status !== "authenticated") {
+      setRedirectTo(redirectHash);
+    }
+  }, [redirectHash, status]);
 
   if (status === "loading") {
     return (
@@ -11,14 +24,8 @@ export default function ProtectedRoute({ children }) {
     );
   }
 
-  if (status === "signedout") {
-    return (
-      <div className="flex min-h-[240px] items-center justify-center p-6">
-        <div className="text-center text-base font-medium text-foreground/80">
-          Veuillez vous connecter pour accéder à ce contenu.
-        </div>
-      </div>
-    );
+  if (status !== "authenticated") {
+    return <Navigate to={loginPath} replace />;
   }
 
   return <>{children}</>;

--- a/src/auth/AccessGate.tsx
+++ b/src/auth/AccessGate.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 
 import { useAuth } from "@/context/AuthContext";
-import { devFlags } from "@/lib/devFlags";
 
-// Simple gate : en local, on autorise tout (fini les “Accès refusé”)
 export default function AccessGate({ children }: { children: React.ReactNode }) {
   const { user, access_rights } = useAuth();
-  if (devFlags.isDev) return <>{children}</>;
 
   if (!user && !access_rights) {
     return (

--- a/src/auth/RequireAuth.jsx
+++ b/src/auth/RequireAuth.jsx
@@ -1,20 +1,27 @@
+import { useEffect, useMemo } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 
 import useAuth from "@/hooks/useAuth";
 import Spinner from "@/components/ui/Spinner";
+import { buildRedirectHash, setRedirectTo } from "@/auth/redirect";
 
 export default function RequireAuth({ roles = [] }) {
   const { status, roles: userRoles } = useAuth();
   const location = useLocation();
-  const rawTarget = `${location.pathname}${location.search}` || "/dashboard";
-  const redirectTarget = rawTarget === "/" ? "/dashboard" : rawTarget;
-  const loginPath = `/login?redirectTo=${encodeURIComponent(redirectTarget)}`;
+  const redirectHash = useMemo(() => buildRedirectHash(location), [location]);
+  const loginPath = `/login?redirectTo=${encodeURIComponent(redirectHash)}`;
+
+  useEffect(() => {
+    if (status !== "authenticated") {
+      setRedirectTo(redirectHash);
+    }
+  }, [redirectHash, status]);
 
   if (status === "loading") {
     return <Spinner label="Chargement de votre session…" />;
   }
 
-  if (status !== "authed") {
+  if (status !== "authenticated") {
     return <Navigate to={loginPath} replace />;
   }
 

--- a/src/auth/redirect.ts
+++ b/src/auth/redirect.ts
@@ -1,0 +1,99 @@
+import type { Location } from "react-router-dom";
+
+const REDIRECT_KEY = "redirectTo";
+const DEFAULT_REDIRECT_HASH = "#/dashboard";
+const DEFAULT_REDIRECT_PATH = "/dashboard";
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined" || !window.sessionStorage) {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRedirectHash(input?: string | null): string {
+  if (!input) return DEFAULT_REDIRECT_HASH;
+  let value = String(input).trim();
+  if (!value) return DEFAULT_REDIRECT_HASH;
+
+  if (!value.startsWith("#")) {
+    if (!value.startsWith("/")) {
+      value = `/${value}`;
+    }
+    value = `#${value}`;
+  }
+
+  if (value === "#" || value === "#/") {
+    return DEFAULT_REDIRECT_HASH;
+  }
+
+  if (!value.startsWith("#/")) {
+    const tail = value.slice(1);
+    const normalizedTail = tail.startsWith("/") ? tail : `/${tail}`;
+    value = `#${normalizedTail}`;
+  }
+
+  return value;
+}
+
+export function buildRedirectHash(location?: Location | null): string {
+  if (typeof window !== "undefined") {
+    const currentHash = window.location?.hash;
+    if (typeof currentHash === "string" && currentHash) {
+      return normalizeRedirectHash(currentHash);
+    }
+  }
+
+  if (location) {
+    const path = `${location.pathname ?? ""}${location.search ?? ""}${location.hash ?? ""}`;
+    if (path) {
+      return normalizeRedirectHash(path);
+    }
+  }
+
+  return DEFAULT_REDIRECT_HASH;
+}
+
+export function getRedirectTo(): string | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(REDIRECT_KEY);
+    if (!raw) return null;
+    return normalizeRedirectHash(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function setRedirectTo(target: string | null | undefined): void {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  try {
+    if (!target) {
+      storage.removeItem(REDIRECT_KEY);
+      return;
+    }
+    const normalized = normalizeRedirectHash(target);
+    storage.setItem(REDIRECT_KEY, normalized);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function clearRedirectTo(): void {
+  setRedirectTo(null);
+}
+
+export function redirectHashToPath(hash: string | null | undefined): string {
+  if (!hash) return DEFAULT_REDIRECT_PATH;
+  const normalized = normalizeRedirectHash(hash);
+  const path = normalized.slice(1);
+  return path ? path : DEFAULT_REDIRECT_PATH;
+}
+
+export { DEFAULT_REDIRECT_HASH, DEFAULT_REDIRECT_PATH };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,15 +1,16 @@
 import { AuthProvider, useAuth as useAuthContext } from "@/context/AuthContext";
 
-type AuthStatus = "loading" | "authed" | "signedout";
+type AuthStatus = "loading" | "authenticated" | "unauthenticated";
 type UseAuthReturn = ReturnType<typeof useAuthContext> & { status: AuthStatus };
 
 export function useAuth(): UseAuthReturn {
   const ctx = useAuthContext();
+  const hasUser = Boolean(ctx.user);
   const status: AuthStatus = ctx.loading
     ? "loading"
-    : ctx.user || ctx.devFakeAuth
-      ? "authed"
-      : "signedout";
+    : hasUser
+      ? "authenticated"
+      : "unauthenticated";
 
   const result: UseAuthReturn = { ...ctx, status };
   return result;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,6 +4,12 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { loginLocal, listLocalUsers } from "@/auth/localAccount";
 import "./login.css";
 import LinkPrefetch from "@/components/LinkPrefetch";
+import {
+  clearRedirectTo,
+  getRedirectTo,
+  redirectHashToPath,
+  setRedirectTo
+} from "@/auth/redirect";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -13,6 +19,15 @@ export default function LoginPage() {
   const [password, setPassword] = useState("Admin123!");
   const [error, setError] = useState("");
   const [canCreateAccount, setCanCreateAccount] = useState(false);
+
+  useEffect(() => {
+    const redirectParam = searchParams.get("redirectTo");
+    if (redirectParam) {
+      setRedirectTo(redirectParam);
+    } else {
+      clearRedirectTo();
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     let mounted = true;
@@ -36,9 +51,11 @@ export default function LoginPage() {
     try {
       const user = await loginLocal(email, password);
       await signIn(user);
-      const redirectTo = searchParams.get("redirectTo");
-      const target = redirectTo && redirectTo.startsWith("/") ? redirectTo : "/dashboard";
-      navigate(target, { replace: true });
+      const storedRedirect = getRedirectTo();
+      const redirectParam = storedRedirect ?? searchParams.get("redirectTo");
+      const targetPath = redirectHashToPath(redirectParam);
+      clearRedirectTo();
+      navigate(targetPath, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }

--- a/src/pages/setup/FirstRun.jsx
+++ b/src/pages/setup/FirstRun.jsx
@@ -4,6 +4,7 @@ import { registerLocal, listLocalUsers } from "@/auth/localAccount";
 import { useAuth } from "@/context/AuthContext";
 import '@/pages/login.css';
 import LinkPrefetch from "@/components/LinkPrefetch";
+import { clearRedirectTo, getRedirectTo, redirectHashToPath } from "@/auth/redirect";
 
 export default function FirstRun() {
   const navigate = useNavigate();
@@ -77,7 +78,10 @@ export default function FirstRun() {
     try {
       const user = await registerLocal(normalizedEmail, password, "admin");
       await signIn(user);
-      navigate("/", { replace: true });
+      const storedRedirect = getRedirectTo();
+      const targetPath = redirectHashToPath(storedRedirect);
+      clearRedirectTo();
+      navigate(targetPath, { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);


### PR DESCRIPTION
## Summary
- remove the development auth shortcut by always requiring a stored user before exposing an authenticated status
- centralize redirect handling in sessionStorage and update access gates to send unauthenticated visitors to the login hash with a redirect parameter
- update login and first-run flows to consume the stored redirect target after successful authentication

## Testing
- `npm run build`
- `npx playwright test test/e2e/navigation.spec.ts` *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9baa218c832da1768a1b9ddafc7d