### PR TITLE
feat: use session store for auth persistence

### DIFF
--- a/src/auth/localAccount.ts
+++ b/src/auth/localAccount.ts
@@ -2,6 +2,7 @@ import { appDataDir, join } from "@tauri-apps/api/path";
 
 import { APP_DIR, getAppDir } from "@/lib/paths";
 import { isTauri } from "@/lib/tauriEnv";
+import { writeStoredFirstRun } from "@/lib/auth/sessionState";
 export const USERS_FILE = "users.json";
 
 // Objet valide (méthode + getter) — évite la syntaxe invalide { isTauri() }
@@ -103,7 +104,9 @@ async function writeUsers(list: LocalUser[]) {
 }
 
 export async function listLocalUsers() {
-  return await readUsers();
+  const users = await readUsers();
+  writeStoredFirstRun(users.length === 0);
+  return users;
 }
 
 export async function registerLocal(
@@ -127,6 +130,7 @@ export async function registerLocal(
   };
   users.push(user);
   await writeUsers(users);
+  writeStoredFirstRun(users.length === 0);
   return user;
 }
 
@@ -164,6 +168,7 @@ export async function updateRoleLocal(id: string, role: string) {
   if (!u) throw new Error("Utilisateur introuvable.");
   u.role = role;
   await writeUsers(users);
+  writeStoredFirstRun(users.length === 0);
   return u;
 }
 
