### PR TITLE
Add Accueil link to sidebar navigation

### DIFF
--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -8,6 +8,7 @@ export type NavItem = {
 };
 
 export const SIDEBAR: NavItem[] = [
+  { label: "Accueil", path: "/accueil", icon: "home" },
   { label: "Dashboard", path: "/dashboard", icon: "layout-dashboard" },
   {
     label: "Produits",


### PR DESCRIPTION
## Summary
- add the Accueil navigation entry to the manual sidebar config so HashRouter renders a #/accueil link

## Testing
- npm run lint:node

------
https://chatgpt.com/codex/tasks/task_e_68ce9bb74004832db728dd20432fbb6a