### PR TITLE
Add smoke test for lazy route imports and clean sidebar

### DIFF
--- a/src/components/sidebar.autogen.tsx
+++ b/src/components/sidebar.autogen.tsx
@@ -41,11 +41,6 @@ export default function SidebarAutogen() {
             Alertes
           </NavLink>
         </li>
-        <li key="/taches/alertes">
-          <NavLink to="/taches/alertes" className={({ isActive }) => "block px-3 py-2 rounded hover:bg-muted " + (isActive ? "font-semibold" : "")}>
-            Alertes
-          </NavLink>
-        </li>
         <li key="/stock/alertesrupture">
           <NavLink to="/stock/alertesrupture" className={({ isActive }) => "block px-3 py-2 rounded hover:bg-muted " + (isActive ? "font-semibold" : "")}>
             Alertes Rupture
@@ -208,11 +203,6 @@ export default function SidebarAutogen() {
         </li>
         <li key="/cuisine/menudujour">
           <NavLink to="/cuisine/menudujour" className={({ isActive }) => "block px-3 py-2 rounded hover:bg-muted " + (isActive ? "font-semibold" : "")}>
-            Menu Du Jour
-          </NavLink>
-        </li>
-        <li key="/menu/menudujour">
-          <NavLink to="/menu/menudujour" className={({ isActive }) => "block px-3 py-2 rounded hover:bg-muted " + (isActive ? "font-semibold" : "")}>
             Menu Du Jour
           </NavLink>
         </li>

--- a/test/imports.spec.ts
+++ b/test/imports.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("lazy routes", () => {
+  it("imports every lazy route module", async () => {
+    const currentFilePath = fileURLToPath(import.meta.url);
+    const routerPath = path.resolve(
+      path.dirname(currentFilePath),
+      "../src/router.autogen.tsx",
+    );
+    const routerSource = await readFile(routerPath, "utf-8");
+    const importMatcher = /import\([^)]*?"([^"\\]+)"\)/g;
+
+    const modules = new Set<string>();
+    for (const match of routerSource.matchAll(importMatcher)) {
+      modules.add(match[1]);
+    }
+
+    expect(modules.size).toBeGreaterThan(0);
+
+    const errors: Array<{ moduleId: string; error: unknown }> = [];
+    for (const moduleId of modules) {
+      try {
+        await import(moduleId);
+      } catch (error) {
+        errors.push({ moduleId, error });
+      }
+    }
+
+    if (errors.length > 0) {
+      const formatted = errors
+        .map(({ moduleId, error }) => {
+          const message =
+            error instanceof Error
+              ? error.stack ?? error.message
+              : String(error);
+          return `${moduleId}: ${message}`;
+        })
+        .join("\n\n");
+
+      throw new Error(`Failed to import ${errors.length} module(s):\n${formatted}`);
+    }
+  }, 120_000);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,6 @@ export default defineConfig({
         new URL("./test/stubs/tauri-dialog.ts", import.meta.url),
       ),
     },
-    extensions: [".js", ".ts", ".tsx"],
+    extensions: [".js", ".ts", ".tsx", ".jsx"],
   },
 });


### PR DESCRIPTION
## Summary
- add a Vitest smoke test that parses the generated lazy router and dynamically imports every page module
- update Vitest resolver settings so .jsx page modules resolve during the smoke test
- remove duplicate "Alertes" and "Menu Du Jour" entries from the generated sidebar while keeping order

## Testing
- npx vitest run test/imports.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce9bcbeef0832dbc86be487edb7482