### PR TITLE
Fix Accueil page syntax and add smoke import test

### DIFF
--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -3,25 +3,26 @@ import { motion as Motion } from "framer-motion";
 import logoMamaStock from "@/assets/logo-mamastock.png";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useEffect } from "react";
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from "@/hooks/useAuth";
 import Footer from "@/components/Footer";
 import PreviewBanner from "@/components/ui/PreviewBanner";
 import {
   LiquidBackground,
   WavesBackground,
   MouseLight,
-  TouchLight } from
-"@/components/LiquidBackground";import { isTauri } from "@/lib/tauriEnv";
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function Accueil() {
   const { session, user } = useAuth();
   const navigate = useNavigate();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
-  const previewIntensity = parseFloat(params.get('intensity'));
-  const intensity = params.has('preview') && !Number.isNaN(previewIntensity) ?
-  Math.min(Math.max(previewIntensity, 0.2), 2) :
-  1;
+  const previewIntensity = parseFloat(params.get("intensity") ?? "");
+  const intensity =
+    params.has("preview") && !Number.isNaN(previewIntensity)
+      ? Math.min(Math.max(previewIntensity, 0.2), 2)
+      : 1;
 
   useEffect(() => {
     if (session && user) {
@@ -41,36 +42,37 @@ export default function Accueil() {
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.8 }}
-          className="w-full max-w-md">
-          
+          className="w-full max-w-md"
+        >
           <div className="bg-white/10 border border-white/20 backdrop-blur-lg rounded-3xl shadow-xl p-6 flex flex-col items-center">
             <img
               src={logoMamaStock}
               alt="MamaStock"
-              className="w-24 h-24 mb-4 rounded-xl shadow" />
-            
+              className="w-24 h-24 mb-4 rounded-xl shadow"
+            />
+
             <h1 className="text-2xl sm:text-3xl font-bold text-center mb-2">
-              Simplifiez votre gestion F&amp;B
+              Simplifiez votre gestion F&B
             </h1>
             <p className="text-center mb-6 text-base sm:text-lg text-white/80">
               MamaStock centralise vos fournisseurs, vos produits et vos factures
               pour un suivi des coûts en toute simplicité.
             </p>
-            {!session &&
-            <Link to="/login">
+            {!session && (
+              <Link to="/login">
                 <Motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.98 }}
-                className="px-8 py-3 rounded-xl bg-white/20 text-white font-semibold backdrop-blur-md border border-white/30 shadow transition">
-                
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.98 }}
+                  className="px-8 py-3 rounded-xl bg-white/20 text-white font-semibold backdrop-blur-md border border-white/30 shadow transition"
+                >
                   Se connecter
                 </Motion.button>
               </Link>
-            }
+            )}
           </div>
         </Motion.div>
       </div>
       <Footer />
-    </div>);
-
+    </div>
+  );
 }

--- a/test/smoke-import.test.ts
+++ b/test/smoke-import.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+
+const modules = [
+  "@/auth/authAdapter",
+  "@/auth/sqlAuth",
+  "@/auth/sqliteAuth",
+  "@/db/index",
+  "@/components/Footer.jsx",
+  "@/pages/Accueil.jsx",
+];
+
+describe("smoke imports", () => {
+  for (const mod of modules) {
+    it(`can import ${mod}`, async () => {
+      const imported = await import(mod);
+      expect(imported).toBeTruthy();
+    });
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,6 @@ export default defineConfig({
         new URL("./test/stubs/tauri-dialog.ts", import.meta.url),
       ),
     },
-    extensions: [".js", ".ts", ".tsx"],
+    extensions: [".js", ".ts", ".tsx", ".jsx"],
   },
 });


### PR DESCRIPTION
## Summary
- restore valid imports and JSX on the Accueil page
- add a smoke import vitest to catch broken module syntax
- allow vitest to resolve `.jsx` modules during smoke imports

## Testing
- npx tsc --noEmit
- npx vitest run test/smoke-import.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9bbb5fb8832db3e7ce3829aa01eb