### PR TITLE
Refactor analytics listener to hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
 } from "react-router-dom";
 
 import Spinner from "@/components/ui/Spinner";
+import { useAnalyticsNavigationListener } from "@/services/analytics";
 
 const NAVIGATION_EVENT = "app:navigation-complete";
 
@@ -128,6 +129,7 @@ function useNavigationAnalyticsEvents() {
 export default function App() {
   useScrollAndFocusRestore();
   useNavigationAnalyticsEvents();
+  useAnalyticsNavigationListener();
 
   return (
     <div className="min-h-screen bg-background text-foreground">


### PR DESCRIPTION
## Summary
- move the analytics navigation listener registration into a reusable hook
- call the hook from the root App component so the listener is mounted via React lifecycle
- ensure the listener is cleaned up when React unmounts to avoid leaking global handlers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9bb2b670832db1e973b7d1b1d165