### PR TITLE
Optimize inventory stock aggregation

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
-import { getDb } from "@/lib/db/database";
+import { getDb, isMemoryDriver } from "@/lib/db/database";
+
+const SUM_STOCK_SQL =
+  "SELECT COALESCE(SUM(qty),0) AS s FROM stock_movements WHERE item_id = $1";
 
 export async function openDb() {
   return await getDb();
@@ -13,9 +16,63 @@ export async function initSchema() {
 
 export async function sumStock(itemId: string): Promise<number> {
   const db = await openDb();
-  const rows = await db.select<{ s: number }>(
-    "SELECT COALESCE(SUM(qty),0) AS s FROM stock_movements WHERE item_id = $1",
-    [itemId]
-  );
+  const rows = await db.select<{ s: number | string | null }>(SUM_STOCK_SQL, [
+    itemId,
+  ]);
   return Number(rows?.[0]?.s ?? 0);
+}
+
+export async function sumStockForItems(
+  itemIds: string[],
+): Promise<Record<string, number>> {
+  if (!Array.isArray(itemIds) || itemIds.length === 0) {
+    return {};
+  }
+
+  const uniqueIds = Array.from(
+    new Set(
+      itemIds.filter((id): id is string => typeof id === "string" && id.length),
+    ),
+  );
+
+  if (uniqueIds.length === 0) {
+    return {};
+  }
+
+  const db = await openDb();
+
+  if (isMemoryDriver(db)) {
+    const fallback: Record<string, number> = {};
+    for (const id of uniqueIds) {
+      const rows = await db.select<{ s: number | string | null }>(
+        SUM_STOCK_SQL,
+        [id],
+      );
+      fallback[id] = Number(rows?.[0]?.s ?? 0);
+    }
+    return fallback;
+  }
+
+  const placeholders = uniqueIds.map((_, index) => `$${index + 1}`).join(",");
+  const rows = await db.select<{ item_id: string; s: number | string | null }>(
+    `SELECT item_id, COALESCE(SUM(qty), 0) AS s
+       FROM stock_movements
+      WHERE item_id IN (${placeholders})
+      GROUP BY item_id`,
+    uniqueIds,
+  );
+
+  const totals: Record<string, number> = {};
+  for (const id of uniqueIds) {
+    totals[id] = 0;
+  }
+
+  for (const row of rows) {
+    if (!row) continue;
+    const { item_id, s } = row;
+    if (typeof item_id !== "string") continue;
+    totals[item_id] = Number(s ?? 0);
+  }
+
+  return totals;
 }

--- a/src/lib/db/database.ts
+++ b/src/lib/db/database.ts
@@ -11,10 +11,16 @@ export type SqlDatabase = {
   close?: () => Promise<void>;
 };
 
+const MEMORY_DRIVER_SYMBOL = Symbol.for("mamastock.db.memoryDriver");
+
+type MemoryDriverDatabase = SqlDatabase & {
+  [MEMORY_DRIVER_SYMBOL]?: true;
+};
+
 export type SqliteDatabase = SqlDatabase;
 
 let tauriDb: SqlDatabase | null = null;
-let devStub: SqlDatabase | null = null;
+let devStub: MemoryDriverDatabase | null = null;
 
 function maskUrl(raw: string): string {
   try {
@@ -53,8 +59,17 @@ function ensureDevStub(): SqlDatabase {
     async close() {
       notify();
     },
+    [MEMORY_DRIVER_SYMBOL]: true,
   };
   return devStub;
+}
+
+export function isMemoryDriver(db: SqlDatabase | null | undefined): db is MemoryDriverDatabase {
+  return Boolean((db as MemoryDriverDatabase)?.[MEMORY_DRIVER_SYMBOL]);
+}
+
+export function isMemoryDriverActive(): boolean {
+  return isMemoryDriver(devStub);
 }
 
 type ResolvedDb = {

--- a/test/services/inventory.test.ts
+++ b/test/services/inventory.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selectMock = vi.fn();
+const executeMock = vi.fn();
+describe("inventory service", () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    executeMock.mockReset();
+    vi.resetModules();
+  });
+
+  it("fetches aggregated stock with a single query for all items", async () => {
+    vi.doMock("@/lib/db/database", () => ({
+      getDb: vi.fn(async () => ({
+        select: selectMock,
+        execute: executeMock,
+      })),
+      isMemoryDriver: vi.fn(() => false),
+    }));
+
+    const items = [
+      {
+        id: "item-1",
+        sku: "SKU-1",
+        name: "Item 1",
+        category: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
+      {
+        id: "item-2",
+        sku: "SKU-2",
+        name: "Item 2",
+        category: null,
+        created_at: "2024-01-02T00:00:00.000Z",
+      },
+      {
+        id: "item-3",
+        sku: "SKU-3",
+        name: "Item 3",
+        category: null,
+        created_at: "2024-01-03T00:00:00.000Z",
+      },
+    ];
+
+    selectMock.mockImplementationOnce(async () => items);
+    selectMock.mockImplementationOnce(async (sql, params) => {
+      expect(sql).toContain("GROUP BY item_id");
+      expect(params).toEqual(["item-1", "item-2", "item-3"]);
+      return [
+        { item_id: "item-1", s: "5" },
+        { item_id: "item-2", s: 3 },
+      ];
+    });
+
+    const { listItems } = await import("@/services/inventory");
+    const result = await listItems();
+
+    expect(selectMock).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(3);
+    expect(result.map((item) => item.stock)).toEqual([5, 3, 0]);
+  });
+});


### PR DESCRIPTION
## Summary
- tag database stubs to detect the in-memory driver
- add a bulk stock aggregation query with a memory fallback
- reuse the aggregated stock lookup in the inventory service
- cover the new behaviour with a targeted unit test

## Testing
- npx vitest run test/services/inventory.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce9bd50668832db824c3227c1e60ca