@@ -176,4 +181,5 @@ export async function deleteUserLocal(id: string) {
   const users = await readUsers();
   const filtered = users.filter((u) => u.id !== id);
   await writeUsers(filtered);
+  writeStoredFirstRun(filtered.length === 0);
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,11 @@
 import { AuthProvider, useAuth as useAuthContext } from "@/context/AuthContext";
 
 type AuthStatus = "loading" | "authed" | "signedout";
-type UseAuthReturn = ReturnType<typeof useAuthContext> & { status: AuthStatus };
+type BaseAuthContext = ReturnType<typeof useAuthContext>;
+type UseAuthReturn = BaseAuthContext & {
+  status: AuthStatus;
+  login: BaseAuthContext["signIn"];
+};
 
 export function useAuth(): UseAuthReturn {
   const ctx = useAuthContext();
@@ -11,7 +15,7 @@ export function useAuth(): UseAuthReturn {
       ? "authed"
       : "signedout";
 
-  const result: UseAuthReturn = { ...ctx, status };
+  const result: UseAuthReturn = { ...ctx, status, login: ctx.signIn };
   return result;
 }
 

--- a/src/lib/auth/sessionState.ts
+++ b/src/lib/auth/sessionState.ts
@@ -1,0 +1,178 @@
+import { sessionStore } from "@/lib/auth/sessionStore";
+
+export const SESSION_KEYS = {
+  user: "auth.user",
+  token: "auth.token",
+  flags: "auth.session.flags",
+  redirectTo: "redirectTo",
+  firstRun: "firstRun"
+} as const;
+
+export type PersistedUser = {
+  id: string | null;
+  email: string | null;
+  mama_id: string | null;
+  role?: string | null;
+};
+
+export type SessionFlags = Record<string, boolean>;
+
+function normalizeUser(input: unknown): PersistedUser | null {
+  if (!input || typeof input !== "object") return null;
+  const value = input as Partial<PersistedUser>;
+  return {
+    id: value?.id ?? null,
+    email: value?.email ?? null,
+    mama_id: value?.mama_id ?? null,
+    role: value?.role ?? null
+  };
+}
+
+export function readStoredUser(): PersistedUser | null {
+  const raw = sessionStore.get(SESSION_KEYS.user);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return normalizeUser(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredUser(user: PersistedUser | null | undefined): void {
+  if (!user) {
+    sessionStore.remove(SESSION_KEYS.user);
+    return;
+  }
+  const normalized = normalizeUser(user);
+  if (!normalized) {
+    sessionStore.remove(SESSION_KEYS.user);
+    return;
+  }
+  try {
+    sessionStore.set(SESSION_KEYS.user, JSON.stringify(normalized));
+  } catch {
+    sessionStore.remove(SESSION_KEYS.user);
+  }
+}
+
+export function clearStoredUser(): void {
+  sessionStore.remove(SESSION_KEYS.user);
+}
+
+export function readStoredToken(): string | null {
+  const raw = sessionStore.get(SESSION_KEYS.token);
+  if (typeof raw === "string" && raw.trim()) {
+    return raw;
+  }
+  return null;
+}
+
+export function writeStoredToken(token: string | null | undefined): void {
+  if (typeof token === "string" && token.trim()) {
+    sessionStore.set(SESSION_KEYS.token, token);
+    return;
+  }
+  sessionStore.remove(SESSION_KEYS.token);
+}
+
+function normalizeFlags(flags: SessionFlags | null | undefined): SessionFlags {
+  if (!flags || typeof flags !== "object") return {};
+  const result: SessionFlags = {};
+  for (const [key, value] of Object.entries(flags)) {
+    if (!key) continue;
+    result[key] = !!value;
+  }
+  return result;
+}
+
+export function readStoredSessionFlags(): SessionFlags {
+  const raw = sessionStore.get(SESSION_KEYS.flags);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return normalizeFlags(parsed as SessionFlags);
+  } catch {
+    return {};
+  }
+}
+
+export function writeStoredSessionFlags(flags: SessionFlags | null | undefined): void {
+  const normalized = normalizeFlags(flags);
+  if (Object.keys(normalized).length === 0) {
+    sessionStore.remove(SESSION_KEYS.flags);
+    return;
+  }
+  try {
+    sessionStore.set(SESSION_KEYS.flags, JSON.stringify(normalized));
+  } catch {
+    sessionStore.remove(SESSION_KEYS.flags);
+  }
+}
+
+export function normalizeRedirectTarget(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  let trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^[a-z]+:/i.test(trimmed) || trimmed.startsWith("//")) return null;
+  if (trimmed.startsWith("/#/")) {
+    trimmed = trimmed.slice(2);
+  }
+  if (trimmed.startsWith("#/")) {
+    trimmed = trimmed.slice(1);
+  }
+  if (trimmed.startsWith("#")) {
+    trimmed = trimmed.slice(1);
+  }
+  if (trimmed.startsWith("?")) {
+    trimmed = `/${trimmed}`;
+  }
+  if (!trimmed.startsWith("/")) {
+    trimmed = `/${trimmed}`;
+  }
+  if (trimmed.length === 0) return null;
+  return trimmed;
+}
+
+export function readStoredRedirectTo(): string | null {
+  const raw = sessionStore.get(SESSION_KEYS.redirectTo);
+  return normalizeRedirectTarget(raw);
+}
+
+export function writeStoredRedirectTo(value: string | null | undefined): void {
+  const normalized = normalizeRedirectTarget(value);
+  if (!normalized) {
+    sessionStore.remove(SESSION_KEYS.redirectTo);
+    return;
+  }
+  sessionStore.set(SESSION_KEYS.redirectTo, normalized);
+}
+
+export function readStoredFirstRun(): boolean | null {
+  const raw = sessionStore.get(SESSION_KEYS.firstRun);
+  if (raw === null) return null;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no") {
+    return false;
+  }
+  return null;
+}
+
+export function writeStoredFirstRun(value: boolean | null | undefined): void {
+  if (value === undefined || value === null) {
+    sessionStore.remove(SESSION_KEYS.firstRun);
+    return;
+  }
+  sessionStore.set(SESSION_KEYS.firstRun, value ? "1" : "0");
+}
+
+export function clearAuthSessionStorage(): void {
+  sessionStore.remove(SESSION_KEYS.user);
+  sessionStore.remove(SESSION_KEYS.token);
+  sessionStore.remove(SESSION_KEYS.flags);
+  sessionStore.remove(SESSION_KEYS.redirectTo);
+  sessionStore.remove(SESSION_KEYS.firstRun);
+}

--- a/src/lib/auth/sessionStore.ts
+++ b/src/lib/auth/sessionStore.ts
@@ -1,0 +1,71 @@
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem" | "clear">;
+
+const memoryStore = new Map<string, string>();
+
+const memoryStorage: StorageLike = {
+  getItem(key: string): string | null {
+    return memoryStore.has(key) ? memoryStore.get(key)! : null;
+  },
+  setItem(key: string, value: string) {
+    memoryStore.set(key, value);
+  },
+  removeItem(key: string) {
+    memoryStore.delete(key);
+  },
+  clear() {
+    memoryStore.clear();
+  }
+};
+
+function resolveNativeStorage(): StorageLike | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const { sessionStorage } = window;
+    if (!sessionStorage) return null;
+    const testKey = "__mamastock_session_store_test__";
+    sessionStorage.setItem(testKey, "1");
+    sessionStorage.removeItem(testKey);
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+let activeStorage: StorageLike = resolveNativeStorage() ?? memoryStorage;
+
+function runWithStorage<T>(fn: (storage: StorageLike) => T, fallbackValue: T): T {
+  try {
+    return fn(activeStorage);
+  } catch {
+    if (activeStorage !== memoryStorage) {
+      activeStorage = memoryStorage;
+      try {
+        return fn(activeStorage);
+      } catch {}
+    }
+    return fallbackValue;
+  }
+}
+
+export const sessionStore = {
+  get(key: string): string | null {
+    return runWithStorage((storage) => storage.getItem(key), null);
+  },
+  set(key: string, value: string): void {
+    runWithStorage((storage) => {
+      storage.setItem(key, value);
+    }, undefined);
+  },
+  remove(key: string): void {
+    runWithStorage((storage) => {
+      storage.removeItem(key);
+    }, undefined);
+  },
+  clear(): void {
+    runWithStorage((storage) => {
+      storage.clear();
+    }, undefined);
+  }
+};
+
+export default sessionStore;


### PR DESCRIPTION
## Summary
- add a sessionStore wrapper with a memory fallback and helpers for auth-specific keys
- refactor AuthContext/useAuth to persist user, token, session flags, redirect target, and first-run state through the session store
- update local auth flows (localAccount, Login, FirstRun) to rely on the new persistence helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9baef4f4832da6e838e4e6f20c7